### PR TITLE
ci: run build-test on a 4 vCPU runner

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   build-test:
-    runs-on: blacksmith-2vcpu-ubuntu-2204
+    # 4 vCPU: the ACC fixture replays peak ~4GB heap and GC-thrash on 2 vCPU, timing out.
+    runs-on: blacksmith-4vcpu-ubuntu-2204
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

`Build & Test` on main fails with two CI-only timeouts:

```
(fail) bin-fixture-detection ... acc-2026-04-10T02-59-28-972Z.bin.gz  [118754.20ms]
  ^ this test timed out after 30000ms.
(fail) acc-2026-04-12T21-16-07-841Z.bin.gz > detects laps correctly with no duplicates  [164494.36ms]
  ^ this test timed out after 120000ms.
```

Both pass locally in ~823ms. The gap is memory, not CPU speed:

- `test/artifacts/sessions/` holds ~120MB of `.bin.gz`; `acc-2026-04-12T21-16-07-841Z.bin.gz` alone decompresses to 122MB.
- Single file, alone: 1.27GB peak RSS. Full suite in one bun heap: **3.97GB peak RSS** — every fixture's packet array accumulates because `bun test` runs all 55 files in one process.
- On `blacksmith-2vcpu-ubuntu-2204` that heap GC-thrashes and the per-test timeouts blow.

## Change

`build-test` runs on `blacksmith-4vcpu-ubuntu-2204`. Raising the timeouts again would only move the wall — `acc-2026-04-12T21-16-07-841Z.test.ts` already carries a `120_000` timeout and a "slow on CI" comment from the last time this was band-aided.

## Follow-ups (not in this PR)

- `bin-fixture-detection.test.ts` builds a full `TelemetryPacket[]` per fixture but only asserts game/track/car — it could stream and assert on the first resolved packet instead of retaining ~1GB.
- Running `test/e2e/**` as a separate `bun test` invocation would reset the heap between fixture groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)