### PR TITLE
feat: Launch on Login setting (Windows)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,3 +23,52 @@ jobs:
 
       - name: Run tests
         run: bun run test
+
+  build-windows:
+    runs-on: blacksmith-2vcpu-windows-2025
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build client
+        run: cd client && bun install && bun run build
+
+      - name: Prepare dist
+        shell: bash
+        run: mkdir -p dist
+
+      - name: Copy client assets
+        shell: bash
+        run: cp -r client/dist dist/public
+
+      - name: Copy shared data
+        run: bun scripts/copy-shared-data.ts
+
+      - name: Compile server binary
+        shell: bash
+        run: NODE_ENV=production bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico --define 'process.env.NODE_ENV="production"' server/bootstrap.ts --outfile dist/raceiq.exe
+
+      - name: Copy libsql native addon
+        shell: bash
+        run: |
+          mkdir -p dist/node_modules/@libsql/win32-x64-msvc
+          cp node_modules/@libsql/win32-x64-msvc/index.node dist/node_modules/@libsql/win32-x64-msvc/
+          cp node_modules/@libsql/win32-x64-msvc/package.json dist/node_modules/@libsql/win32-x64-msvc/
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: raceiq-dist-windows-pr
+          path: dist/
+          retention-days: 1
+
+  playwright:
+    needs: build-windows
+    uses: ./.github/workflows/playwright.yml
+    with:
+      dist-artifact: raceiq-dist-windows-pr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,23 @@ jobs:
 
       - name: Compile server binary
         shell: bash
-        run: NODE_ENV=production bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico --define 'process.env.NODE_ENV="production"' server/bootstrap.ts --outfile dist/raceiq.exe
+        run: |
+          VERSION=${{ needs.compute-version.outputs.version }}
+          NODE_ENV=production bun build --compile --target=bun-windows-x64 \
+            --windows-icon=assets/raceiq.ico \
+            --windows-title=RaceIQ \
+            --windows-publisher=SpeedHQ \
+            --windows-description="RaceIQ Racing Telemetry" \
+            --windows-version=${VERSION} \
+            --define 'process.env.NODE_ENV="production"' \
+            server/bootstrap.ts --outfile dist/raceiq.exe
+
+      - name: Patch PE version info (ProductName)
+        shell: pwsh
+        run: |
+          $rcedit = "$env:TEMP\rcedit.exe"
+          Invoke-WebRequest -Uri "https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe" -OutFile $rcedit
+          & $rcedit dist\raceiq.exe --set-version-string "ProductName" "RaceIQ" --set-version-string "InternalName" "RaceIQ"
 
       - name: Copy libsql native addon
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
             --windows-icon=assets/raceiq.ico \
             --windows-title=RaceIQ \
             --windows-publisher=SpeedHQ \
-            --windows-description="RaceIQ Racing Telemetry" \
+            --windows-description="RaceIQ" \
             --windows-version=${VERSION} \
             --define 'process.env.NODE_ENV="production"' \
             server/bootstrap.ts --outfile dist/raceiq.exe

--- a/client/src/components/Onboarding.tsx
+++ b/client/src/components/Onboarding.tsx
@@ -502,6 +502,45 @@ export function StepSound() {
   );
 }
 
+/* ─── Startup ─── */
+
+export function StepStartup() {
+  const { displaySettings } = useSettings();
+  const saveSettings = useSaveSettings();
+  const enabled = !!displaySettings.isCompiled;
+
+  return (
+    <div>
+      <h2 className="text-sm font-semibold text-app-text mb-1">Launch on Login</h2>
+      <p className="text-sm text-app-text-muted mb-4">Start RaceIQ automatically when you log into Windows.</p>
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          role="switch"
+          disabled={!enabled}
+          aria-checked={!!displaySettings.launchOnLogin}
+          onClick={() => enabled && saveSettings.mutate({ launchOnLogin: !displaySettings.launchOnLogin })}
+          className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-accent ${
+            !enabled
+              ? "opacity-40 cursor-not-allowed bg-app-surface-alt border border-app-border-input"
+              : displaySettings.launchOnLogin
+                ? "cursor-pointer bg-app-accent"
+                : "cursor-pointer bg-app-surface-alt border border-app-border-input"
+          }`}
+        >
+          <span
+            className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition-transform ${
+              displaySettings.launchOnLogin ? "translate-x-4" : "translate-x-0"
+            }`}
+          />
+        </button>
+        <span className="text-sm text-app-text-muted">{!enabled ? "Only available in installed app" : displaySettings.launchOnLogin ? "Enabled" : "Disabled"}</span>
+      </div>
+    </div>
+  );
+}
+
 /* ─── Onboarding Modal (state-managed, no routing) ─── */
 
 const MODAL_STEPS = [
@@ -510,8 +549,9 @@ const MODAL_STEPS = [
   { label: "Wheel", Component: StepWheel },
   { label: "Units", Component: StepUnits },
   { label: "Sound", Component: StepSound },
+  { label: "Startup", Component: StepStartup },
   { label: "Community", Component: StepCommunity },
-] as const;
+];
 
 export function OnboardingModal({ onClose }: { onClose?: () => void } = {}) {
   const [step, setStep] = useState(0);

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -51,6 +51,7 @@ import {
 } from "../lib/settings-storage";
 
 const NAV_ITEMS = [
+  { id: "general", label: "General" },
   { id: "theme", label: "Theme" },
   { id: "games", label: "Games" },
   { id: "connection", label: "Connection" },
@@ -69,7 +70,7 @@ type SectionId = (typeof NAV_ITEMS)[number]["id"];
 
 export function Settings({ initialSection, onClose }: { initialSection?: SectionId; onClose?: () => void } = {}) {
   const { openOnboarding } = useUiStore();
-  const [activeSection, setActiveSection] = useState<SectionId>(initialSection ?? "theme");
+  const [activeSection, setActiveSection] = useState<SectionId>(initialSection ?? "general");
   const [showSetupGuide, setShowSetupGuide] = useState(false);
   const [udpPort, setUdpPort] = useState("5301");
   const [showF1SetupGuide, setShowF1SetupGuide] = useState(false);
@@ -155,6 +156,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
       <nav className="md:w-48 shrink-0 md:border-r border-b md:border-b-0 border-app-border bg-app-surface-alt/50 py-2 flex md:flex-col overflow-x-auto md:overflow-x-visible">
         {NAV_ITEMS.filter((item) => !("devOnly" in item) || isDevelopment).map((item) => (
           <button
+            type="button"
             key={item.id}
             onClick={() => setActiveSection(item.id)}
             className={`shrink-0 md:w-full text-left px-4 py-2 text-sm whitespace-nowrap transition-colors ${
@@ -168,6 +170,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
         ))}
         <div className="hidden md:block mt-auto pt-2 border-t border-app-border mx-2">
           <button
+            type="button"
             className="w-full text-left px-4 py-2 text-sm text-app-text-muted hover:text-app-text hover:bg-app-surface-alt transition-colors"
             onClick={() => {
               onClose?.();
@@ -178,6 +181,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
           </button>
         </div>
         <button
+          type="button"
           className="md:hidden shrink-0 px-4 py-2 text-sm whitespace-nowrap text-app-text-muted hover:text-app-text transition-colors border-l border-app-border ml-auto"
           onClick={() => {
             onClose?.();
@@ -190,6 +194,41 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
 
       {/* Right content */}
       <div className="flex-1 overflow-y-auto p-4 md:p-6">
+        {activeSection === "general" && (
+          <section>
+            <h2 className="text-lg font-semibold text-app-text mb-1">General</h2>
+            <p className="text-sm text-app-text-muted mb-4">App-wide settings.</p>
+
+            <div className="max-w-xs">
+              <Label className={`${displaySettings.isCompiled ? "text-app-text-secondary" : "text-app-text-muted"}`}>Launch on Login</Label>
+              <div className="flex items-center gap-3 mt-1.5">
+                <button
+                  type="button"
+                  role="switch"
+                  disabled={!displaySettings.isCompiled}
+                  aria-checked={!!displaySettings.launchOnLogin}
+                  onClick={() => displaySettings.isCompiled && saveSettings.mutate({ launchOnLogin: !displaySettings.launchOnLogin })}
+                  className={`relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-accent ${
+                    !displaySettings.isCompiled
+                      ? "opacity-40 cursor-not-allowed bg-app-surface-alt border border-app-border-input"
+                      : displaySettings.launchOnLogin
+                        ? "cursor-pointer bg-app-accent"
+                        : "cursor-pointer bg-app-surface-alt border border-app-border-input"
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition-transform ${
+                      displaySettings.launchOnLogin ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+                <span className="text-sm text-app-text-muted">{!displaySettings.isCompiled ? "Only available in installed app" : displaySettings.launchOnLogin ? "Enabled" : "Disabled"}</span>
+              </div>
+              <p className="text-app-text-muted text-xs mt-1">Automatically start RaceIQ when you log into Windows.</p>
+            </div>
+          </section>
+        )}
+
         {activeSection === "games" && <GamesSection />}
 
         {activeSection === "theme" && (
@@ -199,6 +238,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
             <div className="grid grid-cols-2 gap-3 max-w-sm">
               {themes.map((t) => (
                 <button
+                  type="button"
                   key={t.value}
                   onClick={() => setTheme(t.value)}
                   className={`relative rounded-lg border p-3 text-left transition-all ${
@@ -280,31 +320,9 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
               </p>
             </div>
 
-            <div className="mt-4 max-w-xs">
-              <Label className="text-app-text-secondary">Launch on Login</Label>
-              <div className="flex items-center gap-3 mt-1.5">
-                <button
-                  role="switch"
-                  aria-checked={!!displaySettings.launchOnLogin}
-                  onClick={() => saveSettings.mutate({ launchOnLogin: !displaySettings.launchOnLogin })}
-                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-accent ${
-                    displaySettings.launchOnLogin ? "bg-app-accent" : "bg-app-surface-alt border border-app-border-input"
-                  }`}
-                >
-                  <span
-                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition-transform ${
-                      displaySettings.launchOnLogin ? "translate-x-4" : "translate-x-0"
-                    }`}
-                  />
-                </button>
-                <span className="text-sm text-app-text-muted">{displaySettings.launchOnLogin ? "Enabled" : "Disabled"}</span>
-              </div>
-              <p className="text-app-text-muted text-xs mt-1">Automatically start RaceIQ when you log into Windows.</p>
-            </div>
-
             <div className="mt-6 pt-6 border-t border-app-border">
-              <button onClick={() => setShowSetupGuide(!showSetupGuide)} className="flex items-center gap-2 text-sm text-app-accent hover:text-app-accent/80 transition-colors">
-                <svg className={`w-4 h-4 transition-transform ${showSetupGuide ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <button type="button" onClick={() => setShowSetupGuide(!showSetupGuide)} className="flex items-center gap-2 text-sm text-app-accent hover:text-app-accent/80 transition-colors">
+                <svg aria-hidden="true" className={`w-4 h-4 transition-transform ${showSetupGuide ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
                 How to enable Data Out in Forza Motorsport
@@ -354,8 +372,8 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
             </div>
 
             <div className="mt-3">
-              <button onClick={() => setShowF1SetupGuide(!showF1SetupGuide)} className="flex items-center gap-2 text-sm text-app-accent hover:text-app-accent/80 transition-colors">
-                <svg className={`w-4 h-4 transition-transform ${showF1SetupGuide ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <button type="button" onClick={() => setShowF1SetupGuide(!showF1SetupGuide)} className="flex items-center gap-2 text-sm text-app-accent hover:text-app-accent/80 transition-colors">
+                <svg aria-hidden="true" className={`w-4 h-4 transition-transform ${showF1SetupGuide ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                   <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
                 </svg>
                 How to enable UDP Telemetry in F1 2025

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -112,7 +112,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
 
   async function handleSave() {
     const savePort = Number.parseInt(udpPort, 10);
-    if (isNaN(savePort) || savePort < 1024 || savePort > 65535) {
+    if (Number.isNaN(savePort) || savePort < 1024 || savePort > 65535) {
       setStatus("error");
       setErrorMsg("Port must be between 1024-65535");
       return;
@@ -440,7 +440,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
                   onChange={(e) => {
                     setSteerLock(e.target.value);
                     const val = Number.parseInt(e.target.value, 10);
-                    if (!isNaN(val) && val >= 180 && val <= 1800) {
+                    if (!Number.isNaN(val) && val >= 180 && val <= 1800) {
                       localStorage.setItem(STEER_LOCK_KEY, String(val));
                     }
                   }}

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -1,22 +1,22 @@
-import { useEffect, useState } from "react";
-import { isDevelopment } from "@/lib/env";
-import { useUiStore } from "../stores/ui";
+import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Button } from "@/components/ui/button";
+import { isDevelopment } from "@/lib/env";
+import { useEffect, useState } from "react";
+import { type Theme, useTheme } from "../context/theme";
+import { useSaveSettings, useSettings } from "../hooks/queries";
+import { useUiStore } from "../stores/ui";
 import { playBlip, preloadSound } from "./SectorTimes";
-import { useSettings, useSaveSettings } from "../hooks/queries";
-import { useTheme, type Theme } from "../context/theme";
 
-import { WheelPicker } from "./settings/WheelPicker";
-import { GamesSection } from "./settings/GamesSection";
+import { AboutSection } from "./settings/AboutSection";
 import { AiSection } from "./settings/AiSection";
-import { UpdatesSection } from "./settings/UpdatesSection";
+import { DiagnosticsSection } from "./settings/DiagnosticsSection";
 import { ExtractionSection } from "./settings/ExtractionSection";
 import { F1ExtractionSection } from "./settings/F1ExtractionSection";
-import { AboutSection } from "./settings/AboutSection";
-import { DiagnosticsSection } from "./settings/DiagnosticsSection";
+import { GamesSection } from "./settings/GamesSection";
 import { StorageSection } from "./settings/StorageSection";
+import { UpdatesSection } from "./settings/UpdatesSection";
+import { WheelPicker } from "./settings/WheelPicker";
 
 // Re-export localStorage utilities so existing importers don't break
 export {
@@ -35,19 +35,19 @@ export {
 } from "../lib/settings-storage";
 
 import {
-  getSteeringLock,
-  getWheelStyle,
-  getSoundEnabled,
-  setSoundEnabled,
-  getSoundVolume,
-  setSoundVolume,
-  getSoundType,
-  setSoundType,
-  getSoundUrl,
-  setSoundUrl,
   SOUND_PRESETS,
   STEER_LOCK_KEY,
   WHEEL_STYLE_KEY,
+  getSoundEnabled,
+  getSoundType,
+  getSoundUrl,
+  getSoundVolume,
+  getSteeringLock,
+  getWheelStyle,
+  setSoundEnabled,
+  setSoundType,
+  setSoundUrl,
+  setSoundVolume,
 } from "../lib/settings-storage";
 
 const NAV_ITEMS = [
@@ -107,11 +107,11 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
     }
   }, [settingsQuery.displaySettings]);
 
-  const port = parseInt(udpPort, 10);
+  const port = Number.parseInt(udpPort, 10);
   const hasChanges = savedPort === null || port !== savedPort;
 
   async function handleSave() {
-    const savePort = parseInt(udpPort, 10);
+    const savePort = Number.parseInt(udpPort, 10);
     if (isNaN(savePort) || savePort < 1024 || savePort > 65535) {
       setStatus("error");
       setErrorMsg("Port must be between 1024-65535");
@@ -280,6 +280,28 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
               </p>
             </div>
 
+            <div className="mt-4 max-w-xs">
+              <Label className="text-app-text-secondary">Launch on Login</Label>
+              <div className="flex items-center gap-3 mt-1.5">
+                <button
+                  role="switch"
+                  aria-checked={!!displaySettings.launchOnLogin}
+                  onClick={() => saveSettings.mutate({ launchOnLogin: !displaySettings.launchOnLogin })}
+                  className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-accent ${
+                    displaySettings.launchOnLogin ? "bg-app-accent" : "bg-app-surface-alt border border-app-border-input"
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition-transform ${
+                      displaySettings.launchOnLogin ? "translate-x-4" : "translate-x-0"
+                    }`}
+                  />
+                </button>
+                <span className="text-sm text-app-text-muted">{displaySettings.launchOnLogin ? "Enabled" : "Disabled"}</span>
+              </div>
+              <p className="text-app-text-muted text-xs mt-1">Automatically start RaceIQ when you log into Windows.</p>
+            </div>
+
             <div className="mt-6 pt-6 border-t border-app-border">
               <button onClick={() => setShowSetupGuide(!showSetupGuide)} className="flex items-center gap-2 text-sm text-app-accent hover:text-app-accent/80 transition-colors">
                 <svg className={`w-4 h-4 transition-transform ${showSetupGuide ? "rotate-90" : ""}`} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -417,7 +439,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
                   value={steerLock}
                   onChange={(e) => {
                     setSteerLock(e.target.value);
-                    const val = parseInt(e.target.value, 10);
+                    const val = Number.parseInt(e.target.value, 10);
                     if (!isNaN(val) && val >= 180 && val <= 1800) {
                       localStorage.setItem(STEER_LOCK_KEY, String(val));
                     }
@@ -551,7 +573,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
                 max="100"
                 value={Math.round(soundVolume * 100)}
                 onChange={(e) => {
-                  const v = parseInt(e.target.value, 10) / 100;
+                  const v = Number.parseInt(e.target.value, 10) / 100;
                   setSoundVolumeState(v);
                   setSoundVolume(v);
                 }}

--- a/client/src/stores/telemetry.ts
+++ b/client/src/stores/telemetry.ts
@@ -1,6 +1,6 @@
+import type { LapMeta, LivePitData, LiveSectorData, TelemetryPacket } from "@shared/types";
 import { create } from "zustand";
-import type { TelemetryPacket, LiveSectorData, LivePitData, LapMeta } from "@shared/types";
-import { convertPacket, type DisplayPacket } from "../lib/convert-packet";
+import { type DisplayPacket, convertPacket } from "../lib/convert-packet";
 
 export interface DisplaySettings {
   unit: "metric" | "imperial";
@@ -31,6 +31,8 @@ export interface DisplaySettings {
   onboardingComplete?: boolean;
   /** Game IDs excluded from nav and home page */
   hiddenGames?: string[];
+  /** Whether to launch RaceIQ automatically on Windows login */
+  launchOnLogin?: boolean;
 }
 
 export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {

--- a/client/src/stores/telemetry.ts
+++ b/client/src/stores/telemetry.ts
@@ -33,6 +33,8 @@ export interface DisplaySettings {
   hiddenGames?: string[];
   /** Whether to launch RaceIQ automatically on Windows login */
   launchOnLogin?: boolean;
+  /** True when running as compiled exe, false in dev (bun run dev) */
+  isCompiled?: boolean;
 }
 
 export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {

--- a/installer/raceiq.iss
+++ b/installer/raceiq.iss
@@ -117,3 +117,4 @@ Filename: "wscript.exe"; Parameters: """{app}\raceiq-launcher.vbs"""; WorkingDir
 Filename: "taskkill"; Parameters: "/F /IM raceiq.exe"; Flags: runhidden; RunOnceId: "KillRaceIQ"
 Filename: "powershell.exe"; Parameters: "-NoProfile -Command ""Get-NetTCPConnection -LocalPort 3117 -State Listen -EA 0 | ForEach-Object {{ Stop-Process -Id $_.OwningProcess -Force -EA 0 }}"""; Flags: runhidden; RunOnceId: "KillPort3117"
 Filename: "cmdkey"; Parameters: "/delete:RaceIQ:gemini-api-key"; Flags: runhidden; RunOnceId: "DeleteApiKey"
+Filename: "powershell.exe"; Parameters: "-NoProfile -Command ""Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'RaceIQ' -ErrorAction SilentlyContinue"""; Flags: runhidden; RunOnceId: "RemoveStartup"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:dump:f1": "bun run dev:proxy && concurrently \"bun --watch run server/index.ts --record=f1-2025\" \"cd client && portless raceiq bun run dev\"",
     "dev:dump:fm": "bun run dev:proxy && concurrently \"bun --watch run server/index.ts --record=fm-2023\" \"cd client && portless raceiq bun run dev\"",
     "dev:client": "bun run dev:proxy && cd client && portless raceiq bun run dev",
-    "build": "mkdir -p dist && rm -rf dist/* && cd client && bun vite build && cd .. && bun scripts/copy-shared-data.ts && bun scripts/copy-client-dist.ts && NODE_ENV=production bun build --compile --define 'process.env.NODE_ENV=\"production\"' server/bootstrap.ts --outfile dist/raceiq",
+    "build": "mkdir -p dist && rm -rf dist/* && cd client && bun vite build && cd .. && bun scripts/copy-shared-data.ts && bun scripts/copy-client-dist.ts && NODE_ENV=production bun build --compile --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --define 'process.env.NODE_ENV=\"production\"' server/bootstrap.ts --outfile dist/raceiq",
     "start": "NODE_ENV=production ./dist/raceiq",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:dump:f1": "bun run dev:proxy && concurrently \"bun --watch run server/index.ts --record=f1-2025\" \"cd client && portless raceiq bun run dev\"",
     "dev:dump:fm": "bun run dev:proxy && concurrently \"bun --watch run server/index.ts --record=fm-2023\" \"cd client && portless raceiq bun run dev\"",
     "dev:client": "bun run dev:proxy && cd client && portless raceiq bun run dev",
-    "build": "mkdir -p dist && rm -rf dist/* && cd client && bun vite build && cd .. && bun scripts/copy-shared-data.ts && bun scripts/copy-client-dist.ts && NODE_ENV=production bun build --compile --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --windows-description=\"RaceIQ Racing Telemetry\" --define 'process.env.NODE_ENV=\"production\"' server/bootstrap.ts --outfile dist/raceiq",
+    "build": "mkdir -p dist && rm -rf dist/* && cd client && bun vite build && cd .. && bun scripts/copy-shared-data.ts && bun scripts/copy-client-dist.ts && NODE_ENV=production bun build --compile --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --windows-description=\"RaceIQ\" --define 'process.env.NODE_ENV=\"production\"' server/bootstrap.ts --outfile dist/raceiq",
     "start": "NODE_ENV=production ./dist/raceiq",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:dump:f1": "bun run dev:proxy && concurrently \"bun --watch run server/index.ts --record=f1-2025\" \"cd client && portless raceiq bun run dev\"",
     "dev:dump:fm": "bun run dev:proxy && concurrently \"bun --watch run server/index.ts --record=fm-2023\" \"cd client && portless raceiq bun run dev\"",
     "dev:client": "bun run dev:proxy && cd client && portless raceiq bun run dev",
-    "build": "mkdir -p dist && rm -rf dist/* && cd client && bun vite build && cd .. && bun scripts/copy-shared-data.ts && bun scripts/copy-client-dist.ts && NODE_ENV=production bun build --compile --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --define 'process.env.NODE_ENV=\"production\"' server/bootstrap.ts --outfile dist/raceiq",
+    "build": "mkdir -p dist && rm -rf dist/* && cd client && bun vite build && cd .. && bun scripts/copy-shared-data.ts && bun scripts/copy-client-dist.ts && NODE_ENV=production bun build --compile --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --windows-description=\"RaceIQ Racing Telemetry\" --define 'process.env.NODE_ENV=\"production\"' server/bootstrap.ts --outfile dist/raceiq",
     "start": "NODE_ENV=production ./dist/raceiq",
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",

--- a/playwright/fresh-install.spec.ts
+++ b/playwright/fresh-install.spec.ts
@@ -86,7 +86,11 @@ test.describe.serial("fresh install", () => {
     await page.getByRole("button", { name: "Off" }).click();
     await page.getByRole("button", { name: "Next" }).click();
 
-    // Step 6: Community — final. Button reads "Next" when not receiving telemetry; clicking it finishes.
+    // Step 6: Startup (Launch on Login)
+    await expect(page.getByRole("heading", { name: "Launch on Login" })).toBeVisible();
+    await page.getByRole("button", { name: "Next" }).click();
+
+    // Step 7: Community — final. Button reads "Next" when not receiving telemetry; clicking it finishes.
     await expect(page.getByRole("heading", { name: "You're all set!" })).toBeVisible();
     await page.getByRole("button", { name: "Next" }).click();
 

--- a/scripts/build-installer.ts
+++ b/scripts/build-installer.ts
@@ -33,7 +33,7 @@ run("bun scripts/copy-shared-data.ts", "Copying shared data");
 
 // 5. Compile server binary
 run(
-  'bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico server/bootstrap.ts --outfile dist/raceiq.exe',
+  `bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --windows-version=${version} --windows-description="RaceIQ Racing Telemetry" server/bootstrap.ts --outfile dist/raceiq.exe`,
   "Compiling server binary",
   { NODE_ENV: "production" },
 );

--- a/scripts/build-installer.ts
+++ b/scripts/build-installer.ts
@@ -33,7 +33,7 @@ run("bun scripts/copy-shared-data.ts", "Copying shared data");
 
 // 5. Compile server binary
 run(
-  `bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --windows-version=${version} --windows-description="RaceIQ Racing Telemetry" server/bootstrap.ts --outfile dist/raceiq.exe`,
+  `bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico --windows-title=RaceIQ --windows-publisher=SpeedHQ --windows-version=${version} --windows-description="RaceIQ" server/bootstrap.ts --outfile dist/raceiq.exe`,
   "Compiling server binary",
   { NODE_ENV: "production" },
 );

--- a/server/launch-on-login.ts
+++ b/server/launch-on-login.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "child_process";
+import { join } from "path";
+import { dirname } from "path";
+
+const REG_PATH = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+const VALUE_NAME = "RaceIQ";
+
+export function isLaunchOnLoginEnabled(): boolean {
+  if (process.platform !== "win32") return false;
+  try {
+    const result = spawnSync(
+      "powershell.exe",
+      ["-NoProfile", "-Command", `(Get-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue).${VALUE_NAME}`],
+      { encoding: "utf8" },
+    );
+    return result.stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function enableLaunchOnLogin(exeDir: string): void {
+  if (process.platform !== "win32") return;
+  const launcherPath = join(exeDir, "raceiq-launcher.vbs");
+  const value = `wscript "${launcherPath}"`;
+  spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-Command", `Set-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -Value '${value.replace(/'/g, "''")}'`],
+    { encoding: "utf8" },
+  );
+}
+
+export function disableLaunchOnLogin(): void {
+  if (process.platform !== "win32") return;
+  spawnSync(
+    "powershell.exe",
+    ["-NoProfile", "-Command", `Remove-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue`],
+    { encoding: "utf8" },
+  );
+}
+
+export function getLaunchOnLoginExeDir(): string {
+  return dirname(process.execPath);
+}

--- a/server/launch-on-login.ts
+++ b/server/launch-on-login.ts
@@ -1,12 +1,12 @@
 import { spawnSync } from "child_process";
-import { join } from "path";
-import { dirname } from "path";
+import { dirname, join } from "path";
+import { IS_COMPILED } from "./paths";
 
 const REG_PATH = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run";
 const VALUE_NAME = "RaceIQ";
 
 export function isLaunchOnLoginEnabled(): boolean {
-  if (process.platform !== "win32") return false;
+  if (process.platform !== "win32" || !IS_COMPILED) return false;
   try {
     const result = spawnSync(
       "powershell.exe",
@@ -20,18 +20,17 @@ export function isLaunchOnLoginEnabled(): boolean {
 }
 
 export function enableLaunchOnLogin(exeDir: string): void {
-  if (process.platform !== "win32") return;
-  const launcherPath = join(exeDir, "raceiq-launcher.vbs");
-  const value = `wscript "${launcherPath}"`;
+  if (process.platform !== "win32" || !IS_COMPILED) return;
+  const exePath = join(exeDir, "raceiq.exe");
   spawnSync(
     "powershell.exe",
-    ["-NoProfile", "-Command", `Set-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -Value '${value.replace(/'/g, "''")}'`],
+    ["-NoProfile", "-Command", `Set-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -Value '"${exePath}"'`],
     { encoding: "utf8" },
   );
 }
 
 export function disableLaunchOnLogin(): void {
-  if (process.platform !== "win32") return;
+  if (process.platform !== "win32" || !IS_COMPILED) return;
   spawnSync(
     "powershell.exe",
     ["-NoProfile", "-Command", `Remove-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue`],

--- a/server/routes/settings-routes.ts
+++ b/server/routes/settings-routes.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { existsSync, readdirSync } from "fs";
 import { resolve } from "path";
-import { PUBLIC_DIR } from "../paths";
+import { PUBLIC_DIR, IS_COMPILED } from "../paths";
 
 import { GameIdQuerySchema } from "../../shared/schemas";
 import { udpListener } from "../udp";
@@ -57,6 +57,7 @@ export const settingsRoutes = new Hono()
       geminiApiKeySet: hasGeminiKey,
       openaiApiKeySet: hasOpenaiKey,
       anthropicApiKeySet: hasAnthropicKey,
+      isCompiled: IS_COMPILED,
     });
   })
 

--- a/server/routes/settings-routes.ts
+++ b/server/routes/settings-routes.ts
@@ -9,6 +9,7 @@ import { udpListener } from "../udp";
 import { wsManager } from "../ws";
 import { lapDetector } from "../pipeline";
 import { loadSettings, saveSettings, PartialSettingsSchema } from "../settings";
+import { enableLaunchOnLogin, disableLaunchOnLogin, getLaunchOnLoginExeDir } from "../launch-on-login";
 import { getLapStats, setCacheMaxBytes } from "../db/queries";
 import { getRunningGame } from "../games/registry";
 import { getTrackOutlineByOrdinal } from "../../shared/track-data";
@@ -197,6 +198,13 @@ export const settingsRoutes = new Hono()
       }
       if (typeof merged.cacheMaxMB === "number") {
         setCacheMaxBytes(merged.cacheMaxMB * 1024 * 1024);
+      }
+      if ("launchOnLogin" in provided) {
+        if (merged.launchOnLogin) {
+          enableLaunchOnLogin(getLaunchOnLoginExeDir());
+        } else {
+          disableLaunchOnLogin();
+        }
       }
       saveSettings(merged);
       if (provided.onboardingComplete) {

--- a/server/settings.ts
+++ b/server/settings.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
 import { resolveDataDir } from "./data-dir";
+import { isLaunchOnLoginEnabled } from "./launch-on-login";
 
 const SETTINGS_DIR = resolveDataDir();
 const SETTINGS_PATH = `${SETTINGS_DIR}/settings.json`;
@@ -35,6 +36,7 @@ const AppSettingsSchema = z.object({
   // workflows. LRU eviction kicks in once the budget is exceeded.
   cacheMaxMB: z.number().int().min(16).max(2048).default(256),
   hiddenGames: z.array(z.string()).default([]),
+  launchOnLogin: z.boolean().default(false),
 });
 
 export type AppSettings = z.infer<typeof AppSettingsSchema>;
@@ -75,7 +77,10 @@ export function loadSettings(): AppSettings {
     delete parsed.tireHealthThresholds;
     delete parsed.suspensionThresholds;
 
-    return AppSettingsSchema.parse(parsed);
+    const result = AppSettingsSchema.parse(parsed);
+    // Always sync launchOnLogin from the actual registry state
+    result.launchOnLogin = isLaunchOnLoginEnabled();
+    return result;
   } catch (err) {
     console.error(`[Settings] Failed to load ${SETTINGS_PATH}:`, err instanceof Error ? err.message : err);
     console.warn(`[Settings] Falling back to defaults`);


### PR DESCRIPTION
## Summary

- Adds **Launch on Login** toggle in Settings → Connection
- Writes/removes `HKCU\Software\Microsoft\Windows\CurrentVersion\Run` registry key so RaceIQ auto-starts on Windows login
- Setting appears in Task Manager → Startup Apps / Settings → Apps → Startup Apps (standard Windows mechanism)
- Server syncs `launchOnLogin` from actual registry on startup so stored JSON always reflects reality
- No-op on non-Windows platforms

## Files changed

- `server/launch-on-login.ts` (new) — registry read/write/delete via PowerShell
- `server/settings.ts` — adds `launchOnLogin` field, syncs from registry on load
- `server/routes/settings-routes.ts` — applies registry side-effect when setting changes
- `client/src/stores/telemetry.ts` — adds `launchOnLogin` to `DisplaySettings`
- `client/src/components/Settings.tsx` — toggle UI in Connection section

## Test plan

- [ ] Toggle on → `HKCU\...\Run` key `RaceIQ` appears in registry
- [ ] Toggle off → key removed
- [ ] Reboot Windows → app launches automatically
- [ ] macOS: setting visible, toggle calls API, no crash (no-op path)
- [ ] `bun run test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)