### PR TITLE
fix(diagnostics): capture AI chat errors and client errors in export

### DIFF
--- a/client/src/lib/chat-stream.ts
+++ b/client/src/lib/chat-stream.ts
@@ -55,6 +55,7 @@ export async function readChatStream(res: Response, onEvent: (event: ChatStreamE
       } catch {
         // Skip malformed lines — protocol is best-effort; keep the reader
         // alive so later well-formed events still arrive.
+        console.warn("[ChatStream] malformed NDJSON line", line.slice(0, 200));
       }
       idx = buf.indexOf("\n");
     }
@@ -65,7 +66,7 @@ export async function readChatStream(res: Response, onEvent: (event: ChatStreamE
     try {
       onEvent(JSON.parse(tail) as ChatStreamEvent);
     } catch {
-      /* ignore */
+      console.warn("[ChatStream] malformed NDJSON tail", tail.slice(0, 200));
     }
   }
 }

--- a/client/src/lib/crash-diagnostics.ts
+++ b/client/src/lib/crash-diagnostics.ts
@@ -3,13 +3,16 @@
  * load can surface what happened before an "Aw Snap" crash.
  *
  * Captures:
- * - Unhandled errors and promise rejections via window events.
+ * - Unhandled errors and promise rejections via window events. These are also
+ *   forwarded to the server log so they appear in the diagnostics export.
  * - Periodic heap-pressure samples (Chrome-only performance.memory). If
  *   the JS heap climbs past 85% of its limit we log a warning AND write
  *   the last heap sample to localStorage — so if the tab dies moments
  *   later, the next load has a "this is what the heap looked like before
  *   you died" record to compare against.
  */
+
+import { installClientErrorReporting, reportClientError } from "./report-error";
 
 const LAST_ERROR_KEY = "raceiq.crash.last_error";
 const LAST_REJECTION_KEY = "raceiq.crash.last_rejection";
@@ -100,7 +103,7 @@ function reportPreviousCrash(): void {
 
 function installGlobalErrorHandlers(): void {
   window.addEventListener("error", (ev) => {
-    persist(LAST_ERROR_KEY, {
+    const record = {
       message: ev.message,
       filename: ev.filename,
       lineno: ev.lineno,
@@ -108,17 +111,21 @@ function installGlobalErrorHandlers(): void {
       stack: ev.error?.stack ?? null,
       ts: Date.now(),
       url: location.href,
-    });
+    };
+    persist(LAST_ERROR_KEY, record);
+    reportClientError("window.onerror", ev.message || "Uncaught error", record);
   });
 
   window.addEventListener("unhandledrejection", (ev) => {
     const reason = ev.reason as { message?: string; stack?: string } | string | undefined;
-    persist(LAST_REJECTION_KEY, {
+    const record = {
       reason: typeof reason === "string" ? reason : (reason?.message ?? String(reason)),
       stack: typeof reason === "object" && reason ? (reason.stack ?? null) : null,
       ts: Date.now(),
       url: location.href,
-    });
+    };
+    persist(LAST_REJECTION_KEY, record);
+    reportClientError("unhandledrejection", record.reason, record);
   });
 }
 
@@ -145,9 +152,7 @@ function startHeapMonitor(): void {
     if (ratio > WARN_RATIO && !warned) {
       warned = true;
       console.warn(
-        `[RaceIQ] JS heap pressure: ${(ratio * 100).toFixed(1)}% ` +
-          `(${(usedJSHeapSize / 1048576).toFixed(0)} MB / ${(jsHeapSizeLimit / 1048576).toFixed(0)} MB). ` +
-          `An OOM crash (Aw Snap, error 5) may be imminent.`,
+        `[RaceIQ] JS heap pressure: ${(ratio * 100).toFixed(1)}% (${(usedJSHeapSize / 1048576).toFixed(0)} MB / ${(jsHeapSizeLimit / 1048576).toFixed(0)} MB). An OOM crash (Aw Snap, error 5) may be imminent.`,
       );
     } else if (ratio < WARN_RATIO * 0.9) {
       warned = false; // re-arm if heap recovers
@@ -156,6 +161,9 @@ function startHeapMonitor(): void {
 }
 
 export function installCrashDiagnostics(): void {
+  // Patch the console first so the previous session's breadcrumbs below are
+  // themselves forwarded to the server log.
+  installClientErrorReporting();
   reportPreviousCrash();
   installGlobalErrorHandlers();
   startHeapMonitor();

--- a/client/src/lib/report-error.ts
+++ b/client/src/lib/report-error.ts
@@ -1,0 +1,100 @@
+/**
+ * Ship browser-side errors to the server log file.
+ *
+ * The server's file logger only captures the Node/Bun console, so anything that
+ * fails in the browser would otherwise live only in the user's devtools console
+ * — invisible to us when they send a diagnostics export. Everything reported
+ * here lands in `raceiq.log`, which the export zips as `logs.txt`.
+ *
+ * This is deliberately generic: one global install captures uncaught errors,
+ * unhandled promise rejections, and every `console.error` / `console.warn` the
+ * app makes, so no per-feature wiring is needed.
+ *
+ * Best-effort throughout: reporting must never throw or block the UI.
+ */
+import { client } from "./rpc";
+
+/** Stop a render loop that errors every frame from flooding the log. */
+const MAX_REPORTS_PER_SESSION = 200;
+const DUPLICATE_WINDOW_MS = 10_000;
+let reportCount = 0;
+const recent = new Map<string, number>();
+
+export function reportClientError(scope: string, message: string, detail?: unknown, level: "warn" | "error" = "error"): void {
+  try {
+    if (reportCount >= MAX_REPORTS_PER_SESSION) return;
+
+    // Drop repeats of the same message inside a short window.
+    const key = `${scope}:${message}`;
+    const now = Date.now();
+    const last = recent.get(key);
+    if (last !== undefined && now - last < DUPLICATE_WINDOW_MS) return;
+    recent.set(key, now);
+    reportCount += 1;
+
+    void client.api["client-log"]
+      .$post({
+        json: {
+          level,
+          scope: scope.slice(0, 64),
+          message: message.slice(0, 4000),
+          detail: safeDetail(detail),
+        },
+      })
+      .catch(() => {});
+  } catch {
+    /* logging must never break the UI */
+  }
+}
+
+/**
+ * Patch `console.error`/`console.warn` to also ship to the server log. Call
+ * once at app startup.
+ *
+ * Patching the console (rather than only listening for uncaught errors) is what
+ * makes this generic: errors the app already catches and handles never reach
+ * `window.onerror`, but they almost always get consoled. Uncaught errors and
+ * rejections are forwarded separately by `crash-diagnostics.ts`.
+ */
+export function installClientErrorReporting(): void {
+  if (typeof window === "undefined") return;
+
+  const origError = console.error.bind(console);
+  const origWarn = console.warn.bind(console);
+  console.error = (...args: unknown[]) => {
+    origError(...args);
+    reportClientError("console", formatArgs(args), undefined, "error");
+  };
+  console.warn = (...args: unknown[]) => {
+    origWarn(...args);
+    reportClientError("console", formatArgs(args), undefined, "warn");
+  };
+}
+
+function formatArgs(args: unknown[]): string {
+  return args
+    .map((a) => {
+      if (typeof a === "string") return a;
+      if (a instanceof Error) return a.stack ?? a.message;
+      try {
+        return JSON.stringify(a);
+      } catch {
+        return String(a);
+      }
+    })
+    .join(" ");
+}
+
+/** Errors don't survive JSON.stringify; flatten to something loggable. */
+function safeDetail(detail: unknown): unknown {
+  if (detail === undefined) return undefined;
+  if (detail instanceof Error) {
+    return { name: detail.name, message: detail.message, stack: detail.stack };
+  }
+  try {
+    JSON.stringify(detail);
+    return detail;
+  } catch {
+    return String(detail);
+  }
+}

--- a/client/src/lib/report-error.ts
+++ b/client/src/lib/report-error.ts
@@ -14,24 +14,12 @@
  */
 import { client } from "./rpc";
 
-/** Stop a render loop that errors every frame from flooding the log. */
-const MAX_REPORTS_PER_SESSION = 200;
-const DUPLICATE_WINDOW_MS = 10_000;
-let reportCount = 0;
-const recent = new Map<string, number>();
-
+/**
+ * Report every error, unthrottled — nothing is dropped or de-duplicated, so
+ * the log reflects exactly what the client saw, including repeat counts.
+ */
 export function reportClientError(scope: string, message: string, detail?: unknown, level: "warn" | "error" = "error"): void {
   try {
-    if (reportCount >= MAX_REPORTS_PER_SESSION) return;
-
-    // Drop repeats of the same message inside a short window.
-    const key = `${scope}:${message}`;
-    const now = Date.now();
-    const last = recent.get(key);
-    if (last !== undefined && now - last < DUPLICATE_WINDOW_MS) return;
-    recent.set(key, now);
-    reportCount += 1;
-
     void client.api["client-log"]
       .$post({
         json: {

--- a/server/ai/chat-stream.ts
+++ b/server/ai/chat-stream.ts
@@ -22,8 +22,10 @@
  */
 import type { Agent } from "@mastra/core/agent";
 
+import { log } from "../logger";
 import { estimateTokenCostUsd } from "./chat-pricing";
 import { toClientAiError } from "./provider-error";
+import type { ClientAiError } from "./provider-error";
 
 type AgentStream = Awaited<ReturnType<Agent["stream"]>>;
 type AgentStreamPart = AgentStream["fullStream"] extends AsyncIterable<infer Part> ? Part : never;
@@ -48,6 +50,31 @@ type ChatStreamContext = {
   provider: string | null;
   modelId: string | null;
 };
+
+/**
+ * Chat failures are delivered to the browser as `{type:"error"}` stream events
+ * and never bubble to Hono's error middleware, so they have to be logged here
+ * or they never reach `raceiq.log` / the diagnostics export.
+ */
+function logStreamError(
+  where: string,
+  aiError: ClientAiError,
+  context: { provider: string | null; modelId: string | null; attempt: number; willRetry: boolean },
+) {
+  const upstream = aiError.upstream
+    ? ` upstream=${JSON.stringify(aiError.upstream)}`
+    : "";
+  log.error(
+    `[Chat] ${where}: ${aiError.message}`
+    + ` provider=${aiError.provider ?? context.provider ?? "unknown"}`
+    + ` model=${aiError.modelId ?? context.modelId ?? "unknown"}`
+    + ` status=${aiError.statusCode ?? "none"}`
+    + ` retryable=${aiError.retryable}`
+    + ` attempt=${context.attempt}`
+    + ` willRetry=${context.willRetry}`
+    + upstream,
+  );
+}
 export function chatStreamResponse(
   streamSource: Promise<AgentStream> | AgentStream | StreamFactory,
   context?: ChatStreamContext,
@@ -144,6 +171,12 @@ export function chatStreamResponse(
                 }
                 case "error": {
                   const aiError = toClientAiError(p.error);
+                  logStreamError("stream error event", aiError, {
+                    provider,
+                    modelId,
+                    attempt,
+                    willRetry: false,
+                  });
                   writeEvent(controller, { type: "error", ...aiError });
                   break;
                 }
@@ -156,6 +189,12 @@ export function chatStreamResponse(
           } catch (err: unknown) {
             const aiError = toClientAiError(err);
             const shouldRetry = aiError.retryable && attempt < maxAttempts;
+            logStreamError("stream failed", aiError, {
+              provider,
+              modelId,
+              attempt,
+              willRetry: shouldRetry,
+            });
             if (shouldRetry) continue;
             writeEvent(controller, { type: "error", ...aiError });
             try {

--- a/server/routes/misc-routes.ts
+++ b/server/routes/misc-routes.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
 import { existsSync, readdirSync, mkdirSync, readFileSync, writeFileSync, rmSync, statSync } from "fs";
 import { readdir, stat, statfs } from "fs/promises";
 import { resolve, join } from "path";
@@ -15,8 +17,16 @@ import { getRunningGame } from "../games/registry";
 import { getCurrentDetectedGame } from "../parsers";
 import { loadSettings } from "../settings";
 import { client as dbClient } from "../db";
-import { getChatMemory } from "../ai/chat-agent";
+import { getChatMemory, CHAT_RESOURCE_ID } from "../ai/chat-agent";
+import { log } from "../logger";
 import pkg from "../../package.json";
+
+const ClientLogSchema = z.object({
+  level: z.enum(["warn", "error"]).default("error"),
+  scope: z.string().max(64),
+  message: z.string().max(4000),
+  detail: z.unknown().optional(),
+});
 
 import {
   findForzaInstall,
@@ -430,8 +440,36 @@ export const miscRoutes = new Hono()
     return c.json({ deleted: true });
   })
 
+  /**
+   * POST /api/client-log — sink for browser-side errors.
+   *
+   * The file logger only captures the server console, so anything thrown in the
+   * React AI panels stays in devtools and never reaches the diagnostics export.
+   * The client posts here so user-reported chat failures are in `logs.txt`.
+   */
+  .post("/api/client-log", zValidator("json", ClientLogSchema), async (c) => {
+    const { level, scope, message, detail } = c.req.valid("json");
+    const suffix = detail ? ` ${JSON.stringify(detail).slice(0, 2000)}` : "";
+    const line = `[Client/${scope}] ${message}${suffix}`;
+    if (level === "warn") log.warn(line);
+    else log.error(line);
+    return c.json({ ok: true });
+  })
+
   // GET /api/diagnostics — download a zip with diagnostics.json + logs.txt
   .get("/api/diagnostics", async (c) => {
+    /** Mastra stores content as a string or { content, parts: [{ text }] }. */
+    const extractMessageText = (raw: unknown): string => {
+      if (typeof raw === "string") return raw;
+      if (raw && typeof raw === "object") {
+        const o = raw as { content?: unknown; parts?: Array<{ text?: unknown }> };
+        if (typeof o.content === "string") return o.content;
+        if (Array.isArray(o.parts)) {
+          return o.parts.map((p) => (typeof p.text === "string" ? p.text : "")).join("");
+        }
+      }
+      return "";
+    };
     const logFile = join(USER_DATA_DIR, "raceiq.log");
     let logs = "";
     try {
@@ -464,31 +502,37 @@ export const miscRoutes = new Hono()
     const memUsage = process.memoryUsage();
     const serverMemoryMB = Math.round(memUsage.heapUsed / 1024 / 1024);
 
-    // Fetch recent chat messages from Mastra memory
-    let chatMessages: Array<{ role: string; content: string; timestamp?: string }> = [];
+    // Fetch recent chat messages from Mastra memory (newest threads first)
+    const chatMessages: Array<{ threadId: string; role: string; content: string; timestamp?: string }> = [];
+    let chatError: string | null = null;
     try {
-      // Note: Mastra Memory API varies by version. Attempt to fetch threads if available.
       const memory = getChatMemory();
-      if (memory && typeof (memory as any).getThreads === "function") {
-        const threads = await (memory as any).getThreads();
-        if (threads && threads.length > 0) {
-          for (const thread of threads.slice(0, 5)) {
-            if (typeof (memory as any).getMessages === "function") {
-              const messages = await (memory as any).getMessages(thread.id);
-              if (messages) {
-                chatMessages.push(
-                  ...messages.map((m: any) => ({
-                    role: m.role || "unknown",
-                    content: m.content || "",
-                    timestamp: m.createdAt || m.timestamp,
-                  }))
-                );
-              }
-            }
-          }
+      const { threads } = await memory.listThreads({
+        filter: { resourceId: CHAT_RESOURCE_ID },
+        perPage: false,
+      });
+      const toIso = (v: unknown) =>
+        v instanceof Date ? v.toISOString() : v ? String(v) : "";
+      const recent = [...threads]
+        .sort((a, b) => toIso(b.updatedAt).localeCompare(toIso(a.updatedAt)))
+        .slice(0, 5);
+      for (const thread of recent) {
+        const result = await memory.recall({ threadId: thread.id });
+        for (const m of result.messages ?? []) {
+          if (m.role !== "user" && m.role !== "assistant") continue;
+          chatMessages.push({
+            threadId: thread.id,
+            role: m.role,
+            content: extractMessageText(m.content),
+            timestamp: toIso(m.createdAt),
+          });
         }
       }
-    } catch {}
+      chatMessages.sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""));
+    } catch (err: any) {
+      chatError = err?.message ?? String(err);
+      console.error("[Diagnostics] Failed to read chat memory:", chatError);
+    }
 
     // Database size and stats
     let dbSizeMB: number | null = null;
@@ -675,7 +719,12 @@ export const miscRoutes = new Hono()
       },
       chat: {
         messageCount: chatMessages.length,
-        recentMessages: chatMessages.slice(0, 20),
+        error: chatError,
+        // Cap per-message length so a long analysis answer can't bloat the zip.
+        recentMessages: chatMessages.slice(0, 20).map((m) => ({
+          ...m,
+          content: m.content.length > 4000 ? `${m.content.slice(0, 4000)}… [truncated]` : m.content,
+        })),
       },
       generatedAt: new Date().toISOString(),
     };

--- a/server/routes/misc-routes.ts
+++ b/server/routes/misc-routes.ts
@@ -458,18 +458,6 @@ export const miscRoutes = new Hono()
 
   // GET /api/diagnostics — download a zip with diagnostics.json + logs.txt
   .get("/api/diagnostics", async (c) => {
-    /** Mastra stores content as a string or { content, parts: [{ text }] }. */
-    const extractMessageText = (raw: unknown): string => {
-      if (typeof raw === "string") return raw;
-      if (raw && typeof raw === "object") {
-        const o = raw as { content?: unknown; parts?: Array<{ text?: unknown }> };
-        if (typeof o.content === "string") return o.content;
-        if (Array.isArray(o.parts)) {
-          return o.parts.map((p) => (typeof p.text === "string" ? p.text : "")).join("");
-        }
-      }
-      return "";
-    };
     const logFile = join(USER_DATA_DIR, "raceiq.log");
     let logs = "";
     try {
@@ -502,8 +490,13 @@ export const miscRoutes = new Hono()
     const memUsage = process.memoryUsage();
     const serverMemoryMB = Math.round(memUsage.heapUsed / 1024 / 1024);
 
-    // Fetch recent chat messages from Mastra memory (newest threads first)
-    const chatMessages: Array<{ threadId: string; role: string; content: string; timestamp?: string }> = [];
+    // Chat metadata from Mastra memory (newest threads first). Message *text*
+    // is deliberately excluded — a diagnostics zip gets attached to bug reports
+    // and shared around, and the conversation itself is the user's, not ours.
+    // Counts + thread ids answer "was chat used, how much, on which laps",
+    // which is what support actually needs; failures are in `logs.txt`.
+    const chatThreads: Array<{ threadId: string; messages: number; updatedAt: string }> = [];
+    let chatMessageCount = 0;
     let chatError: string | null = null;
     try {
       const memory = getChatMemory();
@@ -518,17 +511,16 @@ export const miscRoutes = new Hono()
         .slice(0, 5);
       for (const thread of recent) {
         const result = await memory.recall({ threadId: thread.id });
-        for (const m of result.messages ?? []) {
-          if (m.role !== "user" && m.role !== "assistant") continue;
-          chatMessages.push({
-            threadId: thread.id,
-            role: m.role,
-            content: extractMessageText(m.content),
-            timestamp: toIso(m.createdAt),
-          });
-        }
+        const count = (result.messages ?? []).filter(
+          (m) => m.role === "user" || m.role === "assistant",
+        ).length;
+        chatMessageCount += count;
+        chatThreads.push({
+          threadId: thread.id,
+          messages: count,
+          updatedAt: toIso(thread.updatedAt),
+        });
       }
-      chatMessages.sort((a, b) => (b.timestamp ?? "").localeCompare(a.timestamp ?? ""));
     } catch (err: any) {
       chatError = err?.message ?? String(err);
       console.error("[Diagnostics] Failed to read chat memory:", chatError);
@@ -718,13 +710,9 @@ export const miscRoutes = new Hono()
         },
       },
       chat: {
-        messageCount: chatMessages.length,
+        messageCount: chatMessageCount,
         error: chatError,
-        // Cap per-message length so a long analysis answer can't bloat the zip.
-        recentMessages: chatMessages.slice(0, 20).map((m) => ({
-          ...m,
-          content: m.content.length > 4000 ? `${m.content.slice(0, 4000)}… [truncated]` : m.content,
-        })),
+        threads: chatThreads,
       },
       generatedAt: new Date().toISOString(),
     };


### PR DESCRIPTION
## Problem

Diagnostic exports contained **no AI chat errors** — when a user reported "the AI chat failed", the zip had nothing to go on.

## Root causes

Three independent gaps, all silent:

1. **Chat failures never reached the log.** `chatStreamResponse` delivers errors as `{type:"error"}` NDJSON events and never throws, so they bypassed Hono's `errorLogger` middleware and the file logger entirely. Rate limits, bad API keys and model errors — the exact failures users report — existed only in the browser.
2. **The diagnostics chat block never worked.** It duck-typed `memory.getThreads()` / `memory.getMessages()`, which Mastra Memory does not implement. The `typeof === "function"` check silently fell through to an empty array, so every export reported `messageCount: 0`, and the surrounding `catch {}` hid it.
3. **Browser errors only hit devtools.** The file logger patches the *server* console; nothing in the browser was captured.

## Changes

Two paths into `raceiq.log`, split by where the error happens:

- **AI chat errors → logged server-side, directly.** `server/ai/chat-stream.ts` logs both the in-stream error event and the outer retry/catch, with provider, model, status code, retryability and upstream error body. No client round-trip, so it works even if the tab dies.
- **Everything client-side → shipped to the server.** `POST /api/client-log` + `client/src/lib/report-error.ts`. Deliberately **generic, not AI-specific**: it patches `console.error`/`console.warn` and forwards from the existing `crash-diagnostics` window handlers, capturing everything the app reports. Unthrottled — no session cap, no dedupe.

And the diagnostics chat block (`server/routes/misc-routes.ts`) is rebuilt on the real `listThreads()` / `recall()` API, but reports **metadata only** — `messageCount`, thread ids, `updatedAt`. Message text is deliberately excluded: the zip gets attached to bug reports and passed around, and the conversation is the user's. Counts answer "was chat used, how much, on which laps"; the failures themselves are in `logs.txt`. A memory read failure now surfaces via `chat.error` instead of being swallowed.

```json
"chat": {
  "messageCount": 4,
  "error": null,
  "threads": [{ "threadId": "lap-90", "messages": 4, "updatedAt": "2026-07-14T20:00:08.009Z" }]
}
```

The pre-existing `useTemplate` lint violations in `crash-diagnostics.ts` are fixed only because the pre-commit hook lints the whole staged file; the collapsed template produces an identical string.

## Verification

- `bun run test` — 341 pass, 0 fail (matches baseline).
- Client build (`tsc -b && vite build`) and Biome clean.
- Ran the server against a **copy** of a real data dir (WAL included): the chat block reports thread `lap-90` with 4 messages and `error: null` (previously `messageCount: 0`), and none of that thread's message text appears anywhere in the zip.
- `POST /api/client-log` returns 200 and writes to `raceiq.log`; a malformed payload returns 400:
  ```
  [ERROR] [Client/console] [AiPanel] chat blew up: 429 rate limit {"provider":"gemini","statusCode":429}
  [WARN] [Client/window.onerror] Uncaught TypeError: x is not a function
  ```
- `reportClientError` unit-checked against a stubbed RPC client: 100 repeats produce 100 reports (nothing dropped), `Error` details are flattened rather than lost to `JSON.stringify`, and a circular `detail` doesn't throw.

Not verified: the console patch driven from a real browser session (checked via the endpoint directly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)