### PR TITLE
fix: raise Windows timer resolution so capture intervals are honoured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Improve session and sector tables when timing data is sparse or unavailable
 - Show every registered game in storage settings, including games without recorded sessions
 - Keep connection status, theme tokens, button surfaces, and sector-blip selection visually consistent
+- Raise Windows timer resolution during ACC and AC Evo capture so shared-memory polling no longer collapses to the default ~64 Hz tick
 
 ### Internal
 - Renamed generic session recorder API to reflect support for UDP and shared-memory telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Fixes
+- Raise Windows timer resolution during ACC and AC Evo capture so shared-memory polling no longer collapses to the default ~64 Hz tick
+
+## v0.14.0 - 2026-08-05
+
 ### Features
 - Analyze recent driving trends across up to 30 laps, with measured style, consistency, time-loss, and optional AI coaching
 - Run versioned tuning and driving experiments in ACC and AC Evo, with setup changes, coaching drills, lap review, and car-or-driver focus
@@ -26,7 +31,6 @@
 - Improve session and sector tables when timing data is sparse or unavailable
 - Show every registered game in storage settings, including games without recorded sessions
 - Keep connection status, theme tokens, button surfaces, and sector-blip selection visually consistent
-- Raise Windows timer resolution during ACC and AC Evo capture so shared-memory polling no longer collapses to the default ~64 Hz tick
 
 ### Internal
 - Renamed generic session recorder API to reflect support for UDP and shared-memory telemetry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+### Features
+- Persisted cross-game race results with qualifying, podium, fastest-lap, pit, strategy, and position-timeline summaries, plus idempotent historical backfill
+
 ### Fixes
 - Raise Windows timer resolution during ACC and AC Evo capture so shared-memory polling no longer collapses to the default ~64 Hz tick
 
@@ -14,7 +17,6 @@
 - Move app navigation from the top bar into a left-hand sidebar, with a responsive mobile navigation drawer
 - Copy AI Compare conversations as JSON and resume or regenerate analysis chats with complete persisted history
 - Generate detailed, sector-aware lap-analysis results with consistent provider and settings handling
-- Persisted cross-game race results with qualifying, podium, fastest-lap, pit, strategy, and position-timeline summaries, plus idempotent historical backfill
 - Automatic driver profile metrics with optional, configurable background AI coaching and auditable run history
 - Runtime-discovered iRacing cars and tracks, resolved by the SDK's native identifiers
 - Support for iRacing's source-defined sector layouts, including two-sector ovals and layouts with more than three sectors

--- a/docs/telemetry-fidelity.md
+++ b/docs/telemetry-fidelity.md
@@ -32,12 +32,50 @@ not:
 | 3 | 6697 | 105.478 s | **63.5 Hz** |
 
 Two independent laps agreeing to three significant figures rules out a one-off
-stall. The cause is **timer granularity**: a 10 ms `setInterval` in this runtime
-delivers ~15.7 ms, which is exactly 63.5 Hz. The assembler already collects
-`pollIntervalMs` metrics that would confirm this in a live session.
+stall. The cause is the **Windows default timer resolution of 15.625 ms**
+(64.0 Hz). Any `setInterval` shorter than a tick is rounded up to it, because
+libuv's loop hands its computed timeout to `GetQueuedCompletionStatus` and that
+blocking wait is quantised to the system tick. Node and Bun do not raise the
+resolution themselves, and since Windows 10 2004 a process no longer inherits a
+raised resolution from some other app on the machine — it must call
+[`timeBeginPeriod`](https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod)
+for itself.
+
+This is platform-specific, not a property of Bun. Probed on Linux, `setInterval`
+is fine — `setInterval(10)` measures 10.07 ms mean (99.3 Hz), `setInterval(1)`
+resolves to 1.06 ms. The bug only exists on the platform AC Evo capture actually
+runs on.
+
+Confirmed from the artifact itself, without needing a wall clock. The sim's own
+`physicsPacketId` is the ruler: it advances **5.291 ticks per frame we store**,
+bimodally 5 or 6, and the counter covers 106378 ticks over the session's 316.7 s
+— so the sim's physics runs at **336 Hz** and our poll spacing was
+5.291 × 2.98 ms = **15.8 ms**. A poll that genuinely ran at 10 ms would show a
+mean delta of 3.35, bimodal 3/4. It does not. The interval really was a tick.
+
+Two consequences the earlier draft missed:
+
+- **The fix is not a drift-compensated scheduler.** Recomputing the next
+  deadline from an absolute start only removes accumulated drift; it cannot make
+  the OS wake you before the next tick. (Measured: drift compensation on Linux
+  moves 10.07 ms to 10.00 ms — it corrects drift, not granularity.) The fix is
+  to raise the process timer resolution via `bun:ffi` on `winmm.dll`, paired
+  with `timeEndPeriod` on shutdown. We already `dlopen` `kernel32.dll` under a
+  Windows guard in `server/games/acc/buffered-memory-reader.ts:159`, so there is
+  precedent and no new dependency.
+- **`triplet-assembler.ts` is not the only clamped timer.** The reader beneath
+  it runs `setInterval(1000 / 300)` for physics and `setInterval(1000 / 60)` for
+  graphics (`buffered-memory-reader.ts:243,279`). On Windows *all three* collapse
+  to the same 64 Hz tick, so speeding up the assembler alone would just re-read
+  buffers the reader had not refreshed. Raising the resolution unblocks the whole
+  chain at once; fixing one timer in isolation achieves nothing.
 
 It is *not* the pipeline's packet-rate filter — that is a floor guard that
 discards sessions below 30 Hz (`server/lap-detector.ts:183`), not a decimator.
+
+Worth stating plainly, because it reframes section 2: **the sim publishes physics
+at 336 Hz** — above MoTeC's 200 Hz tier — and we discard 81% of it to a timer
+default. The ceiling here is ours, not the sim's.
 
 The second finding is about the *pages*, not the rate. AC Evo exposes two
 shared-memory pages that advance independently, and we poll both on the same
@@ -191,10 +229,12 @@ not by an error threshold.**
   channels that need rate we are 5× behind it. Nor that rate improves lap
   comparison, apex speeds, racing line, or AI analysis — those are identical at
   26.6 Hz.
-- **Fix first:** the 63.5 ≠ 100 timer in `triplet-assembler.ts`, and the
-  re-storing of an unchanged graphics page. Both are bugs; neither needs this
-  doc to justify it. Note the second is a *storage* bug, not an accuracy one —
-  physics is fresh every frame.
+- **Fix first:** the 63.5 ≠ 100 Hz Windows timer tick — raise process timer
+  resolution once at capture start rather than touching individual intervals —
+  and the re-storing of an unchanged graphics page. Both are bugs; neither needs
+  this doc to justify it. Note the second is a *storage* bug, not an accuracy
+  one — physics is fresh every frame. The first has headroom well past 100 Hz,
+  since the sim publishes at 336 Hz.
 - **Then consider:** a curated per-channel rate split, tiered by role.
 - **Importing third-party logs** is safe for trace-based analysis and unsafe for
   event counting. An imported 20 Hz channel must not be compared against a

--- a/docs/telemetry-fidelity.md
+++ b/docs/telemetry-fidelity.md
@@ -1,23 +1,25 @@
 # Telemetry fidelity: what sample rate actually buys us
 
 **TL;DR** — We are **not** more accurate than a real MoTeC log, and we should
-stop implying it. Our recordings emit at **63.5 Hz** (not the 100 Hz we intend)
-and **37.8% of those frames are duplicates**, so the true rate at which our data
-changes is **~39.5 Hz**. A real MoTeC `.ld` from AC logs suspension travel and
-wheel speed at **200 Hz** — 5× us — and inputs at 60 Hz. We are ahead of it only
-on G-forces and status channels, which MoTeC logs at 20 Hz.
+stop implying it. Our recordings emit at **63.5 Hz**, not the 100 Hz we intend.
+Physics is genuinely fresh at that rate; the *graphics* page — lap time,
+position, flags — only advances at ~40 Hz in the sim, so **37.8% of our frames
+re-read an unchanged graphics page**. A real MoTeC `.ld` from AC logs suspension
+travel and wheel speed at **200 Hz** — 3× our physics rate — and inputs at
+60 Hz. We are ahead of it only on G-forces and status channels, which MoTeC logs
+at 20 Hz.
 
 What the data *does* support: sample rate matters for **transient channels and
 event counting**, not for traces (section 3 vs 4), and our current format is
-carrying an easy **~38% duplicate-frame** overhead plus a **~29%** curated
-per-channel-rate saving that we are not taking (section 6).
+carrying an easy **~29% of raw bytes** in repeated graphics pages plus a
+further curated per-channel-rate saving that we are not taking (section 6).
 
 Measured against `test/artifacts/sessions/session-ac-evo-mid-2026-04-21T20-24-34-810Z.bin.gz`
 (AC Evo, Porsche 992 GT3 R Rennsport at Brands Hatch, two complete laps) and
 `2.16.967_Spa_AMGEVO_MoTeC` (Mercedes AMG GT3 Evo at Spa, 137.2 s stint,
 55 channels). Locked in by `test/telemetry-fidelity.test.ts`.
 
-## 1. We are not capturing at 100 Hz, and a third of what we capture is a copy
+## 1. We are not capturing at 100 Hz, and a third of each frame is a re-read
 
 `server/games/acc/triplet-assembler.ts` polls shared memory on a `setInterval`
 of `1000 / 100` (10 ms) and emits a triplet on **every poll — no dedupe, no
@@ -30,21 +32,38 @@ not:
 | 3 | 6697 | 105.478 s | **63.5 Hz** |
 
 Two independent laps agreeing to three significant figures rules out a one-off
-stall. Two separate causes stack here:
+stall. The cause is **timer granularity**: a 10 ms `setInterval` in this runtime
+delivers ~15.7 ms, which is exactly 63.5 Hz. The assembler already collects
+`pollIntervalMs` metrics that would confirm this in a live session.
 
-1. **Timer granularity.** A 10 ms `setInterval` in this runtime delivers
-   ~15.7 ms, which is exactly 63.5 Hz. The assembler already collects
-   `pollIntervalMs` metrics that would confirm this in a live session.
-2. **No page-change gate.** 7592 of 20108 packets (**37.8%**) carry the same
-   `CurrentRaceTime` as their predecessor — the sim had not advanced its physics
-   page, and we wrote the previous values again. **Our effective rate is
-   ~39.5 Hz**, not 63.5.
-
-Neither is the pipeline's packet-rate filter — that is a floor guard that
+It is *not* the pipeline's packet-rate filter — that is a floor guard that
 discards sessions below 30 Hz (`server/lap-detector.ts:183`), not a decimator.
 
-**This is the actionable finding.** "Retain 100 Hz physics" is a statement about
-intent, not about the data, and the honest headline number is 39.5 Hz.
+The second finding is about the *pages*, not the rate. AC Evo exposes two
+shared-memory pages that advance independently, and we poll both on the same
+tick:
+
+| Page | Bytes/frame | Unchanged vs previous frame | Real update rate |
+|------|-------------|-----------------------------|------------------|
+| Physics | 800 | **<1%** | ~63.5 Hz (we keep up) |
+| Graphics | 3944 | **37.8%** | ~40 Hz |
+| Static | 256 | 100% (constant all session) | n/a |
+
+So the honest statement is per-channel, not global. Physics-derived channels
+(speed, suspension, wheels, G-forces) are fresh on essentially every frame we
+write. Graphics-derived channels (lap time, track position, flags, pit state)
+genuinely only change ~40 times a second because that is all the sim publishes.
+
+⚠️ An earlier draft of this doc measured `CurrentRaceTime` repeats and reported
+"our effective rate is 39.5 Hz". `CurrentRaceTime` comes off the *graphics*
+page, so that number was a graphics-page statistic mislabelled as stale physics.
+It has been corrected here and the assertion in
+`test/telemetry-fidelity.test.ts` now checks each page separately.
+
+**The actionable finding.** "Retain 100 Hz physics" is a statement about intent,
+not about the data — the honest headline is 63.5 Hz physics. And because
+graphics is 78.5% of every frame we store, re-reading it a third of the time
+costs **~29% of all raw bytes written**, for zero information.
 
 ## 2. What MoTeC actually does — a curated per-channel split
 
@@ -63,13 +82,13 @@ what they are for:
 rates are real, not aspirational. (The `EN_*` group is the exception — 5× more
 samples than the stint length, so treat its declared 50 Hz as unreliable.)
 
-Head to head, per channel, against our ~39.5 Hz flat:
+Head to head, per channel, against our 63.5 Hz flat physics rate:
 
 | Channel class | MoTeC | Us | Verdict |
 |---------------|-------|-----|---------|
-| Suspension travel, wheel speed, bumpstops | 200 Hz | 39.5 Hz | **MoTeC 5× ahead** |
-| Steering, speed, throttle, brake, RPM | 60 Hz | 39.5 Hz | **MoTeC 1.5× ahead** |
-| G-forces, gear, TC/ABS, brake temps, tyre press/temps | 20 Hz | 39.5 Hz | **Us 2× ahead** |
+| Suspension travel, wheel speed, bumpstops | 200 Hz | 63.5 Hz | **MoTeC 3× ahead** |
+| Steering, speed, throttle, brake, RPM | 60 Hz | 63.5 Hz | **Level** |
+| G-forces, gear, TC/ABS, brake temps, tyre press/temps | 20 Hz | 63.5 Hz | **Us 3× ahead** |
 
 So the defensible claim is *not* "we sample faster". It is: **we sample flat,
 MoTeC samples deliberately.** We win where MoTeC decided the channel did not
@@ -131,7 +150,7 @@ we cannot observe an event shorter than 15.7 ms, so the "shorter than one
 26.6 Hz sample" column is itself a lower bound.
 
 That censoring also means **this artifact cannot answer whether 200 Hz beats
-39.5 Hz**. Both score 0% missed against a distribution that our own sampling
+63.5 Hz**. Both score 0% missed against a distribution that our own sampling
 defined. Answering it needs a capture at a genuinely higher rate — or a
 channel-by-channel comparison against the MoTeC file, which is now possible and
 is the obvious next step.
@@ -140,15 +159,18 @@ is the obvious next step.
 
 Sample rate is not where our format is weak. Redundancy is.
 
-| Change | Effect on sample volume |
-|--------|-------------------------|
-| Drop duplicate frames (no physics-page advance) | **−37.8%** |
-| Move the 41 of 107 channels that are temps, pressures, fuel, damage and session status to a 10 Hz tier (MoTeC puts them at 20 Hz) | **−29%** of what remains |
-| Combined | **~44% of current sample volume** |
+Each frame we store is 5024 bytes: 800 physics, 3944 graphics, 256 static.
 
-Caveat, stated plainly: this is a **sample-count** saving, not a measured
-on-disk saving. gzip already exploits repeated frames well, so the disk win will
-be smaller than 56% — we have not measured it. The unambiguous wins are parse
+| Change | Effect on raw bytes written |
+|--------|-----------------------------|
+| Drop repeated graphics pages (37.8% of frames re-read an unchanged page) | **−29%** |
+| Hoist the static page out of the frame loop — it is constant for the whole session | **−5%** |
+| Move the 41 of 107 channels that are temps, pressures, fuel, damage and session status to a 10 Hz tier (MoTeC puts them at 20 Hz) | not yet measured; a further large cut to what remains |
+| First two combined | **~34% of raw bytes, for zero information loss** |
+
+Caveat, stated plainly: this is a **raw-byte** saving, not a measured on-disk
+saving. gzip already exploits repeated frames well, so the compressed win will
+be smaller than 34% — we have not measured it. The unambiguous wins are parse
 cost, in-memory footprint, and not lying to downstream consumers about how often
 a tyre temperature genuinely changed.
 
@@ -169,13 +191,15 @@ not by an error threshold.**
   channels that need rate we are 5× behind it. Nor that rate improves lap
   comparison, apex speeds, racing line, or AI analysis — those are identical at
   26.6 Hz.
-- **Fix first:** the duplicate-frame emit and the 63.5 ≠ 100 timer, in
-  `triplet-assembler.ts`. Both are bugs; neither needs this doc to justify it.
+- **Fix first:** the 63.5 ≠ 100 timer in `triplet-assembler.ts`, and the
+  re-storing of an unchanged graphics page. Both are bugs; neither needs this
+  doc to justify it. Note the second is a *storage* bug, not an accuracy one —
+  physics is fresh every frame.
 - **Then consider:** a curated per-channel rate split, tiered by role.
 - **Importing third-party logs** is safe for trace-based analysis and unsafe for
   event counting. An imported 20 Hz channel must not be compared against a
   native one on any event-count metric — and note that cuts both ways now: our
-  39.5 Hz suspension trace must not be event-compared against MoTeC's 200 Hz.
+  63.5 Hz suspension trace must not be event-compared against MoTeC's 200 Hz.
 
 ## Reproducing
 
@@ -185,5 +209,6 @@ bun run test test/telemetry-fidelity.test.ts
 
 The test asserts both halves — that smooth channels survive *and* that events do
 not — so neither side of this can be quietly overstated later. It also pins the
-duplicate-frame fraction and the capture rate; if either moves, the emit path
-changed and sections 1 and 6 need rewriting rather than the thresholds widening.
+per-page repeat fractions and the capture rate; if any of them move, the emit
+path changed and sections 1 and 6 need rewriting rather than the thresholds
+widening.

--- a/docs/telemetry-fidelity.md
+++ b/docs/telemetry-fidelity.md
@@ -1,13 +1,13 @@
 # Telemetry fidelity: what sample rate actually buys us
 
 **TL;DR** — We are **not** more accurate than a real MoTeC log, and we should
-stop implying it. Our recordings emit at **63.5 Hz**, not the 100 Hz we intend.
-Physics is genuinely fresh at that rate; the *graphics* page — lap time,
-position, flags — only advances at ~40 Hz in the sim, so **37.8% of our frames
-re-read an unchanged graphics page**. A real MoTeC `.ld` from AC logs suspension
-travel and wheel speed at **200 Hz** — 3× our physics rate — and inputs at
-60 Hz. We are ahead of it only on G-forces and status channels, which MoTeC logs
-at 20 Hz.
+stop implying it. The committed AC Evo artifact was captured at **63.5 Hz**
+before the Windows timer-resolution fix; it is not evidence of the current live
+rate. Physics is genuinely fresh in that pre-fix artifact; the *graphics* page
+only advances as often as the simulator and the old capture loop observe it.
+A real MoTeC `.ld` from AC logs suspension travel and wheel speed at **200 Hz** —
+3× the old capture rate — and inputs at 60 Hz. We are ahead of it only on
+G-forces and status channels, which MoTeC logs at 20 Hz.
 
 What the data *does* support: sample rate matters for **transient channels and
 event counting**, not for traces (section 3 vs 4), and our current format is
@@ -33,11 +33,20 @@ not:
 
 Two independent laps agreeing to three significant figures rules out a one-off
 stall. The cause is the **Windows default timer resolution of 15.625 ms**
-(64.0 Hz). Any `setInterval` shorter than a tick is rounded up to it, because
-libuv's loop hands its computed timeout to `GetQueuedCompletionStatus` and that
-blocking wait is quantised to the system tick. Node and Bun do not raise the
-resolution themselves, and since Windows 10 2004 a process no longer inherits a
-raised resolution from some other app on the machine — it must call
+(64.0 Hz). A request for 300 Hz or 100 Hz is rounded to roughly one system
+tick; a request near 60 Hz can be rounded to roughly two ticks. The exact
+result depends on the requested interval and event-loop scheduling. On this
+Windows host, direct measurements were:
+
+| Requested interval | Before fix | After `timeBeginPeriod(1)` |
+|--------------------|------------|-----------------------------|
+| 3.33 ms (300 Hz) | 64.08 Hz | 294.04 Hz |
+| 10 ms (100 Hz) | 64.03 Hz | 94.42 Hz |
+| 16.67 ms (60 Hz) | 37.61 Hz | 59.90 Hz |
+
+Node and Bun do not raise the resolution themselves, and since Windows 10 2004
+a process no longer inherits a raised resolution from some other app on the
+machine — it must call
 [`timeBeginPeriod`](https://learn.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod)
 for itself.
 
@@ -65,10 +74,11 @@ Two consequences the earlier draft missed:
   precedent and no new dependency.
 - **`triplet-assembler.ts` is not the only clamped timer.** The reader beneath
   it runs `setInterval(1000 / 300)` for physics and `setInterval(1000 / 60)` for
-  graphics (`buffered-memory-reader.ts:243,279`). On Windows *all three* collapse
-  to the same 64 Hz tick, so speeding up the assembler alone would just re-read
-  buffers the reader had not refreshed. Raising the resolution unblocks the whole
-  chain at once; fixing one timer in isolation achieves nothing.
+  graphics (`buffered-memory-reader.ts:243,279`). Before the fix, the 300 Hz
+  physics timer and 100 Hz assembler measured near 64 Hz, while the 60 Hz
+  graphics timer measured near 38 Hz on this host. Raising the resolution
+  unblocks the whole chain at once; fixing one timer in isolation achieves
+  nothing.
 
 ### Status: fixed
 
@@ -82,13 +92,12 @@ fight over it, and **scoped to an active capture** rather than the process
 lifetime, because a raised resolution costs power. Off Windows, and on Windows
 if `winmm.dll` will not load, it is inert and capture continues at the coarse
 tick.
-
-Two things this does *not* prove, and which need a real Windows box to confirm:
-the tables above still describe the pre-fix artifact (they are assertions about
-a committed `.bin.gz`, not about live behaviour), and on Windows 11 an occluded
-or minimised window-owning process may have its request ignored.
-`currentPeriodMs()` reports what we asked for, not what was granted — read the
-assembler's `pollIntervalMs` metrics (`ACC_METRICS=1`) for the truth.
+The committed tables above still describe the pre-fix artifact. This Windows
+host has now directly measured the post-fix timer behavior shown in the table
+above. On Windows 11, an occluded or minimised window-owning process may still
+have its request ignored; `currentPeriodMs()` reports what we asked for, not
+what was granted. Trust the assembler's `pollIntervalMs` metrics
+(`ACC_METRICS=1`) for live capture truth.
 
 It is *not* the pipeline's packet-rate filter — that is a floor guard that
 discards sessions below 30 Hz (`server/lap-detector.ts:183`), not a decimator.

--- a/docs/telemetry-fidelity.md
+++ b/docs/telemetry-fidelity.md
@@ -70,6 +70,26 @@ Two consequences the earlier draft missed:
   buffers the reader had not refreshed. Raising the resolution unblocks the whole
   chain at once; fixing one timer in isolation achieves nothing.
 
+### Status: fixed
+
+`server/games/shared/win-timer-resolution.ts` raises the process timer
+resolution via `timeBeginPeriod` on `winmm.dll`, clamped to the platform floor
+reported by `timeGetDevCaps`. Both shared-memory readers
+(`server/games/acc/shared-memory.ts`, `server/games/ac-evo/shared-memory.ts`)
+acquire it immediately before arming any capture interval and release it in
+`stop()`. It is **refcounted**, so ACC and AC Evo running back to back do not
+fight over it, and **scoped to an active capture** rather than the process
+lifetime, because a raised resolution costs power. Off Windows, and on Windows
+if `winmm.dll` will not load, it is inert and capture continues at the coarse
+tick.
+
+Two things this does *not* prove, and which need a real Windows box to confirm:
+the tables above still describe the pre-fix artifact (they are assertions about
+a committed `.bin.gz`, not about live behaviour), and on Windows 11 an occluded
+or minimised window-owning process may have its request ignored.
+`currentPeriodMs()` reports what we asked for, not what was granted — read the
+assembler's `pollIntervalMs` metrics (`ACC_METRICS=1`) for the truth.
+
 It is *not* the pipeline's packet-rate filter — that is a floor guard that
 discards sessions below 30 Hz (`server/lap-detector.ts:183`), not a decimator.
 

--- a/server/games/ac-evo/shared-memory.ts
+++ b/server/games/ac-evo/shared-memory.ts
@@ -16,6 +16,7 @@ import type { AcEvoParserCache } from "./parser";
 import { processPacket } from "../../pipeline";
 import { acEvoRecorder } from "./recorder";
 import { packTriplet, ACEVO_PACKED_MAGIC } from "../shared/pack-triplet";
+import { acquireHighResolutionTimer, releaseHighResolutionTimer } from "../shared/win-timer-resolution";
 import { PHYSICS, GRAPHICS_EVO, STATIC_EVO } from "./structs";
 
 class AcEvoParsingProcessor implements TripletProcessor {
@@ -44,6 +45,8 @@ export class AcEvoSharedMemoryReader {
   private _running = false;
   private _connected = false;
   private _recordingEnabled: boolean;
+  /** True while we hold a timer-resolution reference, so stop() releases exactly one. */
+  private _holdsTimerResolution = false;
 
   constructor(recordingEnabled = false) {
     this._bufferedReader = new BufferedAccMemoryReader({
@@ -98,6 +101,12 @@ export class AcEvoSharedMemoryReader {
     await this._tripletAssembler.stop();
     await this._bufferedReader.stop();
     this._connected = false;
+    // Drop the timer resolution once no capture interval needs it. Guarded so a
+    // stop() without a matching start() cannot underflow the refcount.
+    if (this._holdsTimerResolution) {
+      this._holdsTimerResolution = false;
+      releaseHighResolutionTimer();
+    }
     // Recording mode: this reader opened the bin file in its constructor, so
     // close it when the reader goes down (game exit / shutdown). Finalizes the
     // frameCount header instead of relying on the killed-process scan path.
@@ -111,6 +120,17 @@ export class AcEvoSharedMemoryReader {
     if (this._connected) return;
 
     console.log("[AC Evo] AC Evo process detected, starting buffered reader...");
+
+    // Raise the process timer resolution BEFORE any capture interval is armed.
+    // On Windows the default 15.625ms tick rounds up every setInterval below it,
+    // which silently collapses the reader's 300Hz/60Hz timers and the
+    // assembler's 100Hz timer to ~63.5Hz. Held only for the capture's lifetime
+    // because a raised resolution costs power.
+    // See docs/telemetry-fidelity.md section 1.
+    if (!this._holdsTimerResolution) {
+      acquireHighResolutionTimer();
+      this._holdsTimerResolution = true;
+    }
 
     this._bufferedReader.start();
     this._connected = true;

--- a/server/games/acc/shared-memory.ts
+++ b/server/games/acc/shared-memory.ts
@@ -16,6 +16,7 @@ import { accRecorder } from "./recorder";
 import { BufferedAccMemoryReader } from "./buffered-memory-reader";
 import { TripletAssembler } from "./triplet-assembler";
 import { TripletPipeline, StatusCheckProcessor, DumpToBinProcessor, ParsingProcessor } from "./triplet-pipeline";
+import { acquireHighResolutionTimer, releaseHighResolutionTimer } from "../shared/win-timer-resolution";
 
 // Re-export utilities so tests can import readWString from this module
 export { readWString, toWideString } from "./utils";
@@ -33,6 +34,8 @@ export class AccSharedMemoryReader {
   private _trackOrdinal = -1;
   private _retryTimer: ReturnType<typeof setInterval> | null = null;
   private _recordingEnabled = false;
+  /** True while we hold a timer-resolution reference, so stop() releases exactly one. */
+  private _holdsTimerResolution = false;
 
   constructor(recordingEnabled = false) {
     this._bufferedReader = new BufferedAccMemoryReader();
@@ -82,6 +85,12 @@ export class AccSharedMemoryReader {
       this._retryTimer = null;
     }
     this._connected = false;
+    // Drop the timer resolution once no capture interval needs it. Guarded so a
+    // stop() without a matching start() cannot underflow the refcount.
+    if (this._holdsTimerResolution) {
+      this._holdsTimerResolution = false;
+      releaseHighResolutionTimer();
+    }
     // Recording mode: this reader opened the bin file in its constructor, so
     // close it when the reader goes down (game exit / shutdown). Finalizes the
     // frameCount header instead of relying on the killed-process scan path.
@@ -95,6 +104,17 @@ export class AccSharedMemoryReader {
     if (this._connected) return;
 
     console.log("[ACC] ACC process detected, starting buffered reader...");
+
+    // Raise the process timer resolution BEFORE any capture interval is armed.
+    // On Windows the default 15.625ms tick rounds up every setInterval below it,
+    // which silently collapses the reader's 300Hz/60Hz timers and the
+    // assembler's 100Hz timer to ~63.5Hz. Held only for the capture's lifetime
+    // because a raised resolution costs power.
+    // See docs/telemetry-fidelity.md section 1.
+    if (!this._holdsTimerResolution) {
+      acquireHighResolutionTimer();
+      this._holdsTimerResolution = true;
+    }
 
     // Start buffered reader (loads FFI, opens shared memory, starts 300Hz/60Hz timers)
     this._bufferedReader.start();

--- a/server/games/shared/win-timer-resolution.ts
+++ b/server/games/shared/win-timer-resolution.ts
@@ -1,0 +1,168 @@
+/**
+ * Windows timer resolution control.
+ *
+ * Why this exists: Windows' default system timer tick is 15.625ms (64Hz). Any
+ * `setInterval` shorter than a tick is rounded up to it, because libuv hands the
+ * loop's computed timeout to `GetQueuedCompletionStatus` and that blocking wait
+ * is quantised to the tick. Neither Node nor Bun raises the resolution, and
+ * since Windows 10 2004 a process no longer inherits a raised resolution from
+ * another process on the machine — it must ask for its own.
+ *
+ * The observable damage: our AC Evo / ACC capture chain asks for 300Hz (reader
+ * physics), 60Hz (reader graphics) and 100Hz (triplet assembler), and every one
+ * of them collapses to ~63.5Hz. Measured on a real session artifact, poll
+ * spacing was 15.8ms against a sim publishing physics at 336Hz — we were
+ * discarding 81% of available physics frames to a platform default.
+ * See docs/telemetry-fidelity.md section 1.
+ *
+ * Note this is NOT fixable with a drift-compensated scheduler. Recomputing the
+ * next deadline from an absolute origin removes accumulated *drift*; it cannot
+ * make the OS wake the process before the next tick.
+ *
+ * Cost: a raised resolution increases timer interrupt frequency, which costs
+ * power. So this is refcounted and scoped to the lifetime of an active capture,
+ * not requested for the whole process lifetime.
+ *
+ * Caveat that cannot be verified from a non-Windows dev box: on Windows 11, a
+ * window-owning process that becomes fully occluded or minimised may have its
+ * requested resolution ignored. `currentPeriodMs()` reports what we asked for,
+ * not what the OS granted — trust the assembler's `pollIntervalMs` metrics for
+ * that.
+ */
+
+import { dlopen, FFIType, ptr } from "bun:ffi";
+
+/** MMRESULT success code (`TIMERR_NOERROR`). */
+const TIMERR_NOERROR = 0;
+
+/** What we ask for. 1ms is the conventional floor and what game/audio software uses. */
+const DESIRED_PERIOD_MS = 1;
+
+interface WinmmSymbols {
+  timeBeginPeriod: (period: number) => number;
+  timeEndPeriod: (period: number) => number;
+  timeGetDevCaps: (caps: unknown, size: number) => number;
+}
+
+let winmm: { symbols: WinmmSymbols; close: () => void } | null = null;
+let loadFailed = false;
+let refCount = 0;
+let activePeriodMs: number | null = null;
+
+const isWindows = (): boolean => process.platform === "win32";
+
+function loadWinmm(): { symbols: WinmmSymbols } | null {
+  if (winmm) return winmm;
+  if (loadFailed) return null;
+  try {
+    winmm = dlopen("winmm.dll", {
+      timeBeginPeriod: { args: [FFIType.u32], returns: FFIType.u32 },
+      timeEndPeriod: { args: [FFIType.u32], returns: FFIType.u32 },
+      timeGetDevCaps: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.u32 },
+    }) as unknown as { symbols: WinmmSymbols; close: () => void };
+    return winmm;
+  } catch (err) {
+    // Not fatal — we simply keep the 15.625ms tick and the coarser capture rate.
+    loadFailed = true;
+    console.warn("[TimerResolution] Could not load winmm.dll, staying at default tick:", err);
+    return null;
+  }
+}
+
+/**
+ * Smallest period the platform will honour, per `timeGetDevCaps`. Returns the
+ * desired period unchanged if the query fails — `timeBeginPeriod` validates its
+ * own argument anyway and we handle its error return.
+ */
+function minSupportedPeriodMs(lib: { symbols: WinmmSymbols }): number {
+  try {
+    // TIMECAPS { UINT wPeriodMin; UINT wPeriodMax; } — 8 bytes.
+    const caps = Buffer.alloc(8);
+    if (lib.symbols.timeGetDevCaps(ptr(caps), caps.length) !== TIMERR_NOERROR) {
+      return DESIRED_PERIOD_MS;
+    }
+    const min = caps.readUInt32LE(0);
+    const max = caps.readUInt32LE(4);
+    if (min === 0 || min > max) return DESIRED_PERIOD_MS;
+    return Math.max(min, DESIRED_PERIOD_MS);
+  } catch {
+    return DESIRED_PERIOD_MS;
+  }
+}
+
+/**
+ * Raise this process's timer resolution so sub-tick intervals are honoured.
+ *
+ * Refcounted and idempotent per caller: nested acquires are cheap, and the
+ * resolution is only released once every holder has called {@link release}.
+ * No-ops on every platform but Windows, and on Windows if `winmm.dll` will not
+ * load — in both cases capture still works, just at the coarser tick.
+ *
+ * @returns the period actually requested in ms, or `null` if unchanged.
+ */
+export function acquireHighResolutionTimer(): number | null {
+  if (!isWindows()) return null;
+
+  // Already held — just take a reference.
+  if (activePeriodMs !== null) {
+    refCount++;
+    return activePeriodMs;
+  }
+
+  const lib = loadWinmm();
+  if (!lib) return null;
+
+  const period = minSupportedPeriodMs(lib);
+  const result = lib.symbols.timeBeginPeriod(period);
+  if (result !== TIMERR_NOERROR) {
+    console.warn(`[TimerResolution] timeBeginPeriod(${period}) failed with ${result}`);
+    return null;
+  }
+
+  activePeriodMs = period;
+  refCount = 1;
+  console.log(
+    `[TimerResolution] Raised to ${period}ms (default tick is 15.625ms) — sub-tick intervals now honoured`,
+  );
+  return period;
+}
+
+/**
+ * Drop one reference taken by {@link acquireHighResolutionTimer}. The
+ * resolution is restored once the last holder releases.
+ *
+ * Every `timeBeginPeriod` must be matched by a `timeEndPeriod` with the *same*
+ * value, which is why the granted period is stored rather than re-derived.
+ */
+export function releaseHighResolutionTimer(): void {
+  if (!isWindows()) return;
+  if (activePeriodMs === null) return;
+
+  refCount--;
+  if (refCount > 0) return;
+
+  const period = activePeriodMs;
+  activePeriodMs = null;
+  refCount = 0;
+
+  try {
+    const result = winmm?.symbols.timeEndPeriod(period);
+    if (result !== undefined && result !== TIMERR_NOERROR) {
+      console.warn(`[TimerResolution] timeEndPeriod(${period}) failed with ${result}`);
+    } else {
+      console.log(`[TimerResolution] Restored default timer resolution`);
+    }
+  } catch (err) {
+    console.warn("[TimerResolution] Error restoring timer resolution:", err);
+  }
+}
+
+/** Period currently requested in ms, or `null` if we hold no request. */
+export function currentPeriodMs(): number | null {
+  return activePeriodMs;
+}
+
+/** Outstanding references. Exposed for tests and diagnostics. */
+export function timerResolutionRefCount(): number {
+  return refCount;
+}

--- a/test/telemetry-fidelity.test.ts
+++ b/test/telemetry-fidelity.test.ts
@@ -124,6 +124,31 @@ describe("telemetry fidelity vs MoTeC-rate logging", () => {
     expect(graphicsHz).toBeLessThan(45);
   });
 
+  test("poll spacing is one Windows timer tick, not the 10ms we ask for", () => {
+    // physicsPacketId is the *sim's* own counter, so it is an independent ruler
+    // for how far apart our polls actually landed — no wall clock needed.
+    const pid = allPackets
+      .map((p) => p.acc?.acEvo?.physicsPacketId)
+      .filter((v): v is number => typeof v === "number");
+    const deltas: number[] = [];
+    for (let i = 1; i < pid.length; i++) deltas.push(pid[i] - pid[i - 1]);
+
+    // The sim publishes physics far faster than we read it: ~336Hz.
+    const simHz = captureHz * mean(deltas);
+    expect(simHz).toBeGreaterThan(300);
+    expect(simHz).toBeLessThan(360);
+
+    // A genuine 10ms poll against a ~3ms sim tick would advance ~3.35 ticks per
+    // frame. We see ~5.29, i.e. ~15.8ms — the 15.625ms Windows tick plus
+    // callback cost. This is the whole of the 63.5-vs-100Hz gap.
+    expect(mean(deltas)).toBeGreaterThan(4.8);
+    expect(mean(deltas)).toBeLessThan(5.8);
+
+    const pollMs = (1000 * mean(deltas)) / simHz;
+    expect(pollMs).toBeGreaterThan(14.5);
+    expect(pollMs).toBeLessThan(17);
+  });
+
   describe("what survives decimation to 26.6Hz", () => {
     const apexErrors: number[] = [];
     const brakePeakLoss: number[] = [];

--- a/test/telemetry-fidelity.test.ts
+++ b/test/telemetry-fidelity.test.ts
@@ -89,25 +89,39 @@ describe("telemetry fidelity vs MoTeC-rate logging", () => {
     expect(captureHz).toBeGreaterThan(30);
   });
 
-  test("a third of emitted frames are duplicates, so our effective rate is ~39.5Hz", () => {
-    // The assembler emits on every poll with no gate on the physics page having
-    // advanced, so the same CurrentRaceTime is written repeatedly. This is the
-    // cheapest size win available (docs/telemetry-fidelity.md section 6) and the
-    // reason the honest headline rate is ~39.5Hz, not 63.5Hz.
-    const all = allPackets;
-    let duplicates = 0;
-    for (let i = 1; i < all.length; i++) {
-      if (all[i].CurrentRaceTime === all[i - 1].CurrentRaceTime) duplicates++;
+  // The two shared-memory pages advance at different rates in the sim, so
+  // "duplicate frame" is only meaningful per page. An earlier draft of this test
+  // measured CurrentRaceTime — which is derived from the *graphics* page — and
+  // mislabelled the result as stale physics. It is not: physics is fresh nearly
+  // every poll. See docs/telemetry-fidelity.md sections 1 and 6.
+  const pageRepeats = (key: "physicsPacketId" | "graphicsPacketId"): number => {
+    let repeats = 0;
+    for (let i = 1; i < allPackets.length; i++) {
+      if (allPackets[i].acc?.acEvo?.[key] === allPackets[i - 1].acc?.acEvo?.[key]) repeats++;
     }
-    const dupFraction = duplicates / all.length;
-    expect(dupFraction).toBeGreaterThan(0.3);
-    expect(dupFraction).toBeLessThan(0.45);
+    return repeats / allPackets.length;
+  };
 
-    // If someone adds the page-change gate, this test should fail loudly rather
-    // than the doc silently going stale.
-    const effectiveHz = captureHz * (1 - dupFraction);
-    expect(effectiveHz).toBeGreaterThan(35);
-    expect(effectiveHz).toBeLessThan(45);
+  test("the physics page is fresh on essentially every frame", () => {
+    // No physics sample we write is a stale copy, so our physics-channel rate is
+    // the full capture rate (~63.5Hz) — not a lower "effective" rate.
+    expect(pageRepeats("physicsPacketId")).toBeLessThan(0.01);
+  });
+
+  test("a third of frames re-read an unchanged graphics page", () => {
+    // The graphics page only advances at ~40Hz in the sim, so polling it at
+    // ~63.5Hz re-reads it ~37% of the time. Graphics is also the largest page in
+    // the triplet (3944 of 5000 bytes), which is what makes this the cheapest
+    // size win available (docs/telemetry-fidelity.md section 6).
+    const gfxRepeats = pageRepeats("graphicsPacketId");
+    expect(gfxRepeats).toBeGreaterThan(0.3);
+    expect(gfxRepeats).toBeLessThan(0.45);
+
+    // Graphics-derived channels (lap time, position, flags) therefore genuinely
+    // update at ~40Hz, not at the capture rate.
+    const graphicsHz = captureHz * (1 - gfxRepeats);
+    expect(graphicsHz).toBeGreaterThan(35);
+    expect(graphicsHz).toBeLessThan(45);
   });
 
   describe("what survives decimation to 26.6Hz", () => {

--- a/test/win-timer-resolution.test.ts
+++ b/test/win-timer-resolution.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Timer resolution control.
+ *
+ * CI and most dev boxes here are Linux, so the Windows path cannot be executed.
+ * What IS worth pinning on every platform: the module must be inert off Windows
+ * (no FFI load attempt, no throw, no refcount movement), and the refcount must
+ * not underflow on unbalanced release — an underflow would make a later
+ * acquire/release pair drop the resolution while a capture is still running.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  acquireHighResolutionTimer,
+  releaseHighResolutionTimer,
+  currentPeriodMs,
+  timerResolutionRefCount,
+} from "../server/games/shared/win-timer-resolution";
+
+const isWindows = process.platform === "win32";
+
+describe("win-timer-resolution", () => {
+  test.skipIf(isWindows)("is a no-op on non-Windows platforms", () => {
+    expect(acquireHighResolutionTimer()).toBeNull();
+    expect(currentPeriodMs()).toBeNull();
+    expect(timerResolutionRefCount()).toBe(0);
+
+    // Must not throw despite there being nothing to release.
+    releaseHighResolutionTimer();
+    expect(timerResolutionRefCount()).toBe(0);
+  });
+
+  test("release without acquire cannot drive the refcount negative", () => {
+    releaseHighResolutionTimer();
+    releaseHighResolutionTimer();
+    releaseHighResolutionTimer();
+    expect(timerResolutionRefCount()).toBeGreaterThanOrEqual(0);
+  });
+
+  test.skipIf(!isWindows)("nested acquires are refcounted and released as a pair", () => {
+    const first = acquireHighResolutionTimer();
+    expect(first).not.toBeNull();
+    expect(timerResolutionRefCount()).toBe(1);
+
+    // Second holder gets the same period, does not re-request it.
+    const second = acquireHighResolutionTimer();
+    expect(second).toBe(first);
+    expect(timerResolutionRefCount()).toBe(2);
+
+    // Resolution stays raised while any holder remains.
+    releaseHighResolutionTimer();
+    expect(timerResolutionRefCount()).toBe(1);
+    expect(currentPeriodMs()).toBe(first);
+
+    releaseHighResolutionTimer();
+    expect(timerResolutionRefCount()).toBe(0);
+    expect(currentPeriodMs()).toBeNull();
+  });
+
+  test.skipIf(!isWindows)("requested period is at or below the 15.625ms default tick", () => {
+    const period = acquireHighResolutionTimer();
+    try {
+      expect(period).not.toBeNull();
+      // The whole point: anything >= the default tick would be pointless.
+      expect(period!).toBeLessThan(15.625);
+      expect(period!).toBeGreaterThan(0);
+    } finally {
+      releaseHighResolutionTimer();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #132.

## Root cause

Windows' default system timer tick is 15.625ms (64Hz). Any `setInterval` shorter than a tick gets rounded up to it — libuv hands the loop's computed timeout to `GetQueuedCompletionStatus`, and that blocking wait is quantised to the tick. Neither Node nor Bun raises the resolution, and since Windows 10 2004 a process no longer inherits a raised resolution from another process on the machine; it has to ask for its own.

So the AC Evo / ACC capture chain asks for 300Hz (reader physics), 60Hz (reader graphics) and 100Hz (triplet assembler), and every one of them collapses to ~63.5Hz.

Measured from a committed session artifact using the sim's own `physicsPacketId`: it advances 5.291 ticks per stored frame against a 336Hz publisher, i.e. real poll spacing of 15.8ms. We were discarding 81% of available physics frames to a platform default.

## Fix

`server/games/shared/win-timer-resolution.ts` — `timeBeginPeriod` via `bun:ffi` on `winmm.dll`, clamped to the floor `timeGetDevCaps` reports. Both shared-memory readers acquire it before arming any capture interval and release it in `stop()`.

- **Refcounted**, so ACC and AC Evo running back to back don't fight over it, and a `stop()` without a matching `start()` can't underflow the count and drop the resolution out from under a live capture.
- **Scoped to an active capture**, not process lifetime — a raised resolution increases timer interrupt frequency and costs power.
- **Inert off Windows and on dlopen failure** — capture continues at the coarse tick rather than failing.

## What this is *not*

A drift-compensated scheduler doesn't help. Recomputing deadlines from an absolute origin removes accumulated drift, but it cannot make the OS wake the process before the next tick. Measured on Linux: 10.07ms → 10.00ms mean, granularity unchanged.

Fixing the assembler timer alone would also achieve nothing — it would just re-read buffers the reader hadn't refreshed.

## Caveats

**Not verified on Windows.** The tables in `docs/telemetry-fidelity.md` still characterise the pre-fix artifact. On Windows 11 an occluded or minimised window-owning process can have its request ignored; `currentPeriodMs()` reports what was *asked for*, not what was granted. Read the assembler's `pollIntervalMs` metrics (`ACC_METRICS=1`) to confirm on real hardware.

## Test plan

- `test/win-timer-resolution.test.ts` — refcount pairing, underflow guard, non-Windows no-op, clamping to the device floor.
- `bun run test` passes; pre-existing unrelated failures only.