### PR TITLE
refactor(settings): move color thresholds to game adapters

### DIFF
--- a/client/src/components/CarWireframe.tsx
+++ b/client/src/components/CarWireframe.tsx
@@ -8,6 +8,7 @@ import { tireTempColorHex } from "../lib/vehicle-dynamics";
 import { useUnits } from "../hooks/useUnits";
 import { useSettings } from "../hooks/queries";
 import { useGameId } from "../stores/game";
+import { tryGetGame } from "@shared/games/registry";
 import { needsTrackFlip, flipBoundaries } from "../lib/track-coords";
 import { useLocalStorage } from "../hooks/useLocalStorage";
 import { recordGpuSnapshot } from "../lib/crash-diagnostics";
@@ -79,7 +80,7 @@ export const CarWireframe = React.memo(function CarWireframe({
   }, [carOrdinal, configsLoaded, isF1, carModelProp]);
   const units = useUnits();
   const { displaySettings } = useSettings();
-  const suspThresholds = displaySettings.suspensionThresholds.values;
+  const suspThresholds = tryGetGame(gameId)?.suspensionThresholds.values ?? [25, 65, 85];
   const tLabel = tempLabelProp ?? units.tempLabel;
   const fmtTemp = useCallback((v: number) => `${units.temp(v).toFixed(0)}${tLabel}`, [units, tLabel]);
   const [editMode, setEditMode] = useState(false);

--- a/client/src/components/LiveTelemetry.tsx
+++ b/client/src/components/LiveTelemetry.tsx
@@ -6,7 +6,6 @@ import { useUnits } from "../hooks/useUnits";
 import { client } from "../lib/rpc";
 import { useGameId } from "../stores/game";
 import { useTelemetryStore } from "../stores/telemetry";
-import { useSettings } from "../hooks/queries";
 
 import { GripHistory } from "./telemetry/GripHistory";
 import { PitEstimate } from "./telemetry/PitEstimate";
@@ -30,7 +29,6 @@ interface Props {
 export function LiveTelemetry({ packet, mode = "driver" }: Props) {
   const gameId = useGameId();
   const pit = useTelemetryStore((s) => s.pit);
-  const { displaySettings } = useSettings();
   const [carName, setCarName] = useState<string>("");
   const lastCarOrdRef = useRef<number | null>(null);
 
@@ -134,7 +132,7 @@ export function LiveTelemetry({ packet, mode = "driver" }: Props) {
             <h2 className="text-xs font-semibold text-app-text-muted uppercase tracking-wider">Pit Window</h2>
           </div>
           <div className="p-3">
-            <PitEstimate packet={packet} pit={pit} gameId={gameId} healthThresholds={displaySettings.tireHealthThresholds.values} />
+            <PitEstimate packet={packet} pit={pit} gameId={gameId} />
           </div>
         </div>
 

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -56,8 +56,6 @@ const NAV_ITEMS = [
   { id: "connection", label: "Connection" },
   { id: "wheel", label: "Wheel" },
   { id: "temperature", label: "Temperature" },
-  { id: "tireHealth", label: "Tire Health" },
-  { id: "suspension", label: "Suspension" },
   { id: "speed", label: "Units" },
   { id: "sound", label: "Sound" },
   { id: "storage", label: "Storage" },
@@ -91,20 +89,12 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
   const { theme, setTheme } = useTheme();
   const [unitSystem, setUnitSystem] = useState<"metric" | "imperial">(displaySettings.unit);
   const tempUnit = unitSystem === "metric" ? "C" as const : "F" as const;
-  const [healthThresholds, setHealthThresholds] = useState(displaySettings.tireHealthThresholds.values);
-  const [suspThresholds, setSuspThresholds] = useState(displaySettings.suspensionThresholds.values);
-  const [healthStatus, setHealthStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const [healthError, setHealthError] = useState("");
-  const [suspStatus, setSuspStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
-  const [suspError, setSuspError] = useState("");
   const [unitStatus, setUnitStatus] = useState<"idle" | "saving" | "saved" | "error">("idle");
   const [unitError, setUnitError] = useState("");
 
   const tempSettingsJson = JSON.stringify(displaySettings);
   useEffect(() => {
     setUnitSystem(displaySettings.unit);
-    setHealthThresholds(displaySettings.tireHealthThresholds.values);
-    setSuspThresholds(displaySettings.suspensionThresholds.values);
   }, [tempSettingsJson]);
 
   // Seed UDP port from settings query
@@ -154,59 +144,6 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
     }
   }
 
-  async function handleHealthSave() {
-    const sorted = [...healthThresholds].sort((a, b) => a - b);
-    if (sorted.some((v) => v < 0 || v > 100)) {
-      setHealthStatus("error");
-      setHealthError("Values must be between 0-100");
-      return;
-    }
-    for (let i = 1; i < sorted.length; i++) {
-      if (sorted[i] <= sorted[i - 1]) {
-        setHealthStatus("error");
-        setHealthError("Thresholds must be in ascending order");
-        return;
-      }
-    }
-    setHealthStatus("saving");
-    setHealthError("");
-    try {
-      await saveSettings.mutateAsync({ tireHealthThresholds: { values: sorted } });
-      setHealthThresholds(sorted);
-      setHealthStatus("saved");
-      setTimeout(() => setHealthStatus("idle"), 2000);
-    } catch (err) {
-      setHealthStatus("error");
-      setHealthError(err instanceof Error ? err.message : "Failed to save");
-    }
-  }
-
-  async function handleSuspSave() {
-    const sorted = [...suspThresholds].sort((a, b) => a - b);
-    if (sorted.some((v) => v < 0 || v > 100)) {
-      setSuspStatus("error");
-      setSuspError("Values must be between 0-100");
-      return;
-    }
-    for (let i = 1; i < sorted.length; i++) {
-      if (sorted[i] <= sorted[i - 1]) {
-        setSuspStatus("error");
-        setSuspError("Thresholds must be in ascending order");
-        return;
-      }
-    }
-    setSuspStatus("saving");
-    setSuspError("");
-    try {
-      await saveSettings.mutateAsync({ suspensionThresholds: { values: sorted } });
-      setSuspThresholds(sorted);
-      setSuspStatus("saved");
-      setTimeout(() => setSuspStatus("idle"), 2000);
-    } catch (err) {
-      setSuspStatus("error");
-      setSuspError(err instanceof Error ? err.message : "Failed to save");
-    }
-  }
 
   const themes: { value: Theme; label: string; description: string }[] = [
     { value: "morph", label: "Morph", description: "Morphic black" },
@@ -585,98 +522,6 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
           </section>
         )}
 
-        {activeSection === "tireHealth" && (
-          <section>
-            <h2 className="text-lg font-semibold text-app-text mb-1">Tire Health</h2>
-            <p className="text-sm text-app-text-muted mb-4">
-              Color thresholds for tire health percentage. Values are health % boundaries (ascending).
-            </p>
-
-            <div className="space-y-3 max-w-xs">
-              {[
-                { label: "Critical (below = red)", color: "text-red-400", idx: 0 },
-                { label: "Low (below = orange)", color: "text-orange-400", idx: 1 },
-                { label: "Medium (below = yellow)", color: "text-yellow-400", idx: 2 },
-                { label: "Good (above = green)", color: "text-emerald-400", idx: 3 },
-              ].map(({ label, color, idx }) => (
-                <div key={idx}>
-                  <Label className={`${color} text-xs`}>{label}</Label>
-                  <Input
-                    type="number"
-                    min={0}
-                    max={100}
-                    value={healthThresholds[idx] ?? ""}
-                    onChange={(e) => {
-                      const next = [...healthThresholds];
-                      next[idx] = parseFloat(e.target.value) || 0;
-                      setHealthThresholds(next);
-                    }}
-                    className="glass-input border bg-app-surface-alt border-app-border-input text-app-text font-mono mt-1 w-24"
-                  />
-                </div>
-              ))}
-            </div>
-
-            <div className="flex gap-2 mt-4">
-              <Button onClick={handleHealthSave} disabled={healthStatus === "saving"}>
-                {healthStatus === "saving" ? "Saving..." : healthStatus === "saved" ? "Saved" : "Save"}
-              </Button>
-              <Button variant="outline" onClick={() => setHealthThresholds([20, 40, 60, 80])}>
-                Reset
-              </Button>
-            </div>
-
-            {healthStatus === "error" && (
-              <p className="text-red-400 text-sm mt-2">{healthError}</p>
-            )}
-          </section>
-        )}
-
-        {activeSection === "suspension" && (
-          <section>
-            <h2 className="text-lg font-semibold text-app-text mb-1">Suspension</h2>
-            <p className="text-sm text-app-text-muted mb-4">
-              Color thresholds for suspension travel (0-100%). Values are travel % boundaries (ascending).
-            </p>
-
-            <div className="space-y-3 max-w-xs">
-              {[
-                { label: "Extended (below = blue)", color: "text-blue-400", idx: 0 },
-                { label: "Compressed (above = yellow)", color: "text-yellow-400", idx: 1 },
-                { label: "Bottomed (above = red)", color: "text-red-400", idx: 2 },
-              ].map(({ label, color, idx }) => (
-                <div key={idx}>
-                  <Label className={`${color} text-xs`}>{label}</Label>
-                  <Input
-                    type="number"
-                    min={0}
-                    max={100}
-                    value={suspThresholds[idx] ?? ""}
-                    onChange={(e) => {
-                      const next = [...suspThresholds];
-                      next[idx] = parseFloat(e.target.value) || 0;
-                      setSuspThresholds(next);
-                    }}
-                    className="glass-input border bg-app-surface-alt border-app-border-input text-app-text font-mono mt-1 w-24"
-                  />
-                </div>
-              ))}
-            </div>
-
-            <div className="flex gap-2 mt-4">
-              <Button onClick={handleSuspSave} disabled={suspStatus === "saving"}>
-                {suspStatus === "saving" ? "Saving..." : suspStatus === "saved" ? "Saved" : "Save"}
-              </Button>
-              <Button variant="outline" onClick={() => setSuspThresholds([25, 65, 85])}>
-                Reset
-              </Button>
-            </div>
-
-            {suspStatus === "error" && (
-              <p className="text-red-400 text-sm mt-2">{suspError}</p>
-            )}
-          </section>
-        )}
 
         {activeSection === "speed" && (
           <section>

--- a/client/src/components/acc/AccLiveDashboard.tsx
+++ b/client/src/components/acc/AccLiveDashboard.tsx
@@ -6,7 +6,7 @@ import { LapTimeChart } from "../LapTimeChart";
 import { PitEstimate } from "../telemetry/PitEstimate";
 import { RecordedLaps } from "../RecordedLaps";
 import { NoDataView } from "../NoDataView";
-import { useTrackName, useCarName, useTirePressureOptimal, useSettings } from "../../hooks/queries";
+import { useTrackName, useCarName, useTirePressureOptimal } from "../../hooks/queries";
 import { RaceInfo } from "../RaceInfo";
 
 // ── Main Dashboard ────────────────────────────────────────────────────────────
@@ -16,7 +16,6 @@ export function AccLiveDashboard({ gameId = "acc" }: { gameId?: GameId }) {
   const sessionLaps = useTelemetryStore((s) => s.sessionLaps);
   const sectors = useTelemetryStore((s) => s.sectors);
   const pit = useTelemetryStore((s) => s.pit);
-  const { displaySettings } = useSettings();
   const { data: trackName } = useTrackName(packet?.TrackOrdinal);
   const { data: carName } = useCarName(packet?.CarOrdinal);
   const pressureOptimal = useTirePressureOptimal(gameId, packet?.CarOrdinal);
@@ -54,7 +53,7 @@ export function AccLiveDashboard({ gameId = "acc" }: { gameId?: GameId }) {
             <h2 className="text-xs font-semibold text-app-text-muted uppercase tracking-wider">Pit Window</h2>
           </div>
           <div className="p-3">
-            <PitEstimate packet={packet} pit={pit} gameId="acc" healthThresholds={displaySettings.tireHealthThresholds.values} />
+            <PitEstimate packet={packet} pit={pit} gameId="acc" />
           </div>
         </div>
       </div>

--- a/client/src/components/f1/F1LiveDashboard.tsx
+++ b/client/src/components/f1/F1LiveDashboard.tsx
@@ -8,7 +8,7 @@ import { PitEstimate } from "../telemetry/PitEstimate";
 import { RecordedLaps } from "../RecordedLaps";
 import { NoDataView } from "../NoDataView";
 import { RaceInfo } from "../RaceInfo";
-import { useTrackName, useCarName, useSettings } from "../../hooks/queries";
+import { useTrackName, useCarName } from "../../hooks/queries";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -58,7 +58,6 @@ export function F1LiveDashboard() {
   const sessionLaps = useTelemetryStore((s) => s.sessionLaps);
   const sectors = useTelemetryStore((s) => s.sectors);
   const pit = useTelemetryStore((s) => s.pit);
-  const { displaySettings } = useSettings();
   const hasF1Data = rawPacket?.gameId === "f1-2025" && rawPacket.f1;
   const f1 = hasF1Data ? rawPacket.f1! : null;
   const { data: trackName } = useTrackName(rawPacket?.TrackOrdinal);
@@ -112,7 +111,7 @@ export function F1LiveDashboard() {
             <h2 className="text-xs font-semibold text-app-text-muted uppercase tracking-wider">Pit Window</h2>
           </div>
           <div className="p-3">
-            <PitEstimate packet={rawPacket!} pit={pit} gameId="f1-2025" healthThresholds={displaySettings.tireHealthThresholds.values} />
+            <PitEstimate packet={rawPacket!} pit={pit} gameId="f1-2025" />
           </div>
         </div>
         <GridSection f1={f1} playerPosition={rawPacket!.RacePosition} />

--- a/client/src/components/telemetry/PitEstimate.tsx
+++ b/client/src/components/telemetry/PitEstimate.tsx
@@ -6,17 +6,13 @@ interface PitEstimateProps {
   packet: TelemetryPacket;
   pit: LivePitData | null;
   gameId: GameId | null;
-  /** Tire health thresholds (0–100 percentages) from display settings. */
-  healthThresholds: number[];
 }
 
 /**
  * PitEstimate — Displays server-computed fuel and tire estimates.
  * All computation happens server-side in PitTracker; this component just renders.
- * Pure: caller supplies pit + gameId + healthThresholds.
  */
-export function PitEstimate({ packet, pit, gameId, healthThresholds }: PitEstimateProps) {
-  const healthThresh = healthThresholds;
+export function PitEstimate({ packet, pit, gameId }: PitEstimateProps) {
 
   // Forza: Fuel is 0..1 fraction → percentage. ACC/AC Evo/F1: Fuel is in litres/kg.
   const fuelIsLitres = gameId === "acc" || gameId === "ac-evo" || gameId === "f1-2025";
@@ -37,8 +33,8 @@ export function PitEstimate({ packet, pit, gameId, healthThresholds }: PitEstima
     return {
       label,
       health,
-      healthClr: tireHealthTextClass(health, healthThresh),
-      healthBg: tireHealthBgClass(health, healthThresh),
+      healthClr: tireHealthTextClass(health),
+      healthBg: tireHealthBgClass(health),
       toCliff: pit?.tireEstimates?.toCliff[i] ?? null,
       toDead: pit?.tireEstimates?.toDead[i] ?? null,
       wearPerLap: wpl > 0 ? (wpl * 100).toFixed(1) : null,

--- a/client/src/components/telemetry/TireDiagram.tsx
+++ b/client/src/components/telemetry/TireDiagram.tsx
@@ -2,9 +2,9 @@ import type { TelemetryPacket } from "@shared/types";
 import type { DisplayPacket } from "@/lib/convert-packet";
 import { useUnits } from "@/hooks/useUnits";
 import { convertTemp } from "@/lib/temperature";
-import { useSettings } from "@/hooks/queries";
 import { WeightShiftRadar } from "@/components/WeightShiftRadar";
 import { allWheelStates } from "@/lib/vehicle-dynamics";
+import { tryGetGame } from "@shared/games/registry";
 import { WheelCard } from "./WheelCard";
 import { SuspBar } from "./SuspBar";
 
@@ -16,8 +16,7 @@ import { SuspBar } from "./SuspBar";
  */
 export function TireDiagram({ packet }: { packet: DisplayPacket | TelemetryPacket }) {
   const units = useUnits();
-  const { displaySettings } = useSettings();
-  const suspThresh = displaySettings.suspensionThresholds.values;
+  const suspThresh = tryGetGame(packet.gameId)?.suspensionThresholds.values ?? [25, 65, 85];
   const toDeg = 180 / Math.PI;
 
   // Use canonical wheel states from vehicle-dynamics (same as LapAnalyse)

--- a/client/src/stores/telemetry.ts
+++ b/client/src/stores/telemetry.ts
@@ -4,9 +4,6 @@ import { convertPacket, type DisplayPacket } from "../lib/convert-packet";
 
 export interface DisplaySettings {
   unit: "metric" | "imperial";
-  tireTempCelsiusThresholds: { cold: number; warm: number; hot: number };
-  tireHealthThresholds: { values: number[] };
-  suspensionThresholds: { values: number[] };
   aiProvider: "gemini" | "openai" | "local";
   aiModel: string;
   chatProvider: "gemini" | "openai" | "local";
@@ -33,9 +30,6 @@ export interface DisplaySettings {
 
 export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {
   unit: "metric",
-  tireTempCelsiusThresholds: { cold: 75, warm: 115, hot: 150 },
-  tireHealthThresholds: { values: [20, 40, 60, 80] },
-  suspensionThresholds: { values: [25, 65, 85] },
   aiProvider: "gemini",
   aiModel: "",
   chatProvider: "gemini",

--- a/server/routes/settings-routes.ts
+++ b/server/routes/settings-routes.ts
@@ -95,28 +95,6 @@ export const settingsRoutes = new Hono()
     }
     const merged = { ...current, ...provided };
 
-    if (provided.tireTempCelsiusThresholds) {
-      merged.tireTempCelsiusThresholds = {
-        ...current.tireTempCelsiusThresholds,
-        ...(provided.tireTempCelsiusThresholds as Record<string, unknown>),
-      };
-    }
-
-    const t = merged.tireTempCelsiusThresholds;
-    if (t.cold >= t.warm || t.warm >= t.hot) {
-      return c.json({ error: "Thresholds must be in order: cold < warm < hot" }, 400);
-    }
-
-    for (const [name, arr] of [
-      ["tireHealthThresholds", merged.tireHealthThresholds.values],
-      ["suspensionThresholds", merged.suspensionThresholds.values],
-    ] as const) {
-      for (let i = 1; i < arr.length; i++) {
-        if (arr[i] <= arr[i - 1])
-          return c.json({ error: `${name} must be in ascending order` }, 400);
-      }
-    }
-
     try {
       if (merged.udpPort !== udpListener.port) {
         await udpListener.restart(merged.udpPort);

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -5,10 +5,6 @@ import { resolveDataDir } from "./data-dir";
 const SETTINGS_DIR = resolveDataDir();
 const SETTINGS_PATH = `${SETTINGS_DIR}/settings.json`;
 
-const ColorThresholdsSchema = z.object({
-  values: z.array(z.number()),
-});
-
 // `""` retained in the enum only for backwards compatibility with previously
 // stored settings files where the user hadn't picked a provider yet. Fresh
 // installs and defaults resolve to "gemini" + "gemini-flash-latest" so the
@@ -31,18 +27,10 @@ const AppSettingsSchema = z.object({
   // calls to cap GPU/CPU work when the scene is idle or when the user
   // wants to trade smoothness for battery/thermal headroom. 15–120 fps.
   renderFpsCap: z.number().int().min(15).max(120).default(60),
-  tireTempCelsiusThresholds: z.object({
-    cold: z.number().default(65),
-    warm: z.number().default(105),
-    hot: z.number().default(138),
-  }).default({ cold: 65, warm: 105, hot: 138 }),
-  tireHealthThresholds: ColorThresholdsSchema.default({ values: [20, 40, 60, 80] }),
-  suspensionThresholds: ColorThresholdsSchema.default({ values: [25, 65, 85] }),
   hiddenGames: z.array(z.string()).default([]),
 });
 
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
-export type ColorThresholds = z.infer<typeof ColorThresholdsSchema>;
 
 const DEFAULTS: AppSettings = AppSettingsSchema.parse({});
 
@@ -67,14 +55,15 @@ export function loadSettings(): AppSettings {
     if (!parsed.unit && parsed.speedUnit) {
       parsed.unit = parsed.speedUnit === "mph" ? "imperial" : "metric";
     }
-    // Migrate legacy tireTemperatureThresholds → tireTempCelsiusThresholds
-    if (!parsed.tireTempCelsiusThresholds && parsed.tireTemperatureThresholds) {
-      parsed.tireTempCelsiusThresholds = parsed.tireTemperatureThresholds;
-    }
     // Migrate legacy claude-cli provider → gemini
     if (parsed.aiProvider === "claude-cli") {
       parsed.aiProvider = "gemini";
     }
+    // Strip legacy color-threshold fields — now owned by game adapters
+    delete parsed.tireTempCelsiusThresholds;
+    delete parsed.tireTemperatureThresholds;
+    delete parsed.tireHealthThresholds;
+    delete parsed.suspensionThresholds;
 
     return AppSettingsSchema.parse(parsed);
   } catch (err) {

--- a/shared/games/ac-evo/index.ts
+++ b/shared/games/ac-evo/index.ts
@@ -10,6 +10,7 @@ export const acEvoAdapter: GameAdapter = {
   steeringRange: 1,
   tireHealthThresholds: { green: 0.85, yellow: 0.70 },
   tireTempThresholds: { cold: 70, warm: 100, hot: 120 },
+  suspensionThresholds: { values: [25, 65, 85] },
   brakeTempThresholds: {
     front: { warm: 650, hot: 700 },
     rear:  { warm: 450, hot: 500 },

--- a/shared/games/acc/index.ts
+++ b/shared/games/acc/index.ts
@@ -10,6 +10,7 @@ export const accAdapter: GameAdapter = {
   steeringRange: 1,
   tireHealthThresholds: { green: 0.85, yellow: 0.70 },
   tireTempThresholds: { cold: 70, warm: 100, hot: 120 },
+  suspensionThresholds: { values: [25, 65, 85] },
   // Pressure optimal is class-aware — resolved server-side via the
   // /api/acc/cars/:ordinal/pressure-optimal endpoint.
   brakeTempThresholds: {

--- a/shared/games/f1-2025/index.ts
+++ b/shared/games/f1-2025/index.ts
@@ -10,6 +10,7 @@ export const f1Adapter: GameAdapter = {
   steeringRange: 1,
   tireHealthThresholds: { green: 0.70, yellow: 0.50 },
   tireTempThresholds: { cold: 80, warm: 110, hot: 135 },
+  suspensionThresholds: { values: [25, 65, 85] },
 
   // Stubs — server adapter overrides with real lookups
   getCarName(ordinal) {

--- a/shared/games/fm-2023/index.ts
+++ b/shared/games/fm-2023/index.ts
@@ -10,6 +10,7 @@ export const forzaAdapter: GameAdapter = {
   steeringRange: 127,
   tireHealthThresholds: { green: 0.70, yellow: 0.40 },
   tireTempThresholds: { cold: 75, warm: 115, hot: 150 },
+  suspensionThresholds: { values: [25, 65, 85] },
 
   // Stubs — server adapter overrides with real CSV-backed lookups
   getCarName(ordinal) {

--- a/shared/games/types.ts
+++ b/shared/games/types.ts
@@ -55,6 +55,12 @@ export interface GameAdapter {
   /** Tire temp thresholds in °C — blue < cold < green < warm < amber < hot < red */
   tireTempThresholds: { cold: number; warm: number; hot: number };
 
+  /** Suspension travel color thresholds — normalised 0–100 percent.
+   *  Bar colours step red → amber → green → blue as travel rises through
+   *  these values. Same shape for all games; per-car overrides can layer
+   *  on top later if needed. */
+  suspensionThresholds: { values: number[] };
+
   /** Optimal tire pressure range in PSI — shown green when in range, blue
    *  below, orange above. Games that need class-aware windows (e.g. ACC's
    *  GT3/GT4/TCX split) resolve this server-side via a game-specific API. */

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 
-import { loadSettings, saveSettings, type AppSettings } from "../server/settings";
+import { loadSettings } from "../server/settings";
 
 const SETTINGS_DIR = "./data";
 const SETTINGS_PATH = `${SETTINGS_DIR}/settings.json`;
@@ -26,7 +26,6 @@ describe("settings with unit system", () => {
     writeFileSync(SETTINGS_PATH, JSON.stringify({ udpPort: 5300 }));
     const settings = loadSettings();
     expect(settings.unit).toBe("metric");
-    expect(settings.tireTempCelsiusThresholds).toEqual({ cold: 65, warm: 105, hot: 138 });
   });
 
   test("loadSettings migrates legacy speedUnit to unit", () => {
@@ -36,27 +35,18 @@ describe("settings with unit system", () => {
     expect(settings.unit).toBe("imperial");
   });
 
-  test("saveSettings persists unit and threshold fields", () => {
-    const settings: AppSettings = {
+  test("loadSettings strips legacy threshold fields", () => {
+    if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true });
+    writeFileSync(SETTINGS_PATH, JSON.stringify({
       udpPort: 5300,
-      unit: "imperial",
       tireTempCelsiusThresholds: { cold: 60, warm: 100, hot: 130 },
       tireHealthThresholds: { values: [20, 40, 60, 80] },
       suspensionThresholds: { values: [25, 65, 85] },
-      activeProfileId: null,
-    };
-    saveSettings(settings);
-    const loaded = loadSettings();
-    expect(loaded.unit).toBe("imperial");
-    expect(loaded.tireTempCelsiusThresholds).toEqual({ cold: 60, warm: 100, hot: 130 });
-  });
-
-  test("loadSettings defaults missing threshold subfields", () => {
-    if (!existsSync(SETTINGS_DIR)) mkdirSync(SETTINGS_DIR, { recursive: true });
-    writeFileSync(SETTINGS_PATH, JSON.stringify({ udpPort: 5300, tireTempCelsiusThresholds: { cold: 50 } }));
-    const loaded = loadSettings();
-    expect(loaded.tireTempCelsiusThresholds.cold).toBe(50);
-    expect(loaded.tireTempCelsiusThresholds.warm).toBe(105);
-    expect(loaded.tireTempCelsiusThresholds.hot).toBe(138);
+    }));
+    const loaded = loadSettings() as Record<string, unknown>;
+    expect(loaded.udpPort).toBe(5300);
+    expect(loaded.tireTempCelsiusThresholds).toBeUndefined();
+    expect(loaded.tireHealthThresholds).toBeUndefined();
+    expect(loaded.suspensionThresholds).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- Tire-health, suspension-travel, and tire-temp color thresholds are now owned by each `GameAdapter` rather than user-editable settings
- `CarWireframe` + `TireDiagram` resolve suspension thresholds via `tryGetGame()`; `PitEstimate` drops its `healthThresholds` prop and falls through to the function-level defaults
- Removed `tireTempCelsiusThresholds` (previously unused), `tireHealthThresholds`, and `suspensionThresholds` from settings schema, store, API validation, and UI
- Settings loader strips legacy threshold fields on read — old \`settings.json\` files migrate cleanly

## Test plan
- [x] \`bun run test\` (238 pass)
- [x] \`cd client && bun run build\` (lint + typecheck + vite)
- [ ] Spot-check live dashboards (FM / F1 / ACC / AC Evo) still colour tire health, suspension bars, and temps as expected
- [ ] Open Settings modal — confirm Tire Health and Suspension sections are gone, remaining sections navigate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)