### PR TITLE
fix(onboarding): avoid useRequiredGameId crash on /

### DIFF
--- a/client/src/components/CarWireframe.tsx
+++ b/client/src/components/CarWireframe.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useMemo, useState, useCallback, useEffect } from "react"
 import { client } from "../lib/rpc";
 import { Canvas } from "@react-three/fiber";
 import { useGLTF } from "@react-three/drei";
-import type { TelemetryPacket } from "@shared/types";
+import type { GameId, TelemetryPacket } from "@shared/types";
 import { getCarModel, loadCarModelConfigs, F1_CAR, DEMO_CAR, type CarModelEnrichment } from "../data/car-models";
 import { tireTempColorHex } from "../lib/vehicle-dynamics";
 import { useUnits } from "../hooks/useUnits";
@@ -21,6 +21,7 @@ useGLTF.preload("/models/aston_martin_vantage_gt3.glb");
 useGLTF.preload("/models/f1_2025_mclaren_mcl39.glb");
 
 export const CarWireframe = React.memo(function CarWireframe({
+  gameId: gameIdProp,
   packet,
   telemetry,
   cursorIdx,
@@ -34,6 +35,7 @@ export const CarWireframe = React.memo(function CarWireframe({
   hideControls,
   autoOrbit,
 }: {
+  gameId?: GameId;
   packet: TelemetryPacket;
   telemetry: TelemetryPacket[];
   cursorIdx: number;
@@ -52,7 +54,11 @@ export const CarWireframe = React.memo(function CarWireframe({
 }) {
   const [configsLoaded, setConfigsLoaded] = useState(false);
   useEffect(() => { loadCarModelConfigs().then(() => setConfigsLoaded(true)); }, []);
-  const gameId = useGameId();
+  const storeGameId = useGameId();
+  const gameId = gameIdProp ?? storeGameId;
+  if (!gameId) {
+    throw new Error("CarWireframe: gameId missing — pass as prop or mount inside a GameProvider");
+  }
   const isF1 = gameId === "f1-2025";
 
   const carModel = useMemo(() => {
@@ -151,7 +157,7 @@ export const CarWireframe = React.memo(function CarWireframe({
           };
         }}
       >
-        <CarScene packet={packet} telemetry={telemetry} cursorIdx={cursorIdx} outline={outline} boundaries={boundaries ?? null} toggles={toggles} viewPreset={viewPreset} carModel={carModel} modelOffsetX={modelOffsetX} fmtTemp={fmtTemp} hideModelWheels={!minimal} suspThresholds={suspThresholds} autoOrbit={autoOrbit} tireColors={[
+        <CarScene gameId={gameId} packet={packet} telemetry={telemetry} cursorIdx={cursorIdx} outline={outline} boundaries={boundaries ?? null} toggles={toggles} viewPreset={viewPreset} carModel={carModel} modelOffsetX={modelOffsetX} fmtTemp={fmtTemp} hideModelWheels={!minimal} suspThresholds={suspThresholds} autoOrbit={autoOrbit} tireColors={[
           tireTempColorHex(units.toTempC(packet.TireTempFL), units.thresholds),
           tireTempColorHex(units.toTempC(packet.TireTempFR), units.thresholds),
           tireTempColorHex(units.toTempC(packet.TireTempRL), units.thresholds),

--- a/client/src/components/CarWireframe.tsx
+++ b/client/src/components/CarWireframe.tsx
@@ -90,7 +90,13 @@ export const CarWireframe = React.memo(function CarWireframe({
   });
   // Merge defaults so any keys added after the user's localStorage was first
   // written get sensible values instead of undefined.
-  const toggles: ViewToggles = { ...DEFAULT_TOGGLES, ...storedToggles };
+  // When controls are hidden (e.g. onboarding preview) force wheelInfo off —
+  // the user has no way to toggle it and the stat cards clutter the scene.
+  const toggles: ViewToggles = {
+    ...DEFAULT_TOGGLES,
+    ...storedToggles,
+    ...(hideControls ? { wheelInfo: false } : {}),
+  };
   const [viewPreset, setViewPreset] = useState<ViewPreset>("3/4");
 
   const toggle = (key: keyof ViewToggles) =>

--- a/client/src/components/Onboarding.tsx
+++ b/client/src/components/Onboarding.tsx
@@ -95,6 +95,7 @@ function WelcomeViewport({ telemetry }: { telemetry: TelemetryPacket[] }) {
   return (
     <div className="w-full h-48 rounded-lg overflow-hidden border border-app-border bg-black">
       <CarWireframe
+        gameId="fm-2023"
         packet={packet}
         telemetry={telemetry}
         cursorIdx={cursorIdx}

--- a/client/src/components/wireframe/CarScene.tsx
+++ b/client/src/components/wireframe/CarScene.tsx
@@ -3,11 +3,10 @@ import { useFrame } from "@react-three/fiber";
 import { Grid } from "@react-three/drei";
 import { Line } from "@react-three/drei";
 import * as THREE from "three";
-import type { TelemetryPacket } from "@shared/types";
+import type { GameId, TelemetryPacket } from "@shared/types";
 import type { CarModelEnrichment } from "../../data/car-models";
 import type { ViewToggles, ViewPreset } from "../../lib/wireframe-data";
 import { allWheelStates, tireState } from "../../lib/vehicle-dynamics";
-import { useRequiredGameId } from "../../stores/game";
 import { useTirePressureOptimal } from "../../hooks/queries";
 import { CarBody } from "./CarBody";
 import { Wheel } from "./Wheel";
@@ -46,9 +45,8 @@ function computeLoadDotXZ(
   return { x: dirX * scale, z: dirZ * scale };
 }
 
-export function CarScene({ packet: packetProp, telemetry, cursorIdx, outline, boundaries, toggles, viewPreset, carModel, modelOffsetX, fmtTemp, hideModelWheels, suspThresholds, autoOrbit, tireColors }: { packet: TelemetryPacket; telemetry: TelemetryPacket[]; cursorIdx: number; outline: { x: number; z: number }[] | null; boundaries: { leftEdge: { x: number; z: number }[]; rightEdge: { x: number; z: number }[] } | null; toggles: ViewToggles; viewPreset: ViewPreset; carModel: CarModelEnrichment & { hasModel: boolean }; modelOffsetX: number; fmtTemp: (f: number) => string; hideModelWheels?: boolean; suspThresholds: number[]; autoOrbit?: boolean; tireColors: [string, string, string, string] }) {
+export function CarScene({ gameId, packet: packetProp, telemetry, cursorIdx, outline, boundaries, toggles, viewPreset, carModel, modelOffsetX, fmtTemp, hideModelWheels, suspThresholds, autoOrbit, tireColors }: { gameId: GameId; packet: TelemetryPacket; telemetry: TelemetryPacket[]; cursorIdx: number; outline: { x: number; z: number }[] | null; boundaries: { leftEdge: { x: number; z: number }[]; rightEdge: { x: number; z: number }[] } | null; toggles: ViewToggles; viewPreset: ViewPreset; carModel: CarModelEnrichment & { hasModel: boolean }; modelOffsetX: number; fmtTemp: (f: number) => string; hideModelWheels?: boolean; suspThresholds: number[]; autoOrbit?: boolean; tireColors: [string, string, string, string] }) {
   const [colorFL, colorFR, colorRL, colorRR] = tireColors;
-  const gameId = useRequiredGameId();
   const pressureOptimal = useTirePressureOptimal(gameId, packetProp.CarOrdinal);
 
   // Keep packet in a ref so useFrame reads latest without triggering re-render


### PR DESCRIPTION
## Summary
- `CarScene` called `useRequiredGameId()` which threw `no gameId in store and URL (/) does not match any game route` when Onboarding's welcome viewport rendered `CarWireframe` from a non-game route.
- `CarScene` now takes `gameId` as a required prop; `CarWireframe` accepts an optional `gameId` override that falls back to the store (with an explicit error if neither is set).
- Onboarding passes `gameId="fm-2023"` to match its hardcoded FM demo lap — no implicit fm-2023 fallback in the store/component.

## Test plan
- [x] Client typecheck + build (`cd client && bun run build`)
- [x] Lefthook pre-commit (lint + snapshots + typecheck) passed
- [ ] Manually open onboarding from `/` and confirm no crash
- [ ] Confirm the welcome viewport still renders the demo FM lap

🤖 Generated with [Claude Code](https://claude.com/claude-code)