### PR TITLE
feat(tracks): lap count badge and sort on tracks page

### DIFF
--- a/client/src/components/TrackViewer.tsx
+++ b/client/src/components/TrackViewer.tsx
@@ -8,6 +8,8 @@ import { TrackCard } from "./track/TrackCard";
 import { TrackDetail } from "./track/TrackDetail";
 import type { TrackInfo } from "./track/types";
 
+type SortKey = "name" | "laps";
+
 /** TrackViewer — Gallery view of all known tracks, split into "with outlines" and "without". */
 export function TrackViewer() {
   const routeSearch = useSearch({ strict: false }) as { track?: number; tab?: string };
@@ -17,6 +19,7 @@ export function TrackViewer() {
   const { data: tracks = [], isLoading: loading } = useTracks() as { data: TrackInfo[]; isLoading: boolean };
   const [selectedTrack, setSelectedTrack] = useState<TrackInfo | null>(null);
   const [search, setSearch] = useState("");
+  const [sortKey, setSortKey] = useState<SortKey>("name");
 
   const handleSelectTrack = useCallback((t: TrackInfo) => {
     setSelectedTrack(t);
@@ -56,8 +59,13 @@ export function TrackViewer() {
       )
     : tracks;
 
-  const withOutline = filtered.filter((t) => t.hasOutline);
-  const withoutOutline = filtered.filter((t) => !t.hasOutline);
+  const sorted = [...filtered].sort((a, b) => {
+    if (sortKey === "laps") return (b.lapCount ?? 0) - (a.lapCount ?? 0);
+    return a.name.localeCompare(b.name);
+  });
+
+  const withOutline = sorted.filter((t) => t.hasOutline);
+  const withoutOutline = sorted.filter((t) => !t.hasOutline);
 
   return (
     <div className="p-4 overflow-auto h-full">
@@ -68,6 +76,18 @@ export function TrackViewer() {
           onChange={(e) => setSearch(e.target.value)}
           className="w-full max-w-xs"
         />
+        <div className="flex items-center gap-1 text-app-label text-app-text-muted">
+          <span className="uppercase tracking-wider">Sort:</span>
+          {(["name", "laps"] as SortKey[]).map((key) => (
+            <button
+              key={key}
+              onClick={() => setSortKey(key)}
+              className={`px-2 py-0.5 rounded capitalize ${sortKey === key ? "bg-app-surface-alt border border-app-border text-app-text" : "text-app-text-dim hover:text-app-text-muted"}`}
+            >
+              {key}
+            </button>
+          ))}
+        </div>
         <div className="text-app-label text-app-text-muted uppercase tracking-wider whitespace-nowrap">
           {withOutline.length} with outlines, {withoutOutline.length} without
         </div>
@@ -97,10 +117,13 @@ export function TrackViewer() {
                 className="border border-app-border rounded-lg p-3 bg-app-surface/30 cursor-pointer hover:border-app-border-input"
                 onClick={() => handleSelectTrack(t)}
               >
-                <div className="text-app-body text-app-text-secondary">{t.name}</div>
-                <div className="text-app-label text-app-text-dim">
-                  {t.variant} · {t.location}
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-app-body text-app-text-secondary">{t.name}</div>
+                  <span className="shrink-0 text-app-label px-1.5 py-0.5 rounded bg-app-surface-alt border border-app-border text-app-text-muted">
+                    {t.lapCount ?? 0} {(t.lapCount ?? 0) === 1 ? "lap" : "laps"}
+                  </span>
                 </div>
+                <div className="text-app-label text-app-text-dim">{t.variant} · {t.location}</div>
               </div>
             ))}
           </div>

--- a/client/src/components/track/TrackCard.tsx
+++ b/client/src/components/track/TrackCard.tsx
@@ -39,7 +39,12 @@ export function TrackCard({ track, onSelect, gameId }: { track: TrackInfo; onSel
       onClick={() => onSelect(track)}
     >
       <div className="p-3">
-        <div className="text-app-body font-medium text-app-text">{track.name}</div>
+        <div className="flex items-start justify-between gap-2">
+          <div className="text-app-body font-medium text-app-text">{track.name}</div>
+          <span className="shrink-0 text-app-label px-1.5 py-0.5 rounded bg-app-surface-alt border border-app-border text-app-text-muted">
+            {track.lapCount ?? 0} {(track.lapCount ?? 0) === 1 ? "lap" : "laps"}
+          </span>
+        </div>
         <div className="text-app-label text-app-text-muted">
           {track.variant} · {track.location}, {countryName(track.country)}
           {track.lengthKm > 0 && ` · ${track.lengthKm} km`}

--- a/client/src/components/track/types.ts
+++ b/client/src/components/track/types.ts
@@ -7,6 +7,7 @@ export interface TrackInfo {
   lengthKm: number;
   hasOutline: boolean;
   createdAt: string | null;
+  lapCount?: number;
 }
 
 export interface Point {

--- a/server/db/queries.ts
+++ b/server/db/queries.ts
@@ -960,3 +960,15 @@ export async function getLapsRaw(ids?: number[]) {
 
   return await base.all();
 }
+
+/** Count laps per trackOrdinal for a given game. Returns a Map<trackOrdinal, count>. */
+export async function getLapCountsByTrack(gameId: GameId): Promise<Map<number, number>> {
+  const rows = await db
+    .select({ trackOrdinal: sessions.trackOrdinal, count: sql<number>`count(*)` })
+    .from(laps)
+    .innerJoin(sessions, eq(laps.sessionId, sessions.id))
+    .where(eq(sessions.gameId, gameId))
+    .groupBy(sessions.trackOrdinal)
+    .all();
+  return new Map(rows.map((r) => [r.trackOrdinal, Number(r.count)]));
+}

--- a/server/routes/track-routes.ts
+++ b/server/routes/track-routes.ts
@@ -12,6 +12,7 @@ import {
   getTrackOutline as getDbTrackOutline,
   getTrackOutlineSectors,
   updateTrackOutlineSectors,
+  getLapCountsByTrack,
 } from "../db/queries";
 import {
   getTrackOutlineByOrdinal,
@@ -310,14 +311,14 @@ export const trackRoutes = new Hono()
     }
   )
 
-  // GET /api/tracks — list all tracks with outline availability
+  // GET /api/tracks — list all tracks with outline availability and lap counts
   .get("/api/tracks",
-    (c) => {
+    async (c) => {
       const gameId = c.req.query("gameId");
 
       if (gameId === "f1-2025") {
-        // Return F1 tracks
         const f1Tracks = getF1Tracks();
+        const lapCounts = await getLapCountsByTrack("f1-2025");
         const tracks = Array.from(f1Tracks.entries()).map(([id, info]) => {
           const hasBundled = !!getTrackOutlineByOrdinal(id, "f1-2025", info.commonTrackName);
           return {
@@ -331,6 +332,7 @@ export const trackRoutes = new Hono()
             outlineSource: hasBundled ? "bundled" : null,
             commonTrackName: info.commonTrackName || null,
             createdAt: null,
+            lapCount: lapCounts.get(id) ?? 0,
           };
         });
         tracks.sort((a, b) => a.name.localeCompare(b.name));
@@ -339,6 +341,7 @@ export const trackRoutes = new Hono()
 
       if (gameId === "acc") {
         const accTracks = getAccTracks();
+        const lapCounts = await getLapCountsByTrack("acc");
         const tracks = Array.from(accTracks.entries()).map(([id, info]) => {
           const hasBundled = !!getTrackOutlineByOrdinal(id, "acc", info.commonTrackName ?? undefined);
           return {
@@ -351,6 +354,7 @@ export const trackRoutes = new Hono()
             hasOutline: hasBundled,
             outlineSource: hasBundled ? "bundled" : null,
             createdAt: null,
+            lapCount: lapCounts.get(id) ?? 0,
           };
         });
         tracks.sort((a, b) => a.name.localeCompare(b.name));
@@ -359,6 +363,7 @@ export const trackRoutes = new Hono()
 
       // Default: Forza tracks
       const forzaGameId = gameId ?? "fm-2023";
+      const lapCounts = await getLapCountsByTrack(forzaGameId as any);
       const tracks = Array.from(trackMap.entries()).map(([ordinal, info]) => {
         const hasBundled = !!getTrackOutlineByOrdinal(ordinal, forzaGameId);
         return {
@@ -371,6 +376,7 @@ export const trackRoutes = new Hono()
           hasOutline: hasBundled,
           outlineSource: hasBundled ? "bundled" : null,
           createdAt: null,
+          lapCount: lapCounts.get(ordinal) ?? 0,
         };
       });
       // Sort: tracks with outlines first, then alphabetically


### PR DESCRIPTION
## Summary
- Every track card shows a lap count badge (top-right of title row)
- No-outline list items also show the badge
- Sort toggle at top of page: Name (default) or Laps (descending)
- Server: `getLapCountsByTrack(gameId)` — single GROUP BY query included in `GET /api/tracks` response

## Test plan
- [ ] Open tracks page for each game — all tracks show a lap badge
- [ ] Tracks with recorded laps sort to top when "Laps" selected
- [ ] FM sector splits unaffected (still use top-level sectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)