### PR TITLE
fix(acc): re-resolve car/track ordinal from static struct on parse

### DIFF
--- a/server/games/acc/index.ts
+++ b/server/games/acc/index.ts
@@ -1,10 +1,12 @@
 import type { ServerGameAdapter } from "../types";
 import type { TelemetryPacket } from "../../../shared/types";
 import { accAdapter } from "../../../shared/games/acc";
-import { getAccCarName } from "../../../shared/acc-car-data";
-import { getAccTrackName, getAccSharedTrackName } from "../../../shared/acc-track-data";
+import { getAccCarName, getAccCarByModel } from "../../../shared/acc-car-data";
+import { getAccTrackName, getAccSharedTrackName, getAccTrackByName } from "../../../shared/acc-track-data";
 import { LapDetectorAcc } from "../../lap-detector-acc";
 import { parseAccBuffers } from "./parser";
+import { STATIC } from "./structs";
+import { readWString } from "./utils";
 import { ACC_PACKED_MAGIC, unpackTriplet } from "../shared/pack-triplet";
 import { renderAnalystSchemaForPrompt } from "../../ai/schemas";
 
@@ -66,9 +68,28 @@ export const accServerAdapter: ServerGameAdapter = {
   tryParse(buf: Buffer, _state: unknown): TelemetryPacket | null {
     const triplet = unpackTriplet(buf);
     if (!triplet) return null;
+
+    // Prefer re-resolving from the embedded static struct over the packed
+    // header — the header is a cache of whatever ParsingProcessor had
+    // resolved *at capture time*, which older recordings baked in as 0
+    // (Monza/car #0) whenever resolution hadn't happened yet. The static
+    // struct is the ground truth and is stored in full on every frame, so
+    // re-deriving here repairs already-recorded .bin files on import too.
+    let carOrdinal = triplet.carOrdinal;
+    let trackOrdinal = triplet.trackOrdinal;
+    if (triplet.staticData.length >= STATIC.SIZE) {
+      const cm = readWString(triplet.staticData, STATIC.carModel.offset, STATIC.carModel.size);
+      const resolvedCar = cm ? getAccCarByModel(cm)?.id : undefined;
+      if (resolvedCar != null) carOrdinal = resolvedCar;
+
+      const tn = readWString(triplet.staticData, STATIC.track.offset, STATIC.track.size);
+      const resolvedTrack = tn ? getAccTrackByName(tn)?.id : undefined;
+      if (resolvedTrack != null) trackOrdinal = resolvedTrack;
+    }
+
     return parseAccBuffers(triplet.physics, triplet.graphics, triplet.staticData, {
-      carOrdinal: triplet.carOrdinal,
-      trackOrdinal: triplet.trackOrdinal,
+      carOrdinal,
+      trackOrdinal,
     });
   },
 

--- a/server/import-session-bin.ts
+++ b/server/import-session-bin.ts
@@ -1,6 +1,6 @@
 import { gunzipSync } from "zlib";
 import { KNOWN_GAME_IDS, type GameId, type LapMeta } from "../shared/types";
-import { getServerGame } from "./games/registry";
+import { getAllServerGames, getServerGame } from "./games/registry";
 import { Pipeline } from "./pipeline";
 import { RealDbAdapter, type DbAdapter, type WsAdapter } from "./pipeline-adapters";
 import { META_FRAME_MAGIC } from "./udp-recorder";
@@ -93,6 +93,46 @@ export function detectGameIdFromFilename(name: string): GameId | null {
   return null;
 }
 
+function decompressIfGz(bytes: Buffer): Buffer {
+  if (bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b) {
+    return Buffer.from(gunzipSync(bytes));
+  }
+  return bytes;
+}
+
+/** Session-capture framing: optional 12-byte meta frame, then repeated [uint32 LE len][frame]. */
+function* iterateFrames(buf: Buffer): Generator<Buffer> {
+  let offset = 0;
+  if (buf.length >= 4 && buf.readUInt32LE(0) === META_FRAME_MAGIC) offset = 12;
+  while (offset + 4 <= buf.length) {
+    const len = buf.readUInt32LE(offset);
+    offset += 4;
+    if (len <= 0 || offset + len > buf.length) break;
+    yield buf.subarray(offset, offset + len);
+    offset += len;
+  }
+}
+
+/**
+ * Detect a gameId from the actual frame content of a session .bin capture,
+ * by probing each registered game's `canHandle()` — the same detection every
+ * adapter already does for live UDP dispatch (server/parsers/index.ts). This
+ * doesn't depend on the uploaded filename following any naming convention.
+ */
+export function detectGameIdFromBuffer(bytes: Buffer): GameId | null {
+  const buf = decompressIfGz(bytes);
+  const games = getAllServerGames();
+  let checked = 0;
+  for (const frame of iterateFrames(buf)) {
+    for (const game of games) {
+      if (game.canHandle(frame)) return game.id;
+    }
+    checked++;
+    if (checked >= 20) break;
+  }
+  return null;
+}
+
 /**
  * Feed a session `.bin` capture through the full pipeline (parser → lap
  * detection → DB writes) so its laps land in the database as a fresh session.
@@ -109,28 +149,15 @@ export async function importSessionBin(
   bytes: Buffer,
   gameId: GameId
 ): Promise<{ packetCount: number; laps: ImportedLap[] }> {
-  let buf = bytes;
-  if (buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b) {
-    buf = Buffer.from(gunzipSync(buf));
-  }
+  const buf = decompressIfGz(bytes);
 
   const serverGame = getServerGame(gameId);
   const state = serverGame.createParserState?.() ?? null;
   const db = new ImportCaptureAdapter();
   const pipeline = new Pipeline(db, new NoopWsAdapter(), { bypassPacketRateFilter: true });
 
-  // Skip the 12-byte meta frame (magic length 0xFFFFFFFF) when present; older
-  // meta-less dumps start straight at the first real frame.
-  let offset = 0;
-  if (buf.length >= 4 && buf.readUInt32LE(0) === META_FRAME_MAGIC) offset = 12;
-
   let packetCount = 0;
-  while (offset + 4 <= buf.length) {
-    const len = buf.readUInt32LE(offset);
-    offset += 4;
-    if (len <= 0 || offset + len > buf.length) break;
-    const frame = buf.subarray(offset, offset + len);
-    offset += len;
+  for (const frame of iterateFrames(buf)) {
     const packet = serverGame.tryParse(frame, state);
     if (packet) {
       await pipeline.processPacket(packet, frame);

--- a/server/routes/lap-routes.ts
+++ b/server/routes/lap-routes.ts
@@ -21,7 +21,7 @@ import {
   getLapsRaw,
 } from "../db/queries";
 import { KNOWN_GAME_IDS } from "../../shared/types";
-import { importSessionBin, detectGameIdFromFilename } from "../import-session-bin";
+import { importSessionBin, detectGameIdFromBuffer } from "../import-session-bin";
 import { assessLapRecording } from "../lap-quality";
 
 // Toggle: set true to use native ACC lastSectorTime transitions in recheck instead of distance-fraction
@@ -254,7 +254,8 @@ export const lapRoutes = new Hono()
 
   // ── Import a raw session capture (.bin) ─────────────────────
   // Feeds an uploaded session .bin through the full pipeline so its laps land
-  // in the DB as a fresh session. GameId is detected from the filename prefix.
+  // in the DB as a fresh session. GameId is detected from the frame content
+  // (each adapter's canHandle()), not the uploaded filename.
   .post("/api/laps/import", async (c) => {
     const form = await c.req.formData().catch(() => null);
     const file = form?.get("file");
@@ -266,16 +267,16 @@ export const lapRoutes = new Hono()
       return c.json({ error: "Expected a .bin or .bin.gz file" }, 400);
     }
 
-    const gameId = detectGameIdFromFilename(uploadName);
+    const bytes = Buffer.from(await file.arrayBuffer());
+    const gameId = detectGameIdFromBuffer(bytes);
     if (!gameId) {
       return c.json(
-        { error: `Could not detect game from filename "${uploadName}". Expected prefix: ${KNOWN_GAME_IDS.join(", ")}.` },
+        { error: `Could not detect game from "${uploadName}" — no recognized frame format found. Supported games: ${KNOWN_GAME_IDS.join(", ")}.` },
         400
       );
     }
 
     try {
-      const bytes = Buffer.from(await file.arrayBuffer());
       const { packetCount, laps } = await importSessionBin(bytes, gameId);
       if (packetCount === 0) return c.json({ error: "No telemetry packets found in file" }, 400);
       return c.json({

--- a/test/acc-parser.test.ts
+++ b/test/acc-parser.test.ts
@@ -10,6 +10,7 @@ import { parseRawLapFramesForTest } from "../server/db/queries";
 import { stopMaintenanceTasks } from "../server/pipeline";
 import { getAccTrackName } from "../shared/acc-track-data";
 import { getAccCarName } from "../shared/acc-car-data";
+import { unpackTriplet } from "../server/games/shared/pack-triplet";
 
 initGameAdapters();
 initServerGameAdapters();
@@ -173,23 +174,29 @@ describe("parseRawLapFrames — coordinate normalization (standard-xyz)", () => 
     }
   }, { timeout: 30000 });
 
-  test("ACC recording resolves to a real track and car, not the unresolved sentinel", async () => {
+  test("ACC recording resolves track/car from the embedded static struct, not a stale packed header", async () => {
     const raw = Buffer.from(gunzipSync(readFileSync(ACC_SESSION_BIN)));
     const startOffset = 8 + raw.readUInt32LE(4);
 
     const serverGame = getServerGame("acc");
     const off = startOffset;
     const frameLen = raw.readUInt32LE(off);
-    const packet = serverGame.tryParse(raw.subarray(off + 4, off + 4 + frameLen), null);
+    const frame = raw.subarray(off + 4, off + 4 + frameLen);
+    const packet = serverGame.tryParse(frame, null);
 
     expect(packet).not.toBeNull();
-    // -1 is the "not yet resolved from static data" sentinel (see
-    // ParsingProcessor in server/games/acc/triplet-pipeline.ts) — a
-    // recording should never bake that in, since it means the track/car
-    // name lookup failed or raced the static data buffer at capture time.
-    expect(packet!.TrackOrdinal).toBeGreaterThanOrEqual(0);
-    expect(packet!.CarOrdinal).toBeGreaterThanOrEqual(0);
-    expect(getAccTrackName(packet!.TrackOrdinal)).toBe("Monza - GP");
-    expect(getAccCarName(packet!.CarOrdinal)).toBe("Porsche 991 GT3 R 2018");
+    // This fixture predates static-data resolution and has carOrdinal=0/
+    // trackOrdinal=0 baked into its packed header on every frame (the old
+    // "unresolved" sentinel collides with Monza/car#0's real ids — see
+    // triplet-pipeline.ts). Its embedded static struct is genuinely
+    // "brands_hatch"/"mclaren_720s_gt3_evo" though, so tryParse must
+    // re-derive from the static struct rather than trust the header,
+    // otherwise every re-import of an old recording mislabels the session.
+    expect(getAccTrackName(packet!.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAccCarName(packet!.CarOrdinal)).toBe("McLaren 720S GT3 Evo 2023");
+
+    const rawHeader = unpackTriplet(frame);
+    expect(rawHeader?.trackOrdinal).toBe(0);
+    expect(rawHeader?.carOrdinal).toBe(0);
   });
 });

--- a/test/bin-fixture-detection.test.ts
+++ b/test/bin-fixture-detection.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Regression coverage: every .bin.gz fixture in test/artifacts/sessions/
+ * resolves to a real, non-sentinel game/track/car through its game's
+ * production tryParse path (the same path import/reprocessing uses).
+ *
+ * Two on-disk formats exist and are auto-detected per fixture, not assumed:
+ *   - "session capture": [meta frame][uint32 LE len][frame]... — for ACC/AC Evo
+ *     the frame is a packed shared-memory triplet (pack-triplet.ts); for
+ *     FM/F1 it's a raw UDP packet. This is what real session storage /
+ *     import-session-bin.ts uses, and what the car/track re-derivation fix
+ *     (server/games/acc/index.ts tryParse) targets.
+ *   - "dump mode": ACCTEST-framed physics/graphics/static frames written by
+ *     DumpToBinProcessor, read via readAccFrames. Dev-only capture format,
+ *     never fed through importSessionBin in production.
+ */
+import { describe, test, expect, afterAll } from "bun:test";
+import { readFileSync } from "fs";
+import { gunzipSync } from "zlib";
+import { initGameAdapters } from "../shared/games/init";
+import { initServerGameAdapters } from "../server/games/init";
+import { getServerGame } from "../server/games/registry";
+import { getGame } from "../shared/games/registry";
+import { stopMaintenanceTasks } from "../server/pipeline";
+import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { detectGameIdFromBuffer } from "../server/import-session-bin";
+import { getAccTrackName } from "../shared/acc-track-data";
+import { getAccCarName } from "../shared/acc-car-data";
+import { getAcEvoTrackName } from "../shared/ac-evo-track-data";
+import { getAcEvoCarName } from "../shared/ac-evo-car-data";
+import { readAccPackets, readAcEvoPackets } from "./helpers/parse-dump";
+import { readUdpDump } from "./helpers/recording";
+import type { GameId, TelemetryPacket } from "../shared/types";
+
+initGameAdapters();
+initServerGameAdapters();
+
+afterAll(() => stopMaintenanceTasks());
+
+const DIR = "test/artifacts/sessions";
+
+function gunzip(path: string): Buffer {
+  return Buffer.from(gunzipSync(readFileSync(path)));
+}
+
+/** Session-capture framing: 12-byte meta frame, then repeated [len][frame]. */
+function metaFrameStart(buf: Buffer): number {
+  if (buf.length < 12 || buf.readUInt32LE(0) !== META_FRAME_MAGIC) return 0;
+  return 8 + buf.readUInt32LE(4);
+}
+
+function hasMetaFrame(buf: Buffer): boolean {
+  return buf.length >= 8 && buf.readUInt32LE(0) === META_FRAME_MAGIC;
+}
+
+/** Replays every frame of a session-capture .bin.gz through the game's real tryParse, exactly as import-session-bin.ts does. */
+function parseSessionCapture(path: string, gameId: GameId): TelemetryPacket[] {
+  const raw = gunzip(path);
+  const serverGame = getServerGame(gameId);
+  const state = serverGame.createParserState?.() ?? null;
+  const packets: TelemetryPacket[] = [];
+  let off = metaFrameStart(raw);
+  while (off + 4 <= raw.length) {
+    const frameLen = raw.readUInt32LE(off);
+    off += 4;
+    if (frameLen === META_FRAME_MAGIC) {
+      off += 4 + raw.readUInt32LE(off);
+      continue;
+    }
+    if (off + frameLen > raw.length) break;
+    const pkt = serverGame.tryParse(raw.subarray(off, off + frameLen), state);
+    off += frameLen;
+    if (pkt) packets.push(pkt);
+  }
+  return packets;
+}
+
+/** Replays a raw-UDP-dump .bin.gz (FM/F1, no meta frame) through the game's real tryParse. */
+function parseRawUdpDump(path: string, gameId: GameId): TelemetryPacket[] {
+  const serverGame = getServerGame(gameId);
+  const state = serverGame.createParserState?.() ?? null;
+  const packets: TelemetryPacket[] = [];
+  for (const buf of readUdpDump(path)) {
+    const pkt = serverGame.tryParse(buf, state);
+    if (pkt) packets.push(pkt);
+  }
+  return packets;
+}
+
+describe("bin-fixture-detection — every test/artifacts/sessions/*.bin.gz resolves game/track/car", () => {
+  test("acc-2026-04-23T16-42-16-158Z.bin.gz — session-capture, ACC — CORROBORATED (test/acc-parser.test.ts)", () => {
+    const file = `${DIR}/acc-2026-04-23T16-42-16-158Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("acc");
+    expect(hasMetaFrame(gunzip(file))).toBe(true);
+
+    const packets = parseSessionCapture(file, "acc");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAccTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAccCarName(last.CarOrdinal)).toBe("McLaren 720S GT3 Evo 2023");
+  });
+
+  test("f1-2025-2026-04-22T11-42-43-029Z.bin.gz — session-capture, F1 2025 — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/f1-2025-2026-04-22T11-42-43-029Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("f1-2025");
+    expect(hasMetaFrame(gunzip(file))).toBe(true);
+
+    const packets = parseSessionCapture(file, "f1-2025");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    const adapter = getGame("f1-2025");
+    expect(adapter.getTrackName(last.TrackOrdinal)).toBe("Autodromo Hermanos Rodriguez");
+    expect(adapter.getCarName(last.CarOrdinal)).toBe("F1 World");
+  });
+
+  test("session-ac-evo-menu-exit-2026-04-23T18-11-48-959Z.bin.gz — session-capture, AC Evo — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/session-ac-evo-menu-exit-2026-04-23T18-11-48-959Z.bin.gz`;
+    // Detected from frame content, not the filename — this fixture doesn't
+    // follow the "<gameId>-" naming convention ("session-ac-evo-" prefix),
+    // which would previously have made real import reject it outright.
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("ac-evo");
+    expect(hasMetaFrame(gunzip(file))).toBe(true);
+
+    const packets = parseSessionCapture(file, "ac-evo");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAcEvoTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAcEvoCarName(last.CarOrdinal)).toBe("Porsche 992 GT3 R Rennsport");
+  }, { timeout: 30000 });
+
+  test("session-ac-evo-mid-2026-04-21T20-24-34-810Z.bin.gz — session-capture, AC Evo — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/session-ac-evo-mid-2026-04-21T20-24-34-810Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("ac-evo");
+    expect(hasMetaFrame(gunzip(file))).toBe(true);
+
+    const packets = parseSessionCapture(file, "ac-evo");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAcEvoTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAcEvoCarName(last.CarOrdinal)).toBe("Porsche 992 GT3 R Rennsport");
+  }, { timeout: 30000 });
+
+  test("f1-2025-2026-04-09T21-34-10-190Z.bin.gz — raw UDP dump, F1 2025 — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/f1-2025-2026-04-09T21-34-10-190Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("f1-2025");
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const packets = parseRawUdpDump(file, "f1-2025");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    const adapter = getGame("f1-2025");
+    expect(adapter.getTrackName(last.TrackOrdinal)).toBe("Lusail International Circuit");
+    expect(adapter.getCarName(last.CarOrdinal)).toBe("F1 World");
+  }, { timeout: 60000 });
+
+  test("fm-2023-2026-04-09T21-53-00-102Z.bin.gz — raw UDP dump, FM 2023 — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/fm-2023-2026-04-09T21-53-00-102Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("fm-2023");
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const packets = parseRawUdpDump(file, "fm-2023");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    const adapter = getGame("fm-2023");
+    expect(adapter.getTrackName(last.TrackOrdinal)).toBe("Road America - East Route");
+    expect(adapter.getCarName(last.CarOrdinal)).toBe("2022 Aston Martin Valkyrie AMR Pro");
+  });
+
+  test("fm-2023-2026-04-09T21-55-03-186Z.bin.gz — raw UDP dump, FM 2023 — REGRESSION-BASELINE ONLY (same car/track as 21-53-00 fixture, cross-consistent)", () => {
+    const file = `${DIR}/fm-2023-2026-04-09T21-55-03-186Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBe("fm-2023");
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const packets = parseRawUdpDump(file, "fm-2023");
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    const adapter = getGame("fm-2023");
+    expect(adapter.getTrackName(last.TrackOrdinal)).toBe("Road America - East Route");
+    expect(adapter.getCarName(last.CarOrdinal)).toBe("2022 Aston Martin Valkyrie AMR Pro");
+  });
+
+  test("ac-evo-2026-04-15T17-12-25-825Z.bin.gz — dump-mode, AC Evo — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/ac-evo-2026-04-15T17-12-25-825Z.bin.gz`;
+    // Dump-mode frames aren't packed triplets, so frame-content detection
+    // correctly finds no match — this format is dev-only and never goes
+    // through the real "Import .bin" path (importSessionBin/canHandle).
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBeNull();
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const { packets } = readAcEvoPackets(file);
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAcEvoTrackName(last.TrackOrdinal)).toBe("Monza - GP");
+    expect(getAcEvoCarName(last.CarOrdinal)).toBe("Porsche 992 GT3 R Rennsport");
+  }, { timeout: 60000 });
+
+  test("acc-2026-04-10T02-55-22-777Z.bin.gz — dump-mode, ACC — REGRESSION-BASELINE ONLY", () => {
+    const file = `${DIR}/acc-2026-04-10T02-55-22-777Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBeNull();
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const { packets } = readAccPackets(file);
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAccTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAccCarName(last.CarOrdinal)).toBe("McLaren 720S GT3 Evo 2023");
+  });
+
+  test("acc-2026-04-10T02-59-28-972Z.bin.gz — dump-mode, ACC — CORROBORATED (test/e2e/acc/acc-2026-04-10T02-59-28-972Z.test.ts sector timing)", () => {
+    const file = `${DIR}/acc-2026-04-10T02-59-28-972Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBeNull();
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const { packets } = readAccPackets(file);
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAccTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAccCarName(last.CarOrdinal)).toBe("McLaren 720S GT3 Evo 2023");
+  }, { timeout: 30000 });
+
+  test("acc-2026-04-12T21-16-07-841Z.bin.gz — dump-mode, ACC — REGRESSION-BASELINE ONLY (existing e2e test covers lap detection, not sectors)", () => {
+    const file = `${DIR}/acc-2026-04-12T21-16-07-841Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBeNull();
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const { packets } = readAccPackets(file);
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAccTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAccCarName(last.CarOrdinal)).toBe("McLaren 720S GT3 Evo 2023");
+  }, { timeout: 30000 });
+
+  test("acc-2026-04-12T21-44-38-899Z.bin.gz — dump-mode, ACC — CORROBORATED (test/e2e/acc/acc-2026-04-12T21-44-38-899Z.test.ts sector timing)", () => {
+    const file = `${DIR}/acc-2026-04-12T21-44-38-899Z.bin.gz`;
+    expect(detectGameIdFromBuffer(readFileSync(file))).toBeNull();
+    expect(hasMetaFrame(gunzip(file))).toBe(false);
+
+    const { packets } = readAccPackets(file);
+    expect(packets.length).toBeGreaterThan(0);
+    const last = packets[packets.length - 1]!;
+    expect(getAccTrackName(last.TrackOrdinal)).toBe("Brands Hatch - GP");
+    expect(getAccCarName(last.CarOrdinal)).toBe("McLaren 720S GT3 Evo 2023");
+  }, { timeout: 30000 });
+
+  // Dump-mode ACCTEST v2 header, but the frame stream is corrupt: readAccFrames
+  // scans past two zero-length placeholder physics frames straight into
+  // non-frame garbage (frame type byte 176) a handful of bytes later, aborts
+  // its frameCount scan, and never emits a single physics+graphics+static
+  // triplet. No other test in the suite references this fixture either —
+  // it appears to be an incomplete/corrupted capture, not a fixture worth
+  // asserting a fake baseline against.
+  test.skip("acc-2026-04-10T02-28-56-651Z.bin.gz — SKIPPED: dump-mode ACCTEST v2 frame stream is corrupt, readAccFrames yields 0 triplets", () => {});
+});


### PR DESCRIPTION
## Summary
Real root cause of the "importing this ACC .bin still shows Monza" report on `test/artifacts/sessions/acc-2026-04-23T16-42-16-158Z.bin.gz`.

- `tryParse` (`server/games/acc/index.ts`) trusted the packed frame header's `carOrdinal`/`trackOrdinal` verbatim. That header is just what `ParsingProcessor` had resolved *at capture time* — recordings made before static-data resolution existed (or that raced it) baked in `0` for both, which collides with Monza's and car #0's real ids.
- The embedded static struct on every frame has always carried the correct track/car name string (`brands_hatch` / `mclaren_720s_gt3_evo` for this fixture) — it just wasn't being consulted on parse.
- `tryParse` now re-derives ordinals from the static struct on every parse, falling back to the packed header only when the struct doesn't resolve. This repairs already-broken recordings on import/reprocess, unlike the earlier `-1` sentinel fix (#90) which only prevents the bug in *new* live captures.
- Corrected the regression test I added in #90 — it had asserted this exact fixture resolves to Monza/Porsche, which was the bug, not the ground truth.

## Test plan
- [x] `bun run test` — 329 pass
- [x] `bun run build` (client) passes