### PR TITLE
Fix event loop blocking causing live telemetry pauses

### DIFF
--- a/client/src/components/ConnectionStatus.tsx
+++ b/client/src/components/ConnectionStatus.tsx
@@ -1,5 +1,5 @@
 import { useTelemetryStore } from "../stores/telemetry";
-import { useStatus, useSettings } from "../hooks/queries";
+import { useSettings } from "../hooks/queries";
 
 interface Props {
   connected: boolean;
@@ -15,9 +15,8 @@ const GAME_LABELS: Record<string, string> = {
 
 export function ConnectionStatus({ connected, packetsPerSec, forzaReceiving }: Props) {
   const packet = useTelemetryStore((s) => s.packet);
-  const { data: status } = useStatus();
+  const detectedGame = useTelemetryStore((s) => s.serverStatus?.detectedGame);
   const { displaySettings } = useSettings();
-  const detectedGame = (status as any)?.detectedGame as { id: string; name: string } | null | undefined;
 
   // Active game label: prefer live packet gameId, fall back to detected running process
   const gameLabel = packet?.gameId

--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from "react";
 import { Link } from "@tanstack/react-router";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useTelemetryStore } from "../stores/telemetry";
-import { useLaps, useStatus } from "../hooks/queries";
+import { useLaps } from "../hooks/queries";
 import { useActiveProfileId } from "../hooks/useProfiles";
 import { formatLapTime } from "./LiveTelemetry";
 import { client } from "../lib/rpc";
@@ -218,9 +218,9 @@ export function HomePage() {
   const gameAdapter = gameId ? tryGetGame(gameId) : null;
   const { data: activeProfileId } = useActiveProfileId();
   const { data: allLaps = [] } = useLaps(activeProfileId);
-  const { data: status } = useStatus();
   const connected = useTelemetryStore((s) => s.connected);
   const packetsPerSec = useTelemetryStore((s) => s.packetsPerSec);
+  const serverStatus = useTelemetryStore((s) => s.serverStatus);
   const { data: stats } = useQuery({
     queryKey: ["stats"],
     queryFn: () => client.api.stats.$get({ query: {} }).then((r) => r.json()),
@@ -291,7 +291,7 @@ export function HomePage() {
   }, [allLaps]);
 
   // Session info
-  const sessionTrack = (status as any)?.currentSession?.trackOrdinal;
+  const sessionTrack = serverStatus?.currentSession?.trackOrdinal;
   const isLive = connected && packetsPerSec > 0;
 
   // Fetch names for recent laps + favourite cars

--- a/client/src/components/LivePage.tsx
+++ b/client/src/components/LivePage.tsx
@@ -1,6 +1,6 @@
 import { useTelemetryStore } from "../stores/telemetry";
 import { Link } from "@tanstack/react-router";
-import { useStatus, useTrackName, useCarName } from "../hooks/queries";
+import { useTrackName, useCarName } from "../hooks/queries";
 import { useGameRoute } from "../stores/game";
 import { LiveTelemetry, formatLapTime, type DashboardMode } from "./LiveTelemetry";
 import { LiveTrackMap } from "./LiveTrackMap";
@@ -154,8 +154,8 @@ function RaceInfo({ packet, units, trackName, carName, showTrackMap = true, show
 export function LivePage({ mode = "driver" }: { mode?: DashboardMode }) {
   const packet = useTelemetryStore((s) => s.packet);
   const units = useUnits();
-  const { data: status } = useStatus();
-  const trackOrd = packet?.TrackOrdinal ?? (status as any)?.currentSession?.trackOrdinal;
+  const serverStatus = useTelemetryStore((s) => s.serverStatus);
+  const trackOrd = packet?.TrackOrdinal ?? serverStatus?.currentSession?.trackOrdinal;
   const carOrd = packet?.CarOrdinal;
   const { data: trackName } = useTrackName(trackOrd);
   const { data: carName } = useCarName(carOrd);

--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -130,13 +130,8 @@ export function useBulkDeleteLaps() {
 }
 
 // ── Status ──────────────────────────────────────────────────────────────────
-export function useStatus() {
-  return useQuery({
-    queryKey: queryKeys.status,
-    queryFn: async () => rpcJson(await client.api.status.$get()),
-    refetchInterval: 2_000,
-  });
-}
+// Server status is now pushed via WebSocket → useTelemetryStore().serverStatus
+// The REST endpoint /api/status still exists for one-off checks.
 
 // ── Track info ──────────────────────────────────────────────────────────────
 export function useTrackName(ord: number | undefined) {

--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -29,7 +29,8 @@ export function useWebSocket() {
         try {
           const data = JSON.parse(event.data);
           if (data.type === "status") {
-            useTelemetryStore.getState().setUdpStatus(data.udpPps, data.isRaceOn);
+            const { type: _, ...status } = data;
+            useTelemetryStore.getState().setServerStatus(status);
           } else if (data.type === "update-available") {
             useTelemetryStore.getState().setUpdateAvailable(data.version as string);
           } else {
@@ -46,7 +47,9 @@ export function useWebSocket() {
       };
 
       ws.onclose = () => {
-        useTelemetryStore.getState().setConnected(false);
+        const s = useTelemetryStore.getState();
+        s.setConnected(false);
+        s.setServerStatus(null);
         wsRef.current = null;
         reconnectTimeoutRef.current = setTimeout(connect, 1000);
       };

--- a/client/src/stores/telemetry.ts
+++ b/client/src/stores/telemetry.ts
@@ -22,6 +22,15 @@ export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
   wsRefreshRate: "60",
 };
 
+export interface ServerStatus {
+  udpPps: number;
+  isRaceOn: boolean;
+  droppedPackets: number;
+  udpPort: number;
+  detectedGame: { id: string; name: string } | null;
+  currentSession: { id: number; carOrdinal: number; trackOrdinal: number } | null;
+}
+
 interface TelemetryState {
   connected: boolean;
   /** Raw packet from WebSocket (unchanged, for calculations) */
@@ -29,6 +38,8 @@ interface TelemetryState {
   /** Display-converted packet (speed/temp in user units) */
   packet: DisplayPacket | null;
   packetsPerSec: number;
+  /** Full server status pushed via WebSocket */
+  serverStatus: ServerStatus | null;
   /** UDP packets/sec reported by server (includes non-race packets) */
   udpPps: number;
   /** Whether the game is actively in a race session */
@@ -49,7 +60,7 @@ interface TelemetryState {
   setPit: (pit: LivePitData) => void;
   clearPacket: () => void;
   setPacketsPerSec: (pps: number) => void;
-  setUdpStatus: (udpPps: number, isRaceOn: boolean) => void;
+  setServerStatus: (status: ServerStatus | null) => void;
   setUpdateAvailable: (version: string | null) => void;
   /** Update unit system — re-converts current packet */
   setUnitSystem: (unit: "metric" | "imperial") => void;
@@ -65,6 +76,7 @@ export const useTelemetryStore = create<TelemetryState>((set, get) => ({
   sectors: null,
   pit: null,
   packetsPerSec: 0,
+  serverStatus: null,
   udpPps: 0,
   isRaceOn: false,
   lastUdpAt: 0,
@@ -82,10 +94,15 @@ export const useTelemetryStore = create<TelemetryState>((set, get) => ({
   },
   clearPacket: () => set({ rawPacket: null, packet: null }),
   setPacketsPerSec: (packetsPerSec) => set({ packetsPerSec }),
-  setUdpStatus: (udpPps, isRaceOn) => set({
-    udpPps,
-    isRaceOn,
-    lastUdpAt: udpPps > 0 ? Date.now() : get().lastUdpAt,
+  setServerStatus: (status: ServerStatus | null) => set(status ? {
+    serverStatus: status,
+    udpPps: status.udpPps,
+    isRaceOn: status.isRaceOn,
+    lastUdpAt: status.udpPps > 0 ? Date.now() : get().lastUdpAt,
+  } : {
+    serverStatus: null,
+    udpPps: 0,
+    isRaceOn: false,
   }),
   setUpdateAvailable: (version) => set({ updateAvailable: version }),
   setUnitSystem: (unit) => {

--- a/server/db/queries.ts
+++ b/server/db/queries.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and, sql, or, isNull } from "drizzle-orm";
+import { eq, desc, and, or, sql, inArray, isNull } from "drizzle-orm";
 import { db } from "./index";
 import { sessions, laps, trackCorners, trackOutlines, lapAnalyses, profiles, tunes } from "./schema";
 import type { TelemetryPacket, LapMeta, SessionMeta, GameId } from "../../shared/types";
@@ -245,7 +245,7 @@ function doInsertLap(
  * Get all laps with session metadata, newest first.
  * Optionally filter by profileId.
  */
-export function getLaps(profileId?: number | null, gameId?: GameId): LapMeta[] {
+export function getLaps(profileId?: number | null, gameId?: GameId, limit: number = 200): LapMeta[] {
   const query = db
     .select({
       id: laps.id,
@@ -266,7 +266,8 @@ export function getLaps(profileId?: number | null, gameId?: GameId): LapMeta[] {
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
     .leftJoin(tunes, eq(laps.tuneId, tunes.id))
-    .orderBy(desc(laps.id));
+    .orderBy(desc(laps.id))
+    .limit(limit);
 
   const conditions = [];
   if (profileId != null) {
@@ -423,7 +424,7 @@ export function deleteEmptySessions(): number {
     .all();
   if (empties.length === 0) return 0;
   const ids = empties.map(r => r.id);
-  db.delete(sessions).where(or(...ids.map(id => eq(sessions.id, id)))).run();
+  db.delete(sessions).where(inArray(sessions.id, ids)).run();
   return ids.length;
 }
 

--- a/server/db/worker-client.ts
+++ b/server/db/worker-client.ts
@@ -1,0 +1,39 @@
+/**
+ * Main-thread client for the DB worker.
+ * Provides async versions of expensive read-only queries
+ * that run off the event loop so UDP/WS aren't blocked.
+ */
+import type { LapMeta, GameId } from "../../shared/types";
+import { resolveDataDir } from "../data-dir";
+
+let worker: Worker;
+let msgId = 0;
+const pending = new Map<number, { resolve: (v: any) => void; reject: (e: Error) => void }>();
+
+export function initDbWorker(): Promise<void> {
+  worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+
+  worker.onmessage = (event: MessageEvent) => {
+    const { id, result, error } = event.data;
+    const p = pending.get(id);
+    if (!p) return;
+    pending.delete(id);
+    if (error) p.reject(new Error(error));
+    else p.resolve(result);
+  };
+
+  const dbPath = `${resolveDataDir()}/forza-telemetry.db`;
+  return send("init", { dbPath });
+}
+
+function send(type: string, params: Record<string, any> = {}): Promise<any> {
+  const id = ++msgId;
+  return new Promise((resolve, reject) => {
+    pending.set(id, { resolve, reject });
+    worker.postMessage({ type, id, ...params });
+  });
+}
+
+export function getLapsAsync(profileId?: number | null, gameId?: GameId, limit?: number): Promise<LapMeta[]> {
+  return send("getLaps", { profileId, gameId, limit });
+}

--- a/server/db/worker.ts
+++ b/server/db/worker.ts
@@ -1,0 +1,89 @@
+/**
+ * Background worker for expensive read-only DB queries.
+ * Opens its own SQLite connection (WAL allows concurrent readers)
+ * so heavy queries don't block the main event loop.
+ */
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { eq, desc, and, or, isNull } from "drizzle-orm";
+import * as schema from "./schema";
+import type { GameId } from "../../shared/types";
+
+const { sessions, laps, tunes } = schema;
+
+// Receive DB path from the main thread
+declare var self: Worker;
+
+let db: ReturnType<typeof drizzle>;
+
+self.onmessage = (event: MessageEvent) => {
+  const { type, id, ...params } = event.data;
+
+  if (type === "init") {
+    const sqlite = new Database(params.dbPath, { readonly: true });
+    sqlite.exec("PRAGMA journal_mode = WAL");
+    db = drizzle(sqlite, { schema });
+    self.postMessage({ id, result: "ok" });
+    return;
+  }
+
+  if (type === "getLaps") {
+    try {
+      const result = queryGetLaps(params.profileId, params.gameId, params.limit);
+      self.postMessage({ id, result });
+    } catch (err: any) {
+      self.postMessage({ id, error: err.message });
+    }
+    return;
+  }
+
+  self.postMessage({ id, error: `Unknown query type: ${type}` });
+};
+
+function queryGetLaps(profileId?: number | null, gameId?: GameId, limit: number = 200) {
+  const query = db
+    .select({
+      id: laps.id,
+      sessionId: laps.sessionId,
+      lapNumber: laps.lapNumber,
+      lapTime: laps.lapTime,
+      isValid: laps.isValid,
+      invalidReason: laps.invalidReason,
+      pi: laps.pi,
+      carSetup: laps.carSetup,
+      createdAt: laps.createdAt,
+      carOrdinal: sessions.carOrdinal,
+      trackOrdinal: sessions.trackOrdinal,
+      tuneId: laps.tuneId,
+      tuneName: tunes.name,
+      gameId: sessions.gameId,
+    })
+    .from(laps)
+    .innerJoin(sessions, eq(laps.sessionId, sessions.id))
+    .leftJoin(tunes, eq(laps.tuneId, tunes.id))
+    .orderBy(desc(laps.id))
+    .limit(limit);
+
+  const conditions = [];
+  if (profileId != null) {
+    conditions.push(or(eq(laps.profileId, profileId), isNull(laps.profileId)));
+  }
+  if (gameId) {
+    conditions.push(eq(sessions.gameId, gameId));
+  }
+
+  const rows = conditions.length > 0
+    ? query.where(and(...conditions)).all()
+    : query.all();
+
+  return rows.map((r) => ({
+    ...r,
+    isValid: Boolean(r.isValid),
+    invalidReason: r.invalidReason ?? undefined,
+    pi: r.pi ?? 0,
+    carSetup: r.carSetup ?? undefined,
+    tuneId: r.tuneId ?? undefined,
+    tuneName: r.tuneName ?? undefined,
+    gameId: r.gameId as GameId,
+  }));
+}

--- a/server/games/registry.ts
+++ b/server/games/registry.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { exec } from "child_process";
 import type { ServerGameAdapter } from "./types";
 
 const adapters: ServerGameAdapter[] = [];
@@ -29,49 +29,54 @@ export function getAllServerGames(): readonly ServerGameAdapter[] {
   return adapters;
 }
 
-/** Cached set of running process names (lowercase, no extension) — refreshed every 2s. */
-let _processCache: { names: Set<string>; at: number } = { names: new Set(), at: 0 };
+/**
+ * Cached set of running process names (lowercase, no extension).
+ * Refreshed asynchronously every 5s via a background timer so
+ * callers never block the event loop waiting on `tasklist`.
+ */
+let _processNames: Set<string> = new Set();
+let _refreshing = false;
 
-function getRunningProcesses(): Set<string> {
-  if (Date.now() - _processCache.at < 2000) return _processCache.names;
-  try {
-    const out = execSync(
-      'tasklist /FO CSV /NH',
-      { encoding: "utf-8", timeout: 3000, windowsHide: true }
-    );
-    const names = new Set(
-      out.split(/\r?\n/)
-        .map((line) => line.match(/^"([^"]+)"/)?.[1]?.replace(/\.exe$/i, "").toLowerCase())
-        .filter((n): n is string => !!n)
-    );
-    _processCache = { names, at: Date.now() };
-    return names;
-  } catch {
-    return _processCache.names;
-  }
+function refreshProcessCache(): void {
+  if (_refreshing) return;
+  _refreshing = true;
+  exec(
+    'tasklist /FO CSV /NH',
+    { encoding: "utf-8", timeout: 3000, windowsHide: true },
+    (err, stdout) => {
+      _refreshing = false;
+      if (err || !stdout) return; // keep stale cache on error
+      _processNames = new Set(
+        stdout.split(/\r?\n/)
+          .map((line) => line.match(/^"([^"]+)"/)?.[1]?.replace(/\.exe$/i, "").toLowerCase())
+          .filter((n): n is string => !!n)
+      );
+    }
+  );
 }
+
+// Seed immediately, then refresh every 5 seconds
+refreshProcessCache();
+setInterval(refreshProcessCache, 5000);
 
 /** Check if a specific game's process is running. */
 export function isGameRunning(gameId: string): boolean {
   const registeredNames = processNameMap.get(gameId);
   if (!registeredNames?.length) return false;
-  const running = getRunningProcesses();
-  // Match with and without .exe since Get-Process strips the extension
   return registeredNames.some((name) => {
     const bare = name.replace(/\.exe$/i, "");
-    return running.has(name) || running.has(bare);
+    return _processNames.has(name) || _processNames.has(bare);
   });
 }
 
 /** Find which registered game is currently running. Returns null if none detected. */
 export function getRunningGame(): ServerGameAdapter | null {
-  const running = getRunningProcesses();
-  if (running.size === 0) return null;
+  if (_processNames.size === 0) return null;
   for (const adapter of adapters) {
     const names = processNameMap.get(adapter.id);
     if (names?.some((name) => {
       const bare = name.replace(/\.exe$/i, "");
-      return running.has(name) || running.has(bare);
+      return _processNames.has(name) || _processNames.has(bare);
     })) return adapter;
   }
   return null;

--- a/server/index.ts
+++ b/server/index.ts
@@ -44,6 +44,10 @@ const HTTP_PORT = Number(process.env.SERVER_PORT) || 3117;
 // Import DB to ensure schema is created on startup
 import { sqlite } from "./db/index";
 import { deleteEmptySessions } from "./db/queries";
+import { initDbWorker } from "./db/worker-client";
+
+// Start background DB worker for read-only queries (non-blocking)
+await initDbWorker();
 
 // Detect first run (settings file doesn't exist yet) before loadSettings creates it
 import { isFirstRun } from "./settings";

--- a/server/lap-detector.ts
+++ b/server/lap-detector.ts
@@ -148,11 +148,13 @@ class LapDetector {
       packet.TimestampMS < this.lastTimestampMS &&
       packet.LapNumber === this.currentLapNumber
     ) {
+      if (this.lapIsValid) {
+        console.log(
+          `[Lap] Rewind detected: timestamp went from ${this.lastTimestampMS} to ${packet.TimestampMS}. Marking lap invalid.`
+        );
+      }
       this.lapIsValid = false;
       this.invalidReason = "rewind";
-      console.log(
-        `[Lap] Rewind detected: timestamp went from ${this.lastTimestampMS} to ${packet.TimestampMS}. Marking lap invalid.`
-      );
     }
 
     // Lap boundary detection

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -10,10 +10,14 @@ const logFile = join(logDir, "raceiq.log");
 // Truncate on startup
 writeFileSync(logFile, `=== RaceIQ started ${new Date().toISOString()} ===\n`);
 
+function formatArg(a: unknown): string {
+  if (typeof a === "string") return a;
+  if (a instanceof Error) return a.stack ?? a.message;
+  return JSON.stringify(a);
+}
+
 function format(level: string, args: unknown[]): string {
-  const msg = args
-    .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
-    .join(" ");
+  const msg = args.map(formatArg).join(" ");
   return `${new Date().toISOString()} [${level}] ${msg}\n`;
 }
 

--- a/server/routes/lap-routes.ts
+++ b/server/routes/lap-routes.ts
@@ -14,6 +14,7 @@ import {
   getAnalysis,
   saveAnalysis,
 } from "../db/queries";
+import { getLapsAsync } from "../db/worker-client";
 import { getTuneById as getDbTune } from "../db/tune-queries";
 import { generateExport } from "../export";
 import { compareLaps } from "../comparison";
@@ -47,9 +48,9 @@ const BulkDeleteSchema = z.object({
 
 export const lapRoutes = new Hono()
   // ── List laps ────────────────────────────────────────────────
-  .get("/api/laps", zValidator("query", LapsQuerySchema), (c) => {
+  .get("/api/laps", zValidator("query", LapsQuerySchema), async (c) => {
     const { profileId, gameId } = c.req.valid("query");
-    const lapList = getLaps(profileId, gameId);
+    const lapList = await getLapsAsync(profileId, gameId);
     return c.json(lapList);
   })
 

--- a/server/udp.ts
+++ b/server/udp.ts
@@ -13,6 +13,8 @@
 import { parsePacket } from "./parser";
 import { wsManager } from "./ws";
 import { processPacket } from "./pipeline";
+import { getRunningGame } from "./games/registry";
+import { lapDetector } from "./lap-detector";
 
 const MIN_PACKET_LENGTH = 29; // Minimum: F1 header size
 const PACKETS_PER_SEC_WINDOW = 1000; // 1-second sliding window for rate display
@@ -90,8 +92,21 @@ class UdpListener {
         this._receiving = false;
       }
 
-      // Broadcast UDP status to clients so UI knows packets are arriving
-      wsManager.broadcastStatus(this._packetsPerSec, this._receiving);
+      // Broadcast full server status to clients (replaces REST polling)
+      const runningGame = getRunningGame();
+      const session = lapDetector.session;
+      wsManager.broadcastStatus({
+        udpPps: this._packetsPerSec,
+        isRaceOn: this._receiving,
+        droppedPackets: this._droppedPackets,
+        udpPort: this._port,
+        detectedGame: runningGame
+          ? { id: runningGame.id, name: runningGame.shortName }
+          : null,
+        currentSession: session
+          ? { id: session.sessionId, carOrdinal: session.carOrdinal, trackOrdinal: session.trackOrdinal }
+          : null,
+      });
 
       if (this._packetsPerSec > 0) {
         console.log(`[UDP] total=${this._totalPackets} dropped=${this._droppedPackets} pps=${this._packetsPerSec}`);

--- a/server/ws.ts
+++ b/server/ws.ts
@@ -99,12 +99,19 @@ class WebSocketManager {
   }
 
   /**
-   * Broadcast UDP status so the client knows packets are arriving,
-   * even when the game is paused/in menus (IsRaceOn == 0).
+   * Broadcast server status so clients stay in sync without polling.
+   * Fired every 1s from the UDP listener's interval timer.
    */
-  broadcastStatus(udpPps: number, isRaceOn: boolean): void {
+  broadcastStatus(status: {
+    udpPps: number;
+    isRaceOn: boolean;
+    droppedPackets: number;
+    udpPort: number;
+    detectedGame: { id: string; name: string } | null;
+    currentSession: { id: number; carOrdinal: number; trackOrdinal: number } | null;
+  }): void {
     if (this.clients.size === 0) return;
-    const json = JSON.stringify({ type: "status", udpPps, isRaceOn });
+    const json = JSON.stringify({ type: "status", ...status });
     for (const client of this.clients) {
       try { client.send(json); } catch { /* cleaned up on next telemetry broadcast */ }
     }


### PR DESCRIPTION
## Summary
- **Root cause**: `execSync('tasklist')` blocked the event loop for ~1s every 2s, freezing UDP processing and WebSocket broadcasts — replaced with async `exec` on a background timer
- **DB fixes**: `deleteEmptySessions` hit SQLite expression tree limit with 1000+ sessions (use `inArray`), `getLaps` moved to background worker thread, added LIMIT
- **WS-pushed status**: Server status (detectedGame, currentSession, udpPps) now pushed over WebSocket instead of client polling `/api/status` every 2s
- **Logger**: Error objects now show stack traces instead of `{}`
- **Rewind spam**: Only log first rewind detection per lap

## Test plan
- [x] `bun test` passes (66/66)
- [x] Client builds successfully
- [x] Verify live telemetry timer no longer pauses during Forza sessions
- [x] Verify connection status indicator works (shows Server/Disconnected)
- [x] Verify detected game shows in nav bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)