### PR TITLE
feat: Launch on Login setting (Windows)

### DIFF
--- a/client/src/hooks/queries.ts
+++ b/client/src/hooks/queries.ts
@@ -45,7 +45,7 @@ export function useSettings() {
     staleTime: 1000 * 60 * 30,
     gcTime: 1000 * 60 * 60,
     refetchOnMount: false,
-    refetchOnWindowFocus: false,
+    refetchOnWindowFocus: true,
   });
   return { displaySettings, settingsLoaded: isSuccess };
 }

--- a/installer/raceiq.iss
+++ b/installer/raceiq.iss
@@ -117,4 +117,4 @@ Filename: "wscript.exe"; Parameters: """{app}\raceiq-launcher.vbs"""; WorkingDir
 Filename: "taskkill"; Parameters: "/F /IM raceiq.exe"; Flags: runhidden; RunOnceId: "KillRaceIQ"
 Filename: "powershell.exe"; Parameters: "-NoProfile -Command ""Get-NetTCPConnection -LocalPort 3117 -State Listen -EA 0 | ForEach-Object {{ Stop-Process -Id $_.OwningProcess -Force -EA 0 }}"""; Flags: runhidden; RunOnceId: "KillPort3117"
 Filename: "cmdkey"; Parameters: "/delete:RaceIQ:gemini-api-key"; Flags: runhidden; RunOnceId: "DeleteApiKey"
-Filename: "powershell.exe"; Parameters: "-NoProfile -Command ""Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'RaceIQ' -ErrorAction SilentlyContinue"""; Flags: runhidden; RunOnceId: "RemoveStartup"
+Filename: "powershell.exe"; Parameters: "-NoProfile -Command ""Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'RaceIQ' -ErrorAction SilentlyContinue; Remove-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run' -Name 'RaceIQ' -ErrorAction SilentlyContinue"""; Flags: runhidden; RunOnceId: "RemoveStartup"

--- a/installer/raceiq.iss
+++ b/installer/raceiq.iss
@@ -104,6 +104,11 @@ Source: "..\dist\node_modules\@libsql\win32-x64-msvc\*"; DestDir: "{app}\node_mo
 Source: "..\server\credstore.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "raceiq-launcher.vbs"; DestDir: "{app}"; Flags: ignoreversion
 
+[Registry]
+; Create startup entry on install (enabled by default)
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "RaceIQ"; ValueData: """{app}\raceiq.exe"""; Flags: uninsdeletevalue
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run"; ValueType: binary; ValueName: "RaceIQ"; ValueData: 02 00 00 00 00 00 00 00 00 00 00 00; Flags: uninsdeletevalue
+
 [Icons]
 Name: "{userprograms}\{#MyAppName}"; Filename: "wscript.exe"; Parameters: """{app}\raceiq-launcher.vbs"""; WorkingDir: "{app}"; IconFilename: "{app}\{#MyAppExeName}"
 Name: "{userprograms}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"

--- a/installer/raceiq.iss
+++ b/installer/raceiq.iss
@@ -107,7 +107,7 @@ Source: "raceiq-launcher.vbs"; DestDir: "{app}"; Flags: ignoreversion
 [Registry]
 ; Create startup entry on install (enabled by default)
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "RaceIQ"; ValueData: """{app}\raceiq.exe"""; Flags: uninsdeletevalue
-Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run"; ValueType: binary; ValueName: "RaceIQ"; ValueData: 02 00 00 00 00 00 00 00 00 00 00 00; Flags: uninsdeletevalue
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run"; ValueType: binary; ValueName: "RaceIQ"; ValueData: 03 00 00 00 00 00 00 00 00 00 00 00; Flags: uninsdeletevalue
 
 [Icons]
 Name: "{userprograms}\{#MyAppName}"; Filename: "wscript.exe"; Parameters: """{app}\raceiq-launcher.vbs"""; WorkingDir: "{app}"; IconFilename: "{app}\{#MyAppExeName}"

--- a/server/launch-on-login.ts
+++ b/server/launch-on-login.ts
@@ -3,17 +3,27 @@ import { dirname, join } from "path";
 import { IS_COMPILED } from "./paths";
 
 const REG_PATH = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Run";
+const APPROVED_PATH = "HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\StartupApproved\\Run";
 const VALUE_NAME = "RaceIQ";
+
+// StartupApproved binary values used by Windows (same format as Task Manager)
+const ENABLED_BYTES = "02,00,00,00,00,00,00,00,00,00,00,00";
+const DISABLED_BYTES = "03,00,00,00,00,00,00,00,00,00,00,00";
+
+function ps(command: string): string {
+  const result = spawnSync("powershell.exe", ["-NoProfile", "-Command", command], { encoding: "utf8" });
+  return result.stdout.trim();
+}
 
 export function isLaunchOnLoginEnabled(): boolean {
   if (process.platform !== "win32" || !IS_COMPILED) return false;
   try {
-    const result = spawnSync(
-      "powershell.exe",
-      ["-NoProfile", "-Command", `(Get-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue).${VALUE_NAME}`],
-      { encoding: "utf8" },
-    );
-    return result.stdout.trim().length > 0;
+    // Entry must exist in Run key
+    const exists = ps(`(Get-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue).${VALUE_NAME}`);
+    if (!exists) return false;
+    // Check StartupApproved — if present, first byte must be 0x02 (enabled)
+    const approved = ps(`$v = (Get-ItemProperty -Path '${APPROVED_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue).${VALUE_NAME}; if ($v) { $v[0] } else { 2 }`);
+    return approved !== "3";
   } catch {
     return false;
   }
@@ -22,20 +32,14 @@ export function isLaunchOnLoginEnabled(): boolean {
 export function enableLaunchOnLogin(exeDir: string): void {
   if (process.platform !== "win32" || !IS_COMPILED) return;
   const exePath = join(exeDir, "raceiq.exe");
-  spawnSync(
-    "powershell.exe",
-    ["-NoProfile", "-Command", `Set-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -Value '"${exePath}"'`],
-    { encoding: "utf8" },
-  );
+  ps(`Set-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -Value '"${exePath}"'`);
+  ps(`$bytes = [byte[]](${ENABLED_BYTES} -split ',' | ForEach-Object { [Convert]::ToByte($_.Trim(), 16) }); New-ItemProperty -Path '${APPROVED_PATH}' -Name '${VALUE_NAME}' -Value $bytes -PropertyType Binary -Force | Out-Null`);
 }
 
 export function disableLaunchOnLogin(): void {
   if (process.platform !== "win32" || !IS_COMPILED) return;
-  spawnSync(
-    "powershell.exe",
-    ["-NoProfile", "-Command", `Remove-ItemProperty -Path '${REG_PATH}' -Name '${VALUE_NAME}' -ErrorAction SilentlyContinue`],
-    { encoding: "utf8" },
-  );
+  // Keep the Run entry but mark as disabled in StartupApproved (same as Task Manager disable)
+  ps(`$bytes = [byte[]](${DISABLED_BYTES} -split ',' | ForEach-Object { [Convert]::ToByte($_.Trim(), 16) }); New-ItemProperty -Path '${APPROVED_PATH}' -Name '${VALUE_NAME}' -Value $bytes -PropertyType Binary -Force | Out-Null`);
 }
 
 export function getLaunchOnLoginExeDir(): string {


### PR DESCRIPTION
## Summary
- Registers startup entry on install (disabled by default, wizard enables it)
- Disable in-app uses `StartupApproved\Run` to disable entry without removing it
- Uninstaller removes both `Run` and `StartupApproved\Run` entries
- PE binary metadata fixed: name=RaceIQ, company=SpeedHQ (was bun/oven)
- Settings query refetches on window focus to keep startup status current

## Test plan
- [ ] Install app, verify startup entry exists in Task Manager (disabled)
- [ ] Run wizard, enable launch on login, verify entry enabled in Task Manager
- [ ] Toggle off in Settings, verify entry still listed but disabled
- [ ] Uninstall, verify startup entry fully removed
- [ ] Build release, verify Task Manager shows RaceIQ / SpeedHQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)