### PR TITLE
docs: order supported games by development priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,23 @@ Check out the [demo](https://www.youtube.com/watch?v=hWuIItofivA) and [screensho
 
 | Game | Status | Public Tunes | Public Guides | Tune Creator |
 |------|--------|--------------|---------------|--------------|
-| Forza Motorsport 2023 | Supported | No | No | Yes |
+| Assetto Corsa Evo | Supported | No | No | No |
 | F1 2025 | Supported | Yes | Yes | No |
 | Assetto Corsa Competizione | Supported | Yes | Yes | No |
-| Assetto Corsa Evo | Supported | No | No | No |
+| Forza Motorsport 2023 | Supported | No | No | Yes |
 | Le Mans Ultimate | Blocked — awaiting game key / sponsorship | — | — | — |
 | iRacing | Blocked — awaiting game key / sponsorship | — | — | — |
+
+### Development priority
+
+Supported games are listed in priority order. Priority is based on ongoing game support and freshness — how actively each title is still being updated by its developer:
+
+1. **Assetto Corsa Evo** — actively developed, frequent content updates.
+2. **F1 2025** — current-season title, actively maintained telemetry spec.
+3. **Assetto Corsa Competizione** — stable and widely raced, but feature-complete upstream.
+4. **Forza Motorsport 2023** — lowest priority; no longer meaningfully updated and its telemetry format is frozen.
+
+Lower priority means slower turnaround on new features for that title — it does not mean deprecated. All supported games keep working.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

Reorders the **Supported Games** table in the README so it reads as a priority list, and adds a short **Development priority** section explaining the ordering.

New order: Assetto Corsa Evo → F1 2025 → Assetto Corsa Competizione → Forza Motorsport 2023.

## Rationale

Priority is driven by **ongoing game support and freshness** — how actively each title is still being updated by its developer:

1. **Assetto Corsa Evo** — actively developed, frequent content updates.
2. **F1 2025** — current-season title, actively maintained telemetry spec.
3. **Assetto Corsa Competizione** — stable and widely raced, but feature-complete upstream.
4. **Forza Motorsport 2023** — no longer meaningfully updated, telemetry format frozen.

Explicitly noted in the README: lower priority means slower turnaround on new features, **not** deprecation. All supported games keep working.

## Scope

Docs only — no code, schema, or adapter changes.