### PR TITLE
fix(ac-evo): calibrate suspension rest from session idle height

### DIFF
--- a/server/games/ac-evo/parser.ts
+++ b/server/games/ac-evo/parser.ts
@@ -49,6 +49,28 @@ const DIST_LAP_RESET_M = 50; // current_km drop beyond this (m) ⇒ new lap
 const DIST_CALIB_MIN_M = 5; // require ≥5 m true travel before trusting a k sample
 const DIST_PACKETID_MAX_JUMP = 10000; // ΔpacketId above this ⇒ discontinuity, skip
 
+// --- Suspension rest calibration (calibrateSuspRest) ---
+// PHYSICS.suspTravel* is signed, but its zero point is an arbitrary per-car /
+// per-setup reference, NOT the static ride height. Measured idle values across
+// recordings: the Porsche 992 GT3 R Rennsport sits at ~-36 mm front / ~-17 mm
+// rear in one session and ~-11 mm front / ~+2 mm rear in another. Encoding the
+// bar as a fixed `0.5 + travel/0.1` therefore parked a *stationary* car
+// anywhere between "fully extended" (blue) and "bottoming out" (red).
+// So learn the rest position from the car's own idle height at the start of the
+// session, the same way DistanceTraveled self-calibrates its clock. State lives
+// in the parser cache and is derived only from raw buffers in frame order, so a
+// replay that warms up from the top of the session file (parseRawLapFrames)
+// reproduces the identical baseline live gave us.
+const SUSP_IDLE_SPEED_MPS = 0.3; // below this the car counts as stationary
+const SUSP_IDLE_FRAMES = 30; // ~0.3 s stationary (≈100Hz) before we trust idle
+const SUSP_MOVING_FRAMES = 600; // ~6 s of driving ⇒ fallback baseline (never idled)
+// ±25 mm around rest spans the full 0–1 bar. Measured over a full AC Evo
+// session (test/artifacts/sessions/ac-evo-unknown-track-session17), deflection
+// from rest while driving covers -16 mm to +22 mm including kerb strikes, so
+// this uses ~30-95% of the bar without clipping. The old ±50 mm equivalent left
+// the bar visually inert.
+const SUSP_RANGE_M = 0.025;
+
 export interface AcEvoParserCache {
   carOrdinal: number;
   trackOrdinal: number;
@@ -72,6 +94,13 @@ export interface AcEvoParserCache {
   _distCalibTrueM: number; // Σ true metres (current_km deltas) over that window
   _distK: number; // seconds per physics step (calibrated); 0 = uncalibrated
   _distOut: number; // last emitted DistanceTraveled (m), monotonic clamp
+
+  // Suspension rest calibration state (see calibrateSuspRest).
+  _suspRest: Float32Array; // learned rest travel (m) per corner [FL,FR,RL,RR]
+  _suspRestFinal: boolean; // true once an idle baseline is locked in
+  _suspAccSum: Float64Array; // Σ travel per corner over the current window
+  _suspAccN: number; // frames in the current window
+  _suspAccIdle: boolean; // is the current window an idle window?
 }
 
 export function createAcEvoParserCache(): AcEvoParserCache {
@@ -97,7 +126,78 @@ export function createAcEvoParserCache(): AcEvoParserCache {
     _distCalibTrueM: 0,
     _distK: 0,
     _distOut: 0,
+    _suspRest: new Float32Array(4),
+    _suspRestFinal: false,
+    _suspAccSum: new Float64Array(4),
+    _suspAccN: 0,
+    _suspAccIdle: false,
   };
+}
+
+/**
+ * Learn each corner's rest (static ride height) suspension travel so the UI can
+ * show deflection *relative to how this car actually sits*, instead of assuming
+ * the channel is zero-centred. See the SUSP_* constants above for why.
+ *
+ * Strategy, cheapest trustworthy signal first:
+ *  - Stationary (< SUSP_IDLE_SPEED_MPS) for SUSP_IDLE_FRAMES ⇒ that mean is the
+ *    rest height. Locked as final the moment the car pulls away, so mid-lap
+ *    kerb strikes and pit-stop jacks can never move the baseline afterwards.
+ *  - Never stationary (session joined mid-lap, replay starting on a flying lap)
+ *    ⇒ after SUSP_MOVING_FRAMES fall back to the running mean while moving,
+ *    which averages compression and extension out to roughly ride height. This
+ *    stays refinable, so a later return to the pits upgrades it to a real idle
+ *    baseline.
+ *
+ * Returns the cache's rest array (do not retain — it is mutated in place).
+ */
+function calibrateSuspRest(
+  cache: AcEvoParserCache,
+  speedMps: number,
+  fl: number,
+  fr: number,
+  rl: number,
+  rr: number,
+): Float32Array {
+  if (cache._suspRestFinal) return cache._suspRest;
+
+  const idle = speedMps < SUSP_IDLE_SPEED_MPS;
+  if (idle !== cache._suspAccIdle) {
+    // Leaving a complete idle window: that baseline is the best we will ever
+    // get, so freeze it rather than letting driving frames dilute it.
+    if (cache._suspAccIdle && cache._suspAccN >= SUSP_IDLE_FRAMES) {
+      cache._suspRestFinal = true;
+      return cache._suspRest;
+    }
+    cache._suspAccSum.fill(0);
+    cache._suspAccN = 0;
+    cache._suspAccIdle = idle;
+  }
+
+  cache._suspAccSum[0]! += fl;
+  cache._suspAccSum[1]! += fr;
+  cache._suspAccSum[2]! += rl;
+  cache._suspAccSum[3]! += rr;
+  cache._suspAccN++;
+
+  if (cache._suspAccN >= (idle ? SUSP_IDLE_FRAMES : SUSP_MOVING_FRAMES)) {
+    for (let i = 0; i < 4; i++) cache._suspRest[i] = cache._suspAccSum[i]! / cache._suspAccN;
+  }
+  return cache._suspRest;
+}
+
+/** Reset rest calibration — a different car sits at a different height. */
+function resetSuspRest(cache: AcEvoParserCache): void {
+  cache._suspRest.fill(0);
+  cache._suspRestFinal = false;
+  cache._suspAccSum.fill(0);
+  cache._suspAccN = 0;
+  cache._suspAccIdle = false;
+}
+
+/** Map absolute travel (m) to a 0–1 bar centred on the learned rest height. */
+function normSuspTravel(travelM: number, restM: number): number {
+  return Math.max(0, Math.min(1, 0.5 + (travelM - restM) / (2 * SUSP_RANGE_M)));
 }
 
 /**
@@ -186,6 +286,7 @@ export function parseAcEvoBuffers(
   if (carModelStr && carModelStr !== cache.lastCarModel) {
     cache.lastCarModel = carModelStr;
     const car = getAcEvoCarByDisplayName(carModelStr);
+    resetSuspRest(cache);
     if (car) {
       cache.carOrdinal = car.id;
       console.log(`[AC Evo Parser] Resolved car: "${carModelStr}" → ordinal ${car.id}`);
@@ -488,6 +589,8 @@ export function parseAcEvoBuffers(
   const brakeVal = Math.round(brake * 255);
   const steer = Math.round(steerAngle * 127);
   const speed = speedKmh / 3.6;
+  // Learn/refresh this car's static ride height before normalising the bars.
+  const suspRest = calibrateSuspRest(cache, speed, suspFL, suspFR, suspRL, suspRR);
 
   const INV = 0x7fffffff;
   const currentLap = iCurrentTime > 0 && iCurrentTime !== INV ? iCurrentTime / 1000 : 0;
@@ -603,10 +706,11 @@ export function parseAcEvoBuffers(
     // Encode as centered 0–1 so the bar fills correctly: 0.5 = rest,
     // >0.5 = compressed, <0.5 = extended. ±50 mm assumed full range.
     // SuspensionTravelMFL carries the raw metres for the mm display label.
-    NormSuspensionTravelFL: Math.max(0, Math.min(1, 0.5 + suspFL / 0.1)),
-    NormSuspensionTravelFR: Math.max(0, Math.min(1, 0.5 + suspFR / 0.1)),
-    NormSuspensionTravelRL: Math.max(0, Math.min(1, 0.5 + suspRL / 0.1)),
-    NormSuspensionTravelRR: Math.max(0, Math.min(1, 0.5 + suspRR / 0.1)),
+    // 0.5 = the car's learned rest height, not a hardcoded channel zero.
+    NormSuspensionTravelFL: normSuspTravel(suspFL, suspRest[0]!),
+    NormSuspensionTravelFR: normSuspTravel(suspFR, suspRest[1]!),
+    NormSuspensionTravelRL: normSuspTravel(suspRL, suspRest[2]!),
+    NormSuspensionTravelRR: normSuspTravel(suspRR, suspRest[3]!),
 
     TireSlipRatioFL: slipRatioFL,
     TireSlipRatioFR: slipRatioFR,

--- a/server/telemetry-utils.ts
+++ b/server/telemetry-utils.ts
@@ -14,7 +14,16 @@ const SUSPENSION_RANGE_MM: Record<string, { min: number; max: number }> = {
 };
 const DEFAULT_SUSPENSION_RANGE_MM = { min: 20, max: 80 };
 
+/**
+ * Games whose parser already normalises suspension itself and must never be
+ * second-guessed with a fixed range. AC Evo learns each car's rest height at
+ * idle (calibrateSuspRest), so a legitimate 0.0 there means "fully extended",
+ * not "unset" — the `!== 0` guard below would silently overwrite it.
+ */
+const PARSER_OWNS_NORM_SUSPENSION = new Set(["ac-evo"]);
+
 export function fillNormSuspension(p: TelemetryPacket): void {
+  if (PARSER_OWNS_NORM_SUSPENSION.has(p.gameId ?? "")) return;
   if (p.NormSuspensionTravelFL !== 0 || p.SuspensionTravelMFL <= 0) return;
   const { min, max } = SUSPENSION_RANGE_MM[p.gameId ?? ""] ?? DEFAULT_SUSPENSION_RANGE_MM;
   const span = max - min;

--- a/test/ac-evo-susp-rest.test.ts
+++ b/test/ac-evo-susp-rest.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "bun:test";
+import { parseAcEvoBuffers, createAcEvoParserCache, type AcEvoParserCache } from "../server/games/ac-evo/parser";
+import { PHYSICS, GRAPHICS_EVO, STATIC_EVO, ACEVO_STATUS } from "../server/games/ac-evo/structs";
+import { fillNormSuspension } from "../server/telemetry-utils";
+import type { TelemetryPacket } from "../shared/types";
+
+/**
+ * Suspension rest calibration (calibrateSuspRest in parser.ts).
+ *
+ * AC Evo's suspTravel channel is signed but not zero-centred on ride height —
+ * real recordings idle anywhere from -36 mm to +2 mm depending on car/setup. The
+ * parser learns the rest height from the car's own idle frames so a stationary
+ * car reads 0.5 (mid-bar) instead of landing in the UI's red zone.
+ */
+
+const IDLE_FRAMES = 30; // must match SUSP_IDLE_FRAMES
+const MOVING_FRAMES = 600; // must match SUSP_MOVING_FRAMES
+const RANGE_M = 0.025; // must match SUSP_RANGE_M
+
+type Corners = [number, number, number, number];
+
+/** Parse one synthetic frame at `speedKmh` with the given per-corner travel (m). */
+function frame(cache: AcEvoParserCache, speedKmh: number, travel: Corners): TelemetryPacket {
+  const physics = Buffer.alloc(PHYSICS.SIZE);
+  const graphics = Buffer.alloc(GRAPHICS_EVO.SIZE);
+  const staticData = Buffer.alloc(STATIC_EVO.SIZE);
+  // Default status (0) is AC_OFF — the parser gates out. AC_LIVE runs the body.
+  graphics.writeInt32LE(ACEVO_STATUS.AC_LIVE, GRAPHICS_EVO.status.offset);
+  physics.writeFloatLE(speedKmh, PHYSICS.speedKmh.offset);
+  physics.writeFloatLE(travel[0], PHYSICS.suspTravelFL.offset);
+  physics.writeFloatLE(travel[1], PHYSICS.suspTravelFR.offset);
+  physics.writeFloatLE(travel[2], PHYSICS.suspTravelRL.offset);
+  physics.writeFloatLE(travel[3], PHYSICS.suspTravelRR.offset);
+  const packet = parseAcEvoBuffers(physics, graphics, staticData, cache);
+  expect(packet).not.toBeNull();
+  return packet!;
+}
+
+function norms(p: TelemetryPacket): Corners {
+  return [
+    p.NormSuspensionTravelFL,
+    p.NormSuspensionTravelFR,
+    p.NormSuspensionTravelRL,
+    p.NormSuspensionTravelRR,
+  ];
+}
+
+/** Feed `n` stationary frames at `travel`; returns the last packet. */
+function idle(cache: AcEvoParserCache, travel: Corners, n = IDLE_FRAMES): TelemetryPacket {
+  let p!: TelemetryPacket;
+  for (let i = 0; i < n; i++) p = frame(cache, 0, travel);
+  return p;
+}
+
+// Real measured idle offsets (metres) — a car that the old fixed encoding put
+// deep in the red (FL -36 mm ⇒ 0.5 - 0.36 = 0.14) and one it put near-neutral.
+const OFFSET_CAR: Corners = [-0.036, -0.035, -0.017, -0.017];
+const NEUTRAL_CAR: Corners = [-0.011, -0.010, 0.002, 0.002];
+
+describe("AC Evo suspension rest calibration", () => {
+  test("a stationary car reads mid-bar regardless of its channel offset", () => {
+    for (const rest of [OFFSET_CAR, NEUTRAL_CAR, [0, 0, 0, 0] as Corners]) {
+      const cache = createAcEvoParserCache();
+      const p = idle(cache, rest);
+      for (const n of norms(p)) expect(n).toBeCloseTo(0.5, 5);
+    }
+  });
+
+  test("before enough idle frames the bar is uncalibrated, not garbage", () => {
+    const cache = createAcEvoParserCache();
+    // One frame in: rest is still 0, so we fall back to raw-channel centring.
+    // The point is it stays inside the bar rather than NaN/out-of-range.
+    const p = frame(cache, 0, OFFSET_CAR);
+    for (const n of norms(p)) {
+      expect(Number.isFinite(n)).toBe(true);
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("deflection from rest maps symmetrically around 0.5", () => {
+    const cache = createAcEvoParserCache();
+    idle(cache, OFFSET_CAR);
+
+    // Compress every corner by half the range ⇒ 0.75; extend ⇒ 0.25. Frames are
+    // fed at speed so the baseline is frozen and cannot absorb the deflection.
+    const half = RANGE_M / 2;
+    const bump = OFFSET_CAR.map((v) => v + half) as Corners;
+    const droop = OFFSET_CAR.map((v) => v - half) as Corners;
+    for (const n of norms(frame(cache, 60, bump))) expect(n).toBeCloseTo(0.75, 4);
+    for (const n of norms(frame(cache, 60, droop))) expect(n).toBeCloseTo(0.25, 4);
+
+    // Beyond ±RANGE_M it clamps to the ends of the bar.
+    const slam = OFFSET_CAR.map((v) => v + RANGE_M * 3) as Corners;
+    const lift = OFFSET_CAR.map((v) => v - RANGE_M * 3) as Corners;
+    for (const n of norms(frame(cache, 60, slam))) expect(n).toBe(1);
+    for (const n of norms(frame(cache, 60, lift))) expect(n).toBe(0);
+  });
+
+  test("front/rear rake is preserved — corners calibrate independently", () => {
+    const cache = createAcEvoParserCache();
+    idle(cache, OFFSET_CAR);
+    // Dive: fronts compress by 40% of the range, rears extend by 20% of it.
+    const front = RANGE_M * 0.4;
+    const rear = RANGE_M * 0.2;
+    const dive: Corners = [
+      OFFSET_CAR[0] + front,
+      OFFSET_CAR[1] + front,
+      OFFSET_CAR[2] - rear,
+      OFFSET_CAR[3] - rear,
+    ];
+    const [fl, fr, rl, rr] = norms(frame(cache, 60, dive));
+    expect(fl).toBeCloseTo(0.5 + front / (2 * RANGE_M), 4);
+    expect(fr).toBeCloseTo(0.5 + front / (2 * RANGE_M), 4);
+    expect(rl).toBeCloseTo(0.5 - rear / (2 * RANGE_M), 4);
+    expect(rr).toBeCloseTo(0.5 - rear / (2 * RANGE_M), 4);
+  });
+
+  test("the idle baseline is frozen once the car drives away", () => {
+    const cache = createAcEvoParserCache();
+    idle(cache, OFFSET_CAR);
+
+    // Drive for a long time with a *heavily* compressed, perfectly steady
+    // suspension (a downforce-loaded flat-out stint). The moving-frame fallback
+    // must not kick in and re-baseline to this, or every lap would read 0.5.
+    const squat = RANGE_M * 0.6;
+    const expected = 0.5 + squat / (2 * RANGE_M);
+    const loaded = OFFSET_CAR.map((v) => v + squat) as Corners;
+    let p!: TelemetryPacket;
+    for (let i = 0; i < MOVING_FRAMES * 2; i++) p = frame(cache, 150, loaded);
+    for (const n of norms(p)) expect(n).toBeCloseTo(expected, 4);
+
+    // Returning to a standstill must not move it either.
+    for (const n of norms(idle(cache, loaded, IDLE_FRAMES * 2))) expect(n).toBeCloseTo(expected, 4);
+  });
+
+  test("a session joined mid-lap falls back to the moving mean", () => {
+    const cache = createAcEvoParserCache();
+    // Never stationary: oscillate symmetrically about the true rest height.
+    let p!: TelemetryPacket;
+    for (let i = 0; i < MOVING_FRAMES; i++) {
+      const wobble = (i % 2 === 0 ? 1 : -1) * 0.012;
+      p = frame(cache, 120, OFFSET_CAR.map((v) => v + wobble) as Corners);
+    }
+    // Mean of the oscillation == rest, so the final frame (an extension half of
+    // the wobble) sits one wobble below centre, rather than being pinned to an
+    // arbitrary channel zero.
+    const expected = 0.5 - 0.012 / (2 * RANGE_M);
+    for (const n of norms(p)) expect(n).toBeCloseTo(expected, 3);
+  });
+
+  test("swapping cars re-calibrates instead of reusing the old height", () => {
+    const cache = createAcEvoParserCache();
+    idle(cache, OFFSET_CAR);
+    // Same buffers, but a new car_model string ⇒ baseline must be discarded.
+    const physics = Buffer.alloc(PHYSICS.SIZE);
+    const graphics = Buffer.alloc(GRAPHICS_EVO.SIZE);
+    graphics.writeInt32LE(ACEVO_STATUS.AC_LIVE, GRAPHICS_EVO.status.offset);
+    graphics.write("some_other_car\0", GRAPHICS_EVO.car_model.offset, "utf8");
+    for (const [i, off] of [
+      PHYSICS.suspTravelFL.offset,
+      PHYSICS.suspTravelFR.offset,
+      PHYSICS.suspTravelRL.offset,
+      PHYSICS.suspTravelRR.offset,
+    ].entries()) {
+      physics.writeFloatLE(NEUTRAL_CAR[i]!, off);
+    }
+    parseAcEvoBuffers(physics, graphics, Buffer.alloc(STATIC_EVO.SIZE), cache);
+
+    // Old rest (OFFSET_CAR) is gone; the new car's idle becomes the baseline.
+    for (const n of norms(idle(cache, NEUTRAL_CAR))) expect(n).toBeCloseTo(0.5, 5);
+  });
+
+  test("fillNormSuspension does not overwrite the parser's calibration", () => {
+    const cache = createAcEvoParserCache();
+    idle(cache, OFFSET_CAR);
+    // Fully extended relative to rest ⇒ a legitimate 0.0, with positive
+    // absolute travel. The pipeline must leave it alone.
+    const p = frame(cache, 60, OFFSET_CAR.map(() => 0.02) as Corners);
+    const before = norms(p);
+    fillNormSuspension(p);
+    expect(norms(p)).toEqual(before);
+  });
+});


### PR DESCRIPTION
Closes #121

## Problem

AC Evo's shared memory reports `suspensionTravel` as **absolute travel in metres**, not a normalised 0..1 value. `fillNormSuspension()` was normalising it against a magic full-travel constant (`DEFAULT_SUSPENSION_RANGE_MM`), so at idle every corner landed nowhere near the middle of the bar — a stationary car in Lap Analysis showed solid red against the default thresholds `[25, 65, 85]`.

The display itself was correct (it is showing suspension position); it was the range the colour scale was mapped over that was wrong.

## Fix

The AC Evo parser now learns each corner's **static rest height per session** and reports deflection around it:

- Averages the first `SUSP_IDLE_FRAMES` of genuinely stationary frames (speed under `SUSP_IDLE_SPEED_MPS`) and freezes that as the baseline.
- If a session is joined mid-lap and no idle frames ever arrive, falls back to the mean over `SUSP_MOVING_FRAMES` of driving frames so the bar still centres sensibly.
- **Never re-baselines once set** — a downforce-loaded flat-out stint or a return to the pits cannot drag the baseline back to 0.5.
- Resets when the car model changes (a different car has a different rest height).

Deflection is scaled to ±`SUSP_RANGE_M` (25 mm), so 0.5 is idle, compression rises, extension falls. Corners calibrate independently, so front/rear rake is preserved.

## Real-data validation

Replayed a 22,458-frame recording (`ac-evo-unknown-track-session17`, 7,487 idle + 14,559 driving frames):

| | FL | FR | RL | RR |
|---|---|---|---|---|
| idle norm mean (want ~0.500) | 0.509 | 0.451 | 0.449 | 0.523 |
| driving p01 | 0.282 | 0.269 | 0.389 | 0.339 |
| driving median | 0.466 | 0.480 | 0.624 | 0.589 |
| driving p99 | 0.675 | 0.700 | 0.806 | 0.832 |
| clipped @0 / @1 | 0 | 0 | 0 | 0 |

All four corners use 27%–83% of the bar with zero clipping at either end, and idle reads green under the existing thresholds.

## Tests

Adds `test/ac-evo-susp-rest.test.ts` (8 tests): idle centring, half-range compression/extension, clamping beyond the range, rake preservation, baseline freezing under sustained load, mid-lap moving-mean fallback, and car-change reset.

Full suite passes (`bun run test`) — the only failures in this worktree are missing generated `client/src/paraglide` output, unrelated to this change.