### PR TITLE
fix(dev): persist raw telemetry for imported dumps

### DIFF
--- a/server/routes/dev-routes.ts
+++ b/server/routes/dev-routes.ts
@@ -19,7 +19,7 @@ import { readCString } from "../games/ac-evo/utils";
 import { getAcEvoCarByDisplayName } from "../../shared/ac-evo-car-data";
 import { getAcEvoTrackByName } from "../../shared/ac-evo-track-data";
 import { ACC_PACKED_MAGIC, ACEVO_PACKED_MAGIC, packTriplet } from "../games/shared/pack-triplet";
-import { KNOWN_GAME_IDS, type GameId, type TelemetryPacket, type LapMeta } from "../../shared/types";
+import { KNOWN_GAME_IDS, type GameId, type LapMeta } from "../../shared/types";
 import { getGame } from "../../shared/games/registry";
 import { Pipeline } from "../pipeline";
 import { RealDbAdapter, type DbAdapter, type WsAdapter } from "../pipeline-adapters";

--- a/server/routes/dev-routes.ts
+++ b/server/routes/dev-routes.ts
@@ -1,7 +1,9 @@
 import { Hono } from "hono";
-import { readFileSync, readdirSync, statSync } from "fs";
+import { readFileSync, readdirSync, statSync, writeFileSync, unlinkSync } from "fs";
 import { resolve } from "path";
 import { parsePacket } from "../parsers/index";
+import { tmpdir } from "os";
+import { gunzipSync } from "zlib";
 import { initGameAdapters } from "../../shared/games/init";
 import { initServerGameAdapters } from "../games/init";
 import { getAllServerGames } from "../games/registry";
@@ -16,6 +18,7 @@ import { GRAPHICS_EVO, STATIC_EVO } from "../games/ac-evo/structs";
 import { readCString } from "../games/ac-evo/utils";
 import { getAcEvoCarByDisplayName } from "../../shared/ac-evo-car-data";
 import { getAcEvoTrackByName } from "../../shared/ac-evo-track-data";
+import { ACC_PACKED_MAGIC, ACEVO_PACKED_MAGIC, packTriplet } from "../games/shared/pack-triplet";
 import { KNOWN_GAME_IDS, type GameId, type TelemetryPacket, type LapMeta } from "../../shared/types";
 import { getGame } from "../../shared/games/registry";
 import { Pipeline } from "../pipeline";
@@ -494,11 +497,8 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
     }
 
     // Write to temp file — readAccFrames and the UDP reader both take a path
-    const os = await import("os");
-    const { gunzipSync } = await import("zlib");
-    const { writeFileSync, unlinkSync } = await import("fs");
     tmpPath = resolve(
-      os.tmpdir(),
+      tmpdir(),
       `raceiq-dump-${Date.now()}-${Math.random().toString(36).slice(2)}.bin`
     );
     const arrayBuf = await file.arrayBuffer();
@@ -509,9 +509,16 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
     }
     writeFileSync(tmpPath, bytes);
 
-    const packets: TelemetryPacket[] = [];
+    let packetCount = 0;
     let carModel: string | null = null;
     let trackName: string | null = null;
+
+    // Fresh pipeline per import so lap-detector state doesn't leak
+    const db = new ImportCaptureAdapter();
+    const pipeline = new Pipeline(db, new NoopWsAdapter(), {
+      bypassPacketRateFilter: true,
+    });
+    const start = Date.now();
 
     if (gameId === "acc") {
       let frames: { physics: Buffer; graphics: Buffer; staticData: Buffer }[];
@@ -530,7 +537,17 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
           if (tn) { trackName = tn; trackOrdinal = getAccTrackByName(tn)?.id ?? 0; }
         }
         const packet = parseAccBuffers(frame.physics, frame.graphics, frame.staticData, { carOrdinal, trackOrdinal });
-        if (packet) packets.push(packet);
+        if (!packet) continue;
+        const rawBuf = packTriplet(
+          ACC_PACKED_MAGIC,
+          packet.CarOrdinal,
+          packet.TrackOrdinal ?? 0,
+          frame.physics,
+          frame.graphics,
+          frame.staticData
+        );
+        await pipeline.processPacket(packet, rawBuf);
+        packetCount++;
       }
     } else if (gameId === "ac-evo") {
       let frames: { physics: Buffer; graphics: Buffer; staticData: Buffer }[];
@@ -559,7 +576,17 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
           }
         }
         const packet = parseAcEvoBuffers(frame.physics, frame.graphics, frame.staticData, cache);
-        if (packet) packets.push(packet);
+        if (!packet) continue;
+        const rawBuf = packTriplet(
+          ACEVO_PACKED_MAGIC,
+          packet.CarOrdinal,
+          packet.TrackOrdinal ?? 0,
+          frame.physics,
+          frame.graphics,
+          frame.staticData
+        );
+        await pipeline.processPacket(packet, rawBuf);
+        packetCount++;
       }
     } else {
       // UDP dump — use fresh per-import parser state so we don't collide with
@@ -577,24 +604,18 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
         if (offset + len > buffer.length) break;
         const chunk = buffer.slice(offset, offset + len);
         const packet = serverAdapter.tryParse(chunk, parserState);
-        if (packet) packets.push(packet);
+        if (packet) {
+          await pipeline.processPacket(packet, chunk);
+          packetCount++;
+        }
         offset += len;
       }
     }
 
-    if (packets.length === 0) {
+    if (packetCount === 0) {
       return c.json({ error: "No packets found in dump" }, 400);
     }
 
-    // Fresh pipeline per import so lap-detector state doesn't leak
-    const db = new ImportCaptureAdapter();
-    const pipeline = new Pipeline(db, new NoopWsAdapter(), {
-      bypassPacketRateFilter: true,
-    });
-    const start = Date.now();
-    for (const packet of packets) {
-      await pipeline.processPacket(packet);
-    }
     await pipeline.flushIncompleteLap();
     // Lap-detector uses setTimeout(..., 0) for deferred insertLap calls
     await new Promise<void>((r) => setTimeout(r, 100));
@@ -610,7 +631,7 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
       filename: uploadName,
       gameId,
       routePrefix,
-      packetCount: packets.length,
+      packetCount,
       carModel,
       trackName,
       elapsedMs,
@@ -619,7 +640,7 @@ devRoutes.post("/api/dev/import-dump", async (c) => {
   } catch (e) {
     console.error("[dev] import-dump failed:", e);
     if (tmpPath) {
-      try { (await import("fs")).unlinkSync(tmpPath); } catch { /* ignore */ }
+      try { unlinkSync(tmpPath); } catch { /* ignore */ }
     }
     return c.json({ error: "Import failed", details: String(e) }, 500);
   }

--- a/test/ac-evo-mid-session.test.ts
+++ b/test/ac-evo-mid-session.test.ts
@@ -150,5 +150,5 @@ describe("AC Evo mid-session recording", () => {
     // Recording began mid-lap, so the first captured lap is shorter than a full lap.
     expect(laps.length).toBeGreaterThanOrEqual(2);
     expect(laps[0].lapTime).toBeLessThan(laps[1].lapTime);
-  }, { timeout: 60_000 });
+  }, { timeout: 90_000 });
 });

--- a/test/lap-legacy-detection.test.ts
+++ b/test/lap-legacy-detection.test.ts
@@ -1,8 +1,8 @@
 /**
  * Tests for isLegacy detection. A lap is "legacy" (pre-raw-bin-storage) only
  * when its session has no raw_file path. Per-lap rawByteOffset is NOT a
- * reliable signal — post-migration sessions can produce laps without a byte
- * offset (e.g. import-dump path feeds the pipeline without rawBuf).
+ * reliable signal — post-migration sessions can still produce laps without a byte
+ * offset in synthetic/test pipelines that don't pass rawBuf into processPacket().
  */
 import { describe, test, expect, afterEach } from "bun:test";
 import { db } from "../server/db/index";


### PR DESCRIPTION
## Summary
- make dev import-dump feed raw frame bytes into Pipeline so imported laps persist analyzable raw telemetry
- pack ACC and AC Evo shared-memory frames using packTriplet before processPacket
- pass original UDP chunk bytes into processPacket for UDP dumps
- replace dynamic imports in import-dump route with static imports and update stale test comment
