### PR TITLE
Regenerate release notes when re-running draft release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,19 @@ jobs:
           path: artifacts
           pattern: raceiq-v*
 
+      - name: Delete existing draft for this tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ needs.compute-version.outputs.version }}"
+          RELEASE_ID=$(gh api repos/${{ github.repository }}/releases --jq ".[] | select(.tag_name == \"$TAG\" and .draft) | .id" 2>/dev/null || true)
+          if [ -n "$RELEASE_ID" ]; then
+            echo "Deleting existing draft release $RELEASE_ID for $TAG"
+            gh api -X DELETE repos/${{ github.repository }}/releases/$RELEASE_ID
+            # Also delete the tag so softprops can recreate it
+            git push origin :refs/tags/$TAG 2>/dev/null || true
+          fi
+
       - name: Create draft release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- Deletes any existing draft release for the same tag before creating a new one
- This ensures `generate_release_notes: true` always produces fresh content from the latest commits instead of keeping stale notes from a previous run

## Test plan
- [ ] Run release workflow twice for the same version — second run should have updated release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)