### PR TITLE
fix(analyse): backfill car/track selection from loaded lap metadata

### DIFF
--- a/client/src/components/LapAnalyse.tsx
+++ b/client/src/components/LapAnalyse.tsx
@@ -93,6 +93,16 @@ function LapAnalyseInner() {
   const isLegacyLap = lapData?.isLegacy === true;
   const displayTelemetry = useConvertedTelemetry(telemetry);
 
+  // Backfill track/car selection from the loaded lap's metadata when the URL omitted them
+  useEffect(() => {
+    if (selectedTrack == null && lapData?.meta?.trackOrdinal != null) {
+      setSelectedTrack(lapData.meta.trackOrdinal);
+    }
+    if (selectedCar == null && lapData?.meta?.carOrdinal != null) {
+      setSelectedCar(lapData.meta.carOrdinal);
+    }
+  }, [lapData, selectedTrack, selectedCar]);
+
   // Fetch track data via TanStack Query (keyed on trackOrdinal derived from selection or lap data)
   const trackOrd = selectedTrack ?? lapData?.meta?.trackOrdinal ?? null;
   const { data: outlineRaw } = useTrackOutline(trackOrd ?? undefined);


### PR DESCRIPTION
## Summary
- Reload of an analyse URL missing `?car=` (e.g. `/acc/analyse?track=0&lap=80`) left car select stuck on "Search cars" placeholder and lap select showing raw "Lap 80" instead of friendly name.
- Root cause: `selectedCar` state only ever came from the URL param, with no fallback derivation from loaded lap metadata (unlike other places that use `lapData?.meta?.trackOrdinal` transiently). Empty `selectedCar` kept `filteredLaps` empty, breaking the lap label lookup too.
- Fix: backfill `selectedTrack`/`selectedCar` state from `lapData.meta` once the lap loads, if not already set from the URL.

## Test plan
- [x] `bun run build` (client) passes
- [ ] Manually reload `/acc/analyse?track=0&lap=80` and confirm car select + lap label populate