### PR TITLE
fix(home): use ACC logo image on home page game card

### DIFF
--- a/client/src/components/HomePage.tsx
+++ b/client/src/components/HomePage.tsx
@@ -383,7 +383,7 @@ export function HomePage() {
           {/* Icon + Name */}
           <div className="relative flex items-center gap-2.5 mb-3.5">
             <div className="w-8 h-8 rounded-md flex items-center justify-center shrink-0 bg-orange-500/8 border border-orange-500/10">
-              <span className="text-xs font-black text-orange-400">AC</span>
+              <img src="/acc-logo.png" alt="" className="w-5 h-5 object-contain" />
             </div>
             <span className="text-sm font-bold text-white/90">Assetto Corsa Competizione</span>
           </div>


### PR DESCRIPTION
## Summary
- Home page ACC game card showed text "AC" badge instead of actual logo
- Now uses `/acc-logo.png` image, matching how Forza and F1 cards display their logos
- Consistent with ACC's own `/acc` page header

## Test plan
- [x] Client builds clean
- [x] Pre-commit hooks pass (lint, typecheck, snapshots)
- [ ] Visual check: home page ACC card shows logo image, not text

🤖 Generated with [Claude Code](https://claude.com/claude-code)