### PR TITLE
Always show power and torque and analyse in analyse for FM2023

### DIFF
--- a/client/src/components/LapAnalyse.tsx
+++ b/client/src/components/LapAnalyse.tsx
@@ -512,9 +512,9 @@ export function LapAnalyse() {
       `Throttle: ${((p.Accel / 255) * 100).toFixed(0)}%`,
       `Brake: ${((p.Brake / 255) * 100).toFixed(0)}%`,
       `Steer: ${steerDeg > 0 ? "+" : ""}${steerDeg.toFixed(0)}°`,
-      ...(p.Boost > 0 ? [`Boost: ${p.Boost.toFixed(1)} psi`] : []),
-      ...(p.Power > 0 ? [`Power: ${(p.Power / 745.7).toFixed(0)} hp`] : []),
-      ...(p.Torque > 0 ? [`Torque: ${p.Torque.toFixed(0)} Nm`] : []),
+      ...(gameId === "fm-2023" || p.Boost > 0 ? [`Boost: ${p.Boost.toFixed(1)} psi`] : []),
+      ...(gameId === "fm-2023" || p.Power > 0 ? [`Power: ${(p.Power / 745.7).toFixed(0)} hp`] : []),
+      ...(gameId === "fm-2023" || p.Torque > 0 ? [`Torque: ${p.Torque.toFixed(0)} Nm`] : []),
       `Fuel: ${(p.Fuel * 100).toFixed(1)}% left, ${((startFuel - p.Fuel) * 100).toFixed(1)}% used`,
       ``,
       `Wheel Speed (rad/s): FL=${p.WheelRotationSpeedFL.toFixed(1)} FR=${p.WheelRotationSpeedFR.toFixed(1)} RL=${p.WheelRotationSpeedRL.toFixed(1)} RR=${p.WheelRotationSpeedRR.toFixed(1)}`,
@@ -965,7 +965,7 @@ export function LapAnalyse() {
               <div className="p-3 flex-1 min-h-0 overflow-y-auto">
               {sidebarTab === "live" ? (
                 <>
-              {currentPacket && <MetricsPanel pkt={currentPacket} startFuel={telemetry[0]?.Fuel} />}
+              {currentPacket && <MetricsPanel pkt={currentPacket} startFuel={telemetry[0]?.Fuel} gameId={gameId ?? undefined} />}
 
               {currentPacket && (
                 <>

--- a/client/src/components/analyse/AnalyseMetricsPanel.tsx
+++ b/client/src/components/analyse/AnalyseMetricsPanel.tsx
@@ -1,8 +1,8 @@
-import type { TelemetryPacket } from "@shared/types";
+import type { TelemetryPacket, GameId } from "@shared/types";
 import { useUnits } from "../../hooks/useUnits";
 import { getSteeringLock } from "../Settings";
 
-export function MetricsPanel({ pkt, startFuel }: { pkt: TelemetryPacket & { DisplaySpeed?: number }; startFuel?: number }) {
+export function MetricsPanel({ pkt, startFuel, gameId }: { pkt: TelemetryPacket & { DisplaySpeed?: number }; startFuel?: number; gameId?: GameId }) {
   const units = useUnits();
   const speed = pkt.DisplaySpeed ?? units.speed(pkt.Speed);
   const throttlePct = ((pkt.Accel / 255) * 100).toFixed(0);
@@ -18,9 +18,9 @@ export function MetricsPanel({ pkt, startFuel }: { pkt: TelemetryPacket & { Disp
       <MetricRow label="Throttle" value={`${throttlePct}%`} color={Number(throttlePct) > 50 ? "#34d399" : undefined} />
       <MetricRow label="Brake" value={`${brakePct}%`} color={Number(brakePct) > 10 ? "#ef4444" : undefined} />
       <MetricRow label="Steer" value={`${steerDeg > 0 ? "+" : ""}${steerDeg.toFixed(0)}°`} />
-      {pkt.Boost > 0 && <MetricRow label="Boost" value={`${pkt.Boost.toFixed(1)} psi`} />}
-      {pkt.Power > 0 && <MetricRow label="Power" value={`${(pkt.Power / 745.7).toFixed(0)} hp`} />}
-      {pkt.Torque > 0 && <MetricRow label="Torque" value={`${pkt.Torque.toFixed(0)} Nm`} />}
+      {(gameId === "fm-2023" || pkt.Boost > 0) && <MetricRow label="Boost" value={`${pkt.Boost.toFixed(1)} psi`} />}
+      {(gameId === "fm-2023" || pkt.Power > 0) && <MetricRow label="Power" value={`${(pkt.Power / 745.7).toFixed(0)} hp`} />}
+      {(gameId === "fm-2023" || pkt.Torque > 0) && <MetricRow label="Torque" value={`${pkt.Torque.toFixed(0)} Nm`} />}
       <div className="col-span-2 flex justify-between">
         <span className="text-app-text-muted">Fuel</span>
         <span className="tabular-nums">


### PR DESCRIPTION
## Summary
- Power and torque are now always visible in the analyse view for FM2023 (even when 0 at coast/idle)
- F1 and ACC keep the existing `> 0` conditional since they may not report these values
- Applies to both the metrics panel and the chart tooltip

## Test plan
- [ ] Open FM2023 analyse page — power/torque always visible
- [ ] Open F1/ACC analyse page — power/torque only shown when > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)