### PR TITLE
fix(analyse): collapse AI lap analysis into summary row + modal

### DIFF
--- a/client/messages/de.json
+++ b/client/messages/de.json
@@ -441,6 +441,7 @@
   "aidisplay_best_guess": "Beste Vermutung",
   "aidisplay_setup_recommendations": "Setup-Empfehlungen",
   "aidisplay_close_setup": "Setup-Fenster schließen",
+  "aidisplay_no_tune_linked": "Kein Tune verknüpft — Werte werden aus der Telemetrie geschätzt. Verknüpfe einen Tune für genaue Setup-Vorschläge.",
   "aidisplay_regenerate": "Analyse neu generieren",
   "aidisplay_symptom": "Symptom:",
   "aidisplay_fix": "Lösung:",

--- a/client/messages/en.json
+++ b/client/messages/en.json
@@ -441,6 +441,7 @@
   "aidisplay_best_guess": "Best Guess",
   "aidisplay_setup_recommendations": "Setup Recommendations",
   "aidisplay_close_setup": "Close setup modal",
+  "aidisplay_no_tune_linked": "No tune data linked — values are estimated from telemetry. Link a tune for accurate setup suggestions.",
   "aidisplay_regenerate": "Regenerate analysis",
   "aidisplay_symptom": "Symptom:",
   "aidisplay_fix": "Fix:",

--- a/client/src/components/AiPanel.tsx
+++ b/client/src/components/AiPanel.tsx
@@ -410,7 +410,7 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
 
         {analysis && !loading && analysisOpen && (
           <AnalysisModalShell
-            subtitle={`${carName} · ${trackName}`}
+            subtitle={[carName, trackName].filter(Boolean).join(" · ") || undefined}
             onClose={() => setAnalysisOpen(false)}
             tabs={[
               { key: "analysis", label: m.label_ai_analysis() },

--- a/client/src/components/AiPanel.tsx
+++ b/client/src/components/AiPanel.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage } from "ai";
 import { toPng } from "html-to-image";
-import { Sparkles, Trash2 } from "lucide-react";
+import { Sparkles } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
 import { m } from "@/paraglide/messages";
 import { useSettings } from "../hooks/queries";
@@ -8,7 +8,7 @@ import { type ChatStreamError, type ChatStreamStatus, readChatStream } from "../
 import { isAiConfigured } from "../lib/is-ai-configured";
 import { client } from "../lib/rpc";
 import { useUiStore } from "../stores/ui";
-import { type AnalysisData, AnalysisDisplay, type AnalysisHighlight, findSegment, type Segment } from "./ai/analysis-display";
+import { type AnalysisData, AnalysisDisplay, type AnalysisHighlight, findSegment, type Segment, SetupList } from "./ai/analysis-display";
 import { AnalysisModalShell, AnalysisSummaryRow } from "./ai/analysis-summary";
 import { ChatPanel } from "./ai-chat/ChatPanel";
 import { Button } from "./ui/button";
@@ -105,6 +105,7 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
   const [analyseTool, setAnalyseTool] = useState<string | null>(null);
   const [chatRemountKey, setChatRemountKey] = useState(0);
   const [analysisOpen, setAnalysisOpen] = useState(false);
+  const [modalTab, setModalTab] = useState("analysis");
 
   useImperativeHandle(
     ref,
@@ -408,42 +409,48 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
         )}
 
         {analysis && !loading && analysisOpen && (
-          <AnalysisModalShell subtitle={`${carName} · ${trackName}`} onClose={() => setAnalysisOpen(false)}>
-            <AnalysisDisplay
-              analysis={analysis}
-              cornerFracs={cornerFracs}
-              segments={segments}
-              hasTune={hasTune}
-              usage={usage}
-              loading={loading}
-              containerRef={analysisRef}
-              onJumpToFrac={onJumpToFrac}
-              onHighlightsChange={onHighlightsChange}
-              onExport={handleExport}
-              onRegenerate={() => {
-                clearChat();
-                fetchAnalysis(true);
-              }}
-              onClear={() => {
-                clearChat();
-                setAnalysis(null);
-                setUsage(null);
-                setAnalysisOpen(false);
-                onHighlightsChange?.([]);
-              }}
-            />
-
-            {/* Clear-chat lives here rather than loose in the panel, where it
-                was an unlabelled bin floating under the summary row. */}
-            <div className="flex justify-end pt-2">
-              <button
-                type="button"
-                onClick={clearChat}
-                className="flex items-center gap-1 text-[10px] text-app-text-muted hover:text-red-400 px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
-              >
-                <Trash2 className="size-3" /> {m.compare_clear_chat()}
-              </button>
-            </div>
+          <AnalysisModalShell
+            subtitle={`${carName} · ${trackName}`}
+            onClose={() => setAnalysisOpen(false)}
+            tabs={[
+              { key: "analysis", label: m.label_ai_analysis() },
+              ...(analysis.setup?.length ? [{ key: "setup", label: m.aidisplay_setup(), badge: analysis.setup.length, flag: hasTune ? undefined : m.aidisplay_best_guess() }] : []),
+            ]}
+            activeTab={modalTab}
+            onTabChange={setModalTab}
+          >
+            {modalTab === "setup" ? (
+              <SetupList
+                setup={analysis.setup}
+                hasTune={hasTune}
+                lookupSegs={cornerFracs.length ? cornerFracs : (segments ?? null)}
+                onJumpToFrac={onJumpToFrac}
+                onHighlightsChange={onHighlightsChange}
+              />
+            ) : (
+              <AnalysisDisplay
+                analysis={analysis}
+                cornerFracs={cornerFracs}
+                segments={segments}
+                usage={usage}
+                loading={loading}
+                containerRef={analysisRef}
+                onJumpToFrac={onJumpToFrac}
+                onHighlightsChange={onHighlightsChange}
+                onExport={handleExport}
+                onRegenerate={() => {
+                  clearChat();
+                  fetchAnalysis(true);
+                }}
+                onClear={() => {
+                  clearChat();
+                  setAnalysis(null);
+                  setUsage(null);
+                  setAnalysisOpen(false);
+                  onHighlightsChange?.([]);
+                }}
+              />
+            )}
           </AnalysisModalShell>
         )}
       </div>

--- a/client/src/components/AiPanel.tsx
+++ b/client/src/components/AiPanel.tsx
@@ -322,8 +322,10 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      {/* Unified conversation */}
-      <div className="flex-1 overflow-y-auto min-h-0 px-3 py-3 space-y-2.5">
+      {/* Analysis area. Once the chat is mounted below it this shrinks to its
+          content — otherwise two flex-1 siblings would split the panel 50/50
+          and the collapsed row would sit on top of a tall empty box. */}
+      <div className={`overflow-y-auto px-3 py-3 space-y-2.5 ${analysis && !loading ? "shrink-0 max-h-[50%]" : "flex-1 min-h-0"}`}>
         {/* No AI provider configured */}
         {!aiConfigured && (
           <div className="flex flex-col items-center justify-center py-12 gap-3 text-center">

--- a/client/src/components/AiPanel.tsx
+++ b/client/src/components/AiPanel.tsx
@@ -1,7 +1,8 @@
 import type { UIMessage } from "ai";
 import { toPng } from "html-to-image";
-import { AlertTriangle, CircleDot, Download, Gauge, Lightbulb, RefreshCw, Sliders, Sparkles, Trash2, Zap } from "lucide-react";
+import { AlertTriangle, CircleDot, Download, Eye, Gauge, Lightbulb, RefreshCw, Sliders, Sparkles, Trash2, X, Zap } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { m } from "@/paraglide/messages";
 import { useSettings } from "../hooks/queries";
 import { type ChatStreamError, type ChatStreamStatus, readChatStream } from "../lib/chat-stream";
@@ -253,6 +254,7 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
   const [analyseStatus, setAnalyseStatus] = useState<ChatStreamStatus | null>(null);
   const [analyseTool, setAnalyseTool] = useState<string | null>(null);
   const [chatRemountKey, setChatRemountKey] = useState(0);
+  const [analysisOpen, setAnalysisOpen] = useState(false);
 
   useImperativeHandle(
     ref,
@@ -543,193 +545,243 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
           </div>
         )}
 
-        {/* Analysis as first assistant message (structured cards) */}
+        {/* Analysis collapses to a one-line summary row; the full breakdown
+            opens in a modal — same pattern as the compare panel, so the chat
+            gets the panel height instead of scrolling past the analysis. */}
         {analysis && !loading && (
-          <div ref={analysisRef} className="flex justify-start">
-            <div className="max-w-full rounded-lg px-2.5 py-2 bg-app-surface-alt/60 border border-app-border-input/40 text-app-text-secondary space-y-3">
-              {/* Verdict */}
-              <p className="text-[11px] text-app-text leading-relaxed">{analysis.verdict}</p>
-
-              {/* Pace */}
-              {analysis.pace?.length > 0 && (
-                <div>
-                  <SectionHeader icon={<Gauge className="size-3" />} title={m.label_pace()} />
-                  <div className="grid grid-cols-1 gap-1.5">
-                    {analysis.pace.map((item) => (
-                      <MetricCard key={item.label} item={item} />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Handling */}
-              {analysis.handling?.length > 0 && (
-                <div>
-                  <SectionHeader icon={<Sliders className="size-3" />} title={m.label_handling()} />
-                  <div className="grid grid-cols-1 gap-1.5">
-                    {analysis.handling.map((item) => (
-                      <MetricCard key={item.label} item={item} />
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Problem Corners */}
-              {analysis.corners?.length > 0 && (
-                <div>
-                  <SectionHeader icon={<AlertTriangle className="size-3" />} title={m.label_problem_corners()} />
-                  <div className="space-y-1.5">
-                    {analysis.corners.map((corner) => (
-                      <TrackCard
-                        key={corner.name}
-                        seg={findSegment(cornerFracs.length ? cornerFracs : segments, corner.name)}
-                        color={corner.severity === "major" ? "critical" : corner.severity === "moderate" ? "warning" : "good"}
-                        onJumpToFrac={onJumpToFrac}
-                        onHighlightsChange={onHighlightsChange}
-                        className="bg-app-surface-alt/40 border border-app-border-input/40 rounded-lg px-2.5 py-2"
-                      >
-                        <div className="flex items-center gap-1.5 mb-0.5">
-                          <span className={`size-1.5 rounded-full ${SEVERITY_COLORS[corner.severity]}`} />
-                          <span className="text-[11px] font-semibold text-app-text">{corner.name}</span>
-                        </div>
-                        <p className="text-[10px] text-app-text-secondary">{corner.issue}</p>
-                        <p className="text-[10px] text-emerald-400/80 mt-0.5">{corner.fix}</p>
-                      </TrackCard>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Braking per corner */}
-              {analysis.braking?.length > 0 && (
-                <div>
-                  <SectionHeader icon={<CircleDot className="size-3" />} title={m.label_braking_points()} />
-                  <div className="space-y-1.5">
-                    {analysis.braking.map((item) => (
-                      <TrackCard
-                        key={item.corner}
-                        seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.corner)}
-                        color={item.assessment}
-                        onJumpToFrac={onJumpToFrac}
-                        onHighlightsChange={onHighlightsChange}
-                        className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}
-                      >
-                        <div className="flex items-baseline justify-between gap-2">
-                          <span className="text-[11px] font-semibold text-app-text">{item.corner}</span>
-                          <span className={`text-[10px] font-mono ${ASSESSMENT_COLORS[item.assessment]}`}>{item.brakePoint}</span>
-                        </div>
-                        <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
-                      </TrackCard>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Throttle per corner */}
-              {analysis.throttle?.length > 0 && (
-                <div>
-                  <SectionHeader icon={<Zap className="size-3" />} title={m.label_throttle_application()} />
-                  <div className="space-y-1.5">
-                    {analysis.throttle.map((item) => (
-                      <TrackCard
-                        key={item.corner}
-                        seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.corner)}
-                        color={item.assessment}
-                        onJumpToFrac={onJumpToFrac}
-                        onHighlightsChange={onHighlightsChange}
-                        className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}
-                      >
-                        <div className="flex items-baseline justify-between gap-2">
-                          <span className="text-[11px] font-semibold text-app-text">{item.corner}</span>
-                          <span className={`text-[10px] font-mono ${ASSESSMENT_COLORS[item.assessment]}`}>{item.throttlePoint}</span>
-                        </div>
-                        <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
-                      </TrackCard>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Coaching */}
-              {analysis.coaching?.length > 0 && (
-                <div>
-                  <SectionHeader icon={<Lightbulb className="size-3" />} title={m.label_coaching()} />
-                  <div className="space-y-1.5">
-                    {analysis.coaching.map((item, i) => (
-                      <TrackCard
-                        key={item.tip}
-                        seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.tip, item.detail)}
-                        color="warning"
-                        onJumpToFrac={onJumpToFrac}
-                        onHighlightsChange={onHighlightsChange}
-                        className="flex gap-2"
-                      >
-                        <span className="text-amber-400/60 text-[10px] font-mono mt-0.5">{i + 1}.</span>
-                        <div>
-                          <span className="text-[11px] font-medium text-app-text">{item.tip}</span>
-                          <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
-                        </div>
-                      </TrackCard>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Setup — collapsed into a button; opens a modal. Shared with AnalysisDisplay. */}
-              {analysis.setup?.length > 0 && (
-                <SetupSection
-                  setup={analysis.setup}
-                  hasTune={hasTune}
-                  lookupSegs={cornerFracs.length ? cornerFracs : (segments ?? null)}
-                  onJumpToFrac={onJumpToFrac}
-                  onHighlightsChange={onHighlightsChange}
-                />
-              )}
-
-              {/* Actions bar */}
-              <div className="flex items-center gap-1.5 pt-1.5 border-t border-app-border-input/30">
-                {usage && (
-                  <span className="text-[9px] text-app-text-muted font-mono mr-auto">
-                    {usage.inputTokens.toLocaleString()}↓ {usage.outputTokens.toLocaleString()}↑ ${usage.costUsd.toFixed(4)} {(usage.durationMs / 1000).toFixed(1)}s
-                  </span>
-                )}
-                <button
-                  type="button"
-                  onClick={handleExport}
-                  className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
-                  title={m.label_export_as_image()}
-                >
-                  <Download className="size-3" /> {m.aipanel_export()}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    clearChat();
-                    fetchAnalysis(true);
-                  }}
-                  disabled={loading}
-                  className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors disabled:opacity-50"
-                  title={m.aipanel_regenerate_title()}
-                >
-                  <RefreshCw className="size-3" /> {m.label_regenerate()}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    clearChat();
-                    setAnalysis(null);
-                    setUsage(null);
-                    onHighlightsChange?.([]);
-                  }}
-                  className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-red-400 px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
-                  title={m.aipanel_clear_title()}
-                >
-                  <Trash2 className="size-3" /> {m.common_clear()}
-                </button>
+          <button
+            type="button"
+            onClick={() => setAnalysisOpen(true)}
+            className="w-full flex items-center gap-2 px-2 py-1.5 rounded bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors text-left"
+          >
+            <Sparkles className="size-3 text-emerald-400 shrink-0" />
+            <div className="flex-1 min-w-0">
+              <div className="text-[10px] font-semibold text-emerald-300 uppercase tracking-wider">{m.compare_analysis_complete()}</div>
+              <div className="text-[9px] text-app-text-muted font-mono">
+                {analysis.corners?.length ?? 0} corners · {analysis.coaching?.length ?? 0} tips · {analysis.setup?.length ?? 0} setup
               </div>
             </div>
-          </div>
+            <span className="flex items-center gap-1 text-[10px] text-app-text-secondary shrink-0">
+              <Eye className="size-3" /> {m.label_view()}
+            </span>
+          </button>
         )}
+
+        {analysis &&
+          !loading &&
+          analysisOpen &&
+          createPortal(
+            // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close
+            <div
+              className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+              onMouseDown={(e) => {
+                if (e.target === e.currentTarget) setAnalysisOpen(false);
+              }}
+            >
+              <div className="bg-app-surface border border-app-border rounded-lg shadow-xl w-[640px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden">
+                <div className="flex items-center justify-between px-4 py-3 border-b border-app-border shrink-0">
+                  <div className="flex items-center gap-2">
+                    <Sparkles className="size-3.5 text-amber-400" />
+                    <span className="text-[11px] font-semibold text-app-text uppercase tracking-wider">{m.label_ai_analysis()}</span>
+                    <span className="text-[11px] text-app-text-secondary truncate max-w-[300px]">
+                      {carName} · {trackName}
+                    </span>
+                  </div>
+                  <button type="button" onClick={() => setAnalysisOpen(false)} className="text-app-text-muted hover:text-app-text">
+                    <X className="size-4" />
+                  </button>
+                </div>
+                <div className="flex-1 overflow-y-auto px-4 py-3">
+                  <div ref={analysisRef} className="flex justify-start">
+                    <div className="max-w-full rounded-lg px-2.5 py-2 bg-app-surface-alt/60 border border-app-border-input/40 text-app-text-secondary space-y-3">
+                      {/* Verdict */}
+                      <p className="text-[11px] text-app-text leading-relaxed">{analysis.verdict}</p>
+
+                      {/* Pace */}
+                      {analysis.pace?.length > 0 && (
+                        <div>
+                          <SectionHeader icon={<Gauge className="size-3" />} title={m.label_pace()} />
+                          <div className="grid grid-cols-1 gap-1.5">
+                            {analysis.pace.map((item) => (
+                              <MetricCard key={item.label} item={item} />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Handling */}
+                      {analysis.handling?.length > 0 && (
+                        <div>
+                          <SectionHeader icon={<Sliders className="size-3" />} title={m.label_handling()} />
+                          <div className="grid grid-cols-1 gap-1.5">
+                            {analysis.handling.map((item) => (
+                              <MetricCard key={item.label} item={item} />
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Problem Corners */}
+                      {analysis.corners?.length > 0 && (
+                        <div>
+                          <SectionHeader icon={<AlertTriangle className="size-3" />} title={m.label_problem_corners()} />
+                          <div className="space-y-1.5">
+                            {analysis.corners.map((corner) => (
+                              <TrackCard
+                                key={corner.name}
+                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, corner.name)}
+                                color={corner.severity === "major" ? "critical" : corner.severity === "moderate" ? "warning" : "good"}
+                                onJumpToFrac={onJumpToFrac}
+                                onHighlightsChange={onHighlightsChange}
+                                className="bg-app-surface-alt/40 border border-app-border-input/40 rounded-lg px-2.5 py-2"
+                              >
+                                <div className="flex items-center gap-1.5 mb-0.5">
+                                  <span className={`size-1.5 rounded-full ${SEVERITY_COLORS[corner.severity]}`} />
+                                  <span className="text-[11px] font-semibold text-app-text">{corner.name}</span>
+                                </div>
+                                <p className="text-[10px] text-app-text-secondary">{corner.issue}</p>
+                                <p className="text-[10px] text-emerald-400/80 mt-0.5">{corner.fix}</p>
+                              </TrackCard>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Braking per corner */}
+                      {analysis.braking?.length > 0 && (
+                        <div>
+                          <SectionHeader icon={<CircleDot className="size-3" />} title={m.label_braking_points()} />
+                          <div className="space-y-1.5">
+                            {analysis.braking.map((item) => (
+                              <TrackCard
+                                key={item.corner}
+                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.corner)}
+                                color={item.assessment}
+                                onJumpToFrac={onJumpToFrac}
+                                onHighlightsChange={onHighlightsChange}
+                                className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}
+                              >
+                                <div className="flex items-baseline justify-between gap-2">
+                                  <span className="text-[11px] font-semibold text-app-text">{item.corner}</span>
+                                  <span className={`text-[10px] font-mono ${ASSESSMENT_COLORS[item.assessment]}`}>{item.brakePoint}</span>
+                                </div>
+                                <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
+                              </TrackCard>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Throttle per corner */}
+                      {analysis.throttle?.length > 0 && (
+                        <div>
+                          <SectionHeader icon={<Zap className="size-3" />} title={m.label_throttle_application()} />
+                          <div className="space-y-1.5">
+                            {analysis.throttle.map((item) => (
+                              <TrackCard
+                                key={item.corner}
+                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.corner)}
+                                color={item.assessment}
+                                onJumpToFrac={onJumpToFrac}
+                                onHighlightsChange={onHighlightsChange}
+                                className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}
+                              >
+                                <div className="flex items-baseline justify-between gap-2">
+                                  <span className="text-[11px] font-semibold text-app-text">{item.corner}</span>
+                                  <span className={`text-[10px] font-mono ${ASSESSMENT_COLORS[item.assessment]}`}>{item.throttlePoint}</span>
+                                </div>
+                                <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
+                              </TrackCard>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Coaching */}
+                      {analysis.coaching?.length > 0 && (
+                        <div>
+                          <SectionHeader icon={<Lightbulb className="size-3" />} title={m.label_coaching()} />
+                          <div className="space-y-1.5">
+                            {analysis.coaching.map((item, i) => (
+                              <TrackCard
+                                key={item.tip}
+                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.tip, item.detail)}
+                                color="warning"
+                                onJumpToFrac={onJumpToFrac}
+                                onHighlightsChange={onHighlightsChange}
+                                className="flex gap-2"
+                              >
+                                <span className="text-amber-400/60 text-[10px] font-mono mt-0.5">{i + 1}.</span>
+                                <div>
+                                  <span className="text-[11px] font-medium text-app-text">{item.tip}</span>
+                                  <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
+                                </div>
+                              </TrackCard>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Setup — collapsed into a button; opens a modal. Shared with AnalysisDisplay. */}
+                      {analysis.setup?.length > 0 && (
+                        <SetupSection
+                          setup={analysis.setup}
+                          hasTune={hasTune}
+                          lookupSegs={cornerFracs.length ? cornerFracs : (segments ?? null)}
+                          onJumpToFrac={onJumpToFrac}
+                          onHighlightsChange={onHighlightsChange}
+                        />
+                      )}
+
+                      {/* Actions bar */}
+                      <div className="flex items-center gap-1.5 pt-1.5 border-t border-app-border-input/30">
+                        {usage && (
+                          <span className="text-[9px] text-app-text-muted font-mono mr-auto">
+                            {usage.inputTokens.toLocaleString()}↓ {usage.outputTokens.toLocaleString()}↑ ${usage.costUsd.toFixed(4)} {(usage.durationMs / 1000).toFixed(1)}s
+                          </span>
+                        )}
+                        <button
+                          type="button"
+                          onClick={handleExport}
+                          className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
+                          title={m.label_export_as_image()}
+                        >
+                          <Download className="size-3" /> {m.aipanel_export()}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            clearChat();
+                            fetchAnalysis(true);
+                          }}
+                          disabled={loading}
+                          className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors disabled:opacity-50"
+                          title={m.aipanel_regenerate_title()}
+                        >
+                          <RefreshCw className="size-3" /> {m.label_regenerate()}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            clearChat();
+                            setAnalysis(null);
+                            setUsage(null);
+                            setAnalysisOpen(false);
+                            onHighlightsChange?.([]);
+                          }}
+                          className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-red-400 px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
+                          title={m.aipanel_clear_title()}
+                        >
+                          <Trash2 className="size-3" /> {m.common_clear()}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>,
+            document.body,
+          )}
 
         {/* Chat continues the conversation, below the analysis card. Only
             mounted once analysis exists (or chat has been used before) so

--- a/client/src/components/AiPanel.tsx
+++ b/client/src/components/AiPanel.tsx
@@ -1,15 +1,15 @@
 import type { UIMessage } from "ai";
 import { toPng } from "html-to-image";
-import { AlertTriangle, CircleDot, Download, Eye, Gauge, Lightbulb, RefreshCw, Sliders, Sparkles, Trash2, X, Zap } from "lucide-react";
+import { Sparkles, Trash2 } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { m } from "@/paraglide/messages";
 import { useSettings } from "../hooks/queries";
 import { type ChatStreamError, type ChatStreamStatus, readChatStream } from "../lib/chat-stream";
 import { isAiConfigured } from "../lib/is-ai-configured";
 import { client } from "../lib/rpc";
 import { useUiStore } from "../stores/ui";
-import { SetupSection } from "./ai/analysis-display";
+import { type AnalysisData, AnalysisDisplay, type AnalysisHighlight, findSegment, type Segment } from "./ai/analysis-display";
+import { AnalysisModalShell, AnalysisSummaryRow } from "./ai/analysis-summary";
 import { ChatPanel } from "./ai-chat/ChatPanel";
 import { Button } from "./ui/button";
 
@@ -56,12 +56,7 @@ function safeParseAnalysis(raw: string): unknown {
   }
 }
 
-export interface AnalysisHighlight {
-  startFrac: number;
-  endFrac: number;
-  color: "good" | "warning" | "critical";
-  label: string;
-}
+export type { AnalysisHighlight } from "./ai/analysis-display";
 
 interface AiPanelProps {
   lapId: number;
@@ -72,151 +67,6 @@ interface AiPanelProps {
   onJumpToFrac?: (frac: number) => void;
   onHighlightsChange?: (highlights: AnalysisHighlight[]) => void;
   panelOpen?: boolean;
-}
-
-// ── Analysis types ───────────────────────────────────────────
-
-interface PaceItem {
-  label: string;
-  value: string;
-  assessment: "good" | "warning" | "critical";
-  detail: string;
-}
-interface HandlingItem {
-  label: string;
-  value: string;
-  assessment: "good" | "warning" | "critical";
-  detail: string;
-}
-interface CornerItem {
-  name: string;
-  issue: string;
-  fix: string;
-  severity: "minor" | "moderate" | "major";
-}
-interface CornerBrakingItem {
-  corner: string;
-  assessment: "good" | "warning" | "critical";
-  brakePoint: string;
-  detail: string;
-}
-interface CornerThrottleItem {
-  corner: string;
-  assessment: "good" | "warning" | "critical";
-  throttlePoint: string;
-  detail: string;
-}
-interface CoachingItem {
-  tip: string;
-  detail: string;
-}
-interface SetupItem {
-  component: string;
-  symptom: string;
-  fix: string;
-  current: string;
-  target: string;
-  direction: "increase" | "decrease" | "adjust";
-}
-
-interface AnalysisData {
-  verdict: string;
-  pace: PaceItem[];
-  handling: HandlingItem[];
-  corners: CornerItem[];
-  braking: CornerBrakingItem[];
-  throttle: CornerThrottleItem[];
-  coaching: CoachingItem[];
-  setup: SetupItem[];
-}
-
-const ASSESSMENT_COLORS = { good: "text-emerald-400", warning: "text-amber-400", critical: "text-red-400" };
-const ASSESSMENT_BG = { good: "bg-emerald-400/10 border-emerald-400/20", warning: "bg-amber-400/10 border-amber-400/20", critical: "bg-red-400/10 border-red-400/20" };
-const SEVERITY_COLORS = { minor: "bg-app-text-dim", moderate: "bg-amber-500", major: "bg-red-500" };
-
-function MetricCard({ item }: { item: PaceItem | HandlingItem }) {
-  return (
-    <div className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}>
-      <div className="flex items-baseline justify-between gap-2">
-        <span className="text-[10px] text-app-text-secondary uppercase tracking-wide">{item.label}</span>
-        <span className={`text-[11px] font-mono font-semibold ${ASSESSMENT_COLORS[item.assessment]}`}>{item.value}</span>
-      </div>
-      <p className="text-[10px] text-app-text-secondary mt-0.5 leading-relaxed">{item.detail}</p>
-    </div>
-  );
-}
-
-type Segment = { type: string; name: string; startFrac: number; endFrac: number };
-
-/** Find a segment whose name matches any of the search strings. */
-function findSegment(segments: Segment[] | null | undefined, ...texts: string[]): Segment | null {
-  if (!segments || segments.length === 0) return null;
-  const combined = texts.join(" ").toLowerCase();
-  // Exact substring match first
-  for (const s of segments) {
-    const sn = s.name.toLowerCase();
-    if (combined.includes(sn) || sn.includes(combined)) return s;
-  }
-  // Word-level fuzzy: any word > 2 chars appears in segment name
-  const words = combined.split(/\s+/).filter((w) => w.length > 2);
-  for (const s of segments) {
-    const sn = s.name.toLowerCase();
-    if (words.some((w) => sn.includes(w))) return s;
-  }
-  return null;
-}
-
-/** Wrapper that makes a card clickable to highlight a track zone. */
-function TrackCard({
-  seg,
-  color,
-  onJumpToFrac,
-  onHighlightsChange,
-  className,
-  children,
-}: {
-  seg: Segment | null;
-  color: "good" | "warning" | "critical";
-  onJumpToFrac?: (frac: number) => void;
-  onHighlightsChange?: (h: AnalysisHighlight[]) => void;
-  className?: string;
-  children: React.ReactNode;
-}) {
-  const clickable = !!(seg && onJumpToFrac);
-  const activate = () => {
-    if (!seg) return;
-    onJumpToFrac?.((seg.startFrac + seg.endFrac) / 2);
-    onHighlightsChange?.([{ startFrac: seg.startFrac, endFrac: seg.endFrac, color, label: seg.name }]);
-  };
-  return (
-    <div
-      className={`${className ?? ""} ${clickable ? "cursor-pointer hover:brightness-110 transition" : ""}`}
-      {...(clickable
-        ? {
-            role: "button" as const,
-            tabIndex: 0,
-            onClick: activate,
-            onKeyDown: (e: React.KeyboardEvent) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                activate();
-              }
-            },
-          }
-        : {})}
-    >
-      {children}
-    </div>
-  );
-}
-
-function SectionHeader({ icon, title }: { icon: React.ReactNode; title: string }) {
-  return (
-    <div className="flex items-center gap-1.5 mb-2">
-      <span className="text-app-text-secondary">{icon}</span>
-      <h3 className="text-[10px] font-semibold text-app-text uppercase tracking-wider">{title}</h3>
-    </div>
-  );
 }
 
 async function fetchLapChatHistory(lapId: number, gen?: number): Promise<UIMessage[]> {
@@ -545,243 +395,43 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
           </div>
         )}
 
-        {/* Analysis collapses to a one-line summary row; the full breakdown
-            opens in a modal — same pattern as the compare panel, so the chat
-            gets the panel height instead of scrolling past the analysis. */}
+        {/* Analysis collapses to a summary row; the full breakdown opens in a
+            modal. Both pieces are the shared components the compare panel
+            uses, so the two pages stay in lockstep. */}
         {analysis && !loading && (
-          <button
-            type="button"
-            onClick={() => setAnalysisOpen(true)}
-            className="w-full flex items-center gap-2 px-2 py-1.5 rounded bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors text-left"
-          >
-            <Sparkles className="size-3 text-emerald-400 shrink-0" />
-            <div className="flex-1 min-w-0">
-              <div className="text-[10px] font-semibold text-emerald-300 uppercase tracking-wider">{m.compare_analysis_complete()}</div>
-              <div className="text-[9px] text-app-text-muted font-mono">
-                {analysis.corners?.length ?? 0} corners · {analysis.coaching?.length ?? 0} tips · {analysis.setup?.length ?? 0} setup
-              </div>
-            </div>
-            <span className="flex items-center gap-1 text-[10px] text-app-text-secondary shrink-0">
-              <Eye className="size-3" /> {m.label_view()}
-            </span>
-          </button>
+          <AnalysisSummaryRow
+            detail={`${analysis.corners?.length ?? 0} corners · ${analysis.coaching?.length ?? 0} tips · ${analysis.setup?.length ?? 0} setup`}
+            onView={() => setAnalysisOpen(true)}
+          />
         )}
 
-        {analysis &&
-          !loading &&
-          analysisOpen &&
-          createPortal(
-            // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close
-            <div
-              className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-              onMouseDown={(e) => {
-                if (e.target === e.currentTarget) setAnalysisOpen(false);
+        {analysis && !loading && analysisOpen && (
+          <AnalysisModalShell subtitle={`${carName} · ${trackName}`} onClose={() => setAnalysisOpen(false)}>
+            <AnalysisDisplay
+              analysis={analysis}
+              cornerFracs={cornerFracs}
+              segments={segments}
+              hasTune={hasTune}
+              usage={usage}
+              loading={loading}
+              containerRef={analysisRef}
+              onJumpToFrac={onJumpToFrac}
+              onHighlightsChange={onHighlightsChange}
+              onExport={handleExport}
+              onRegenerate={() => {
+                clearChat();
+                fetchAnalysis(true);
               }}
-            >
-              <div className="bg-app-surface border border-app-border rounded-lg shadow-xl w-[640px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden">
-                <div className="flex items-center justify-between px-4 py-3 border-b border-app-border shrink-0">
-                  <div className="flex items-center gap-2">
-                    <Sparkles className="size-3.5 text-amber-400" />
-                    <span className="text-[11px] font-semibold text-app-text uppercase tracking-wider">{m.label_ai_analysis()}</span>
-                    <span className="text-[11px] text-app-text-secondary truncate max-w-[300px]">
-                      {carName} · {trackName}
-                    </span>
-                  </div>
-                  <button type="button" onClick={() => setAnalysisOpen(false)} className="text-app-text-muted hover:text-app-text">
-                    <X className="size-4" />
-                  </button>
-                </div>
-                <div className="flex-1 overflow-y-auto px-4 py-3">
-                  <div ref={analysisRef} className="flex justify-start">
-                    <div className="max-w-full rounded-lg px-2.5 py-2 bg-app-surface-alt/60 border border-app-border-input/40 text-app-text-secondary space-y-3">
-                      {/* Verdict */}
-                      <p className="text-[11px] text-app-text leading-relaxed">{analysis.verdict}</p>
-
-                      {/* Pace */}
-                      {analysis.pace?.length > 0 && (
-                        <div>
-                          <SectionHeader icon={<Gauge className="size-3" />} title={m.label_pace()} />
-                          <div className="grid grid-cols-1 gap-1.5">
-                            {analysis.pace.map((item) => (
-                              <MetricCard key={item.label} item={item} />
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Handling */}
-                      {analysis.handling?.length > 0 && (
-                        <div>
-                          <SectionHeader icon={<Sliders className="size-3" />} title={m.label_handling()} />
-                          <div className="grid grid-cols-1 gap-1.5">
-                            {analysis.handling.map((item) => (
-                              <MetricCard key={item.label} item={item} />
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Problem Corners */}
-                      {analysis.corners?.length > 0 && (
-                        <div>
-                          <SectionHeader icon={<AlertTriangle className="size-3" />} title={m.label_problem_corners()} />
-                          <div className="space-y-1.5">
-                            {analysis.corners.map((corner) => (
-                              <TrackCard
-                                key={corner.name}
-                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, corner.name)}
-                                color={corner.severity === "major" ? "critical" : corner.severity === "moderate" ? "warning" : "good"}
-                                onJumpToFrac={onJumpToFrac}
-                                onHighlightsChange={onHighlightsChange}
-                                className="bg-app-surface-alt/40 border border-app-border-input/40 rounded-lg px-2.5 py-2"
-                              >
-                                <div className="flex items-center gap-1.5 mb-0.5">
-                                  <span className={`size-1.5 rounded-full ${SEVERITY_COLORS[corner.severity]}`} />
-                                  <span className="text-[11px] font-semibold text-app-text">{corner.name}</span>
-                                </div>
-                                <p className="text-[10px] text-app-text-secondary">{corner.issue}</p>
-                                <p className="text-[10px] text-emerald-400/80 mt-0.5">{corner.fix}</p>
-                              </TrackCard>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Braking per corner */}
-                      {analysis.braking?.length > 0 && (
-                        <div>
-                          <SectionHeader icon={<CircleDot className="size-3" />} title={m.label_braking_points()} />
-                          <div className="space-y-1.5">
-                            {analysis.braking.map((item) => (
-                              <TrackCard
-                                key={item.corner}
-                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.corner)}
-                                color={item.assessment}
-                                onJumpToFrac={onJumpToFrac}
-                                onHighlightsChange={onHighlightsChange}
-                                className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}
-                              >
-                                <div className="flex items-baseline justify-between gap-2">
-                                  <span className="text-[11px] font-semibold text-app-text">{item.corner}</span>
-                                  <span className={`text-[10px] font-mono ${ASSESSMENT_COLORS[item.assessment]}`}>{item.brakePoint}</span>
-                                </div>
-                                <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
-                              </TrackCard>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Throttle per corner */}
-                      {analysis.throttle?.length > 0 && (
-                        <div>
-                          <SectionHeader icon={<Zap className="size-3" />} title={m.label_throttle_application()} />
-                          <div className="space-y-1.5">
-                            {analysis.throttle.map((item) => (
-                              <TrackCard
-                                key={item.corner}
-                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.corner)}
-                                color={item.assessment}
-                                onJumpToFrac={onJumpToFrac}
-                                onHighlightsChange={onHighlightsChange}
-                                className={`rounded-lg border px-2.5 py-1.5 ${ASSESSMENT_BG[item.assessment]}`}
-                              >
-                                <div className="flex items-baseline justify-between gap-2">
-                                  <span className="text-[11px] font-semibold text-app-text">{item.corner}</span>
-                                  <span className={`text-[10px] font-mono ${ASSESSMENT_COLORS[item.assessment]}`}>{item.throttlePoint}</span>
-                                </div>
-                                <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
-                              </TrackCard>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Coaching */}
-                      {analysis.coaching?.length > 0 && (
-                        <div>
-                          <SectionHeader icon={<Lightbulb className="size-3" />} title={m.label_coaching()} />
-                          <div className="space-y-1.5">
-                            {analysis.coaching.map((item, i) => (
-                              <TrackCard
-                                key={item.tip}
-                                seg={findSegment(cornerFracs.length ? cornerFracs : segments, item.tip, item.detail)}
-                                color="warning"
-                                onJumpToFrac={onJumpToFrac}
-                                onHighlightsChange={onHighlightsChange}
-                                className="flex gap-2"
-                              >
-                                <span className="text-amber-400/60 text-[10px] font-mono mt-0.5">{i + 1}.</span>
-                                <div>
-                                  <span className="text-[11px] font-medium text-app-text">{item.tip}</span>
-                                  <p className="text-[10px] text-app-text-secondary mt-0.5">{item.detail}</p>
-                                </div>
-                              </TrackCard>
-                            ))}
-                          </div>
-                        </div>
-                      )}
-
-                      {/* Setup — collapsed into a button; opens a modal. Shared with AnalysisDisplay. */}
-                      {analysis.setup?.length > 0 && (
-                        <SetupSection
-                          setup={analysis.setup}
-                          hasTune={hasTune}
-                          lookupSegs={cornerFracs.length ? cornerFracs : (segments ?? null)}
-                          onJumpToFrac={onJumpToFrac}
-                          onHighlightsChange={onHighlightsChange}
-                        />
-                      )}
-
-                      {/* Actions bar */}
-                      <div className="flex items-center gap-1.5 pt-1.5 border-t border-app-border-input/30">
-                        {usage && (
-                          <span className="text-[9px] text-app-text-muted font-mono mr-auto">
-                            {usage.inputTokens.toLocaleString()}↓ {usage.outputTokens.toLocaleString()}↑ ${usage.costUsd.toFixed(4)} {(usage.durationMs / 1000).toFixed(1)}s
-                          </span>
-                        )}
-                        <button
-                          type="button"
-                          onClick={handleExport}
-                          className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
-                          title={m.label_export_as_image()}
-                        >
-                          <Download className="size-3" /> {m.aipanel_export()}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            clearChat();
-                            fetchAnalysis(true);
-                          }}
-                          disabled={loading}
-                          className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors disabled:opacity-50"
-                          title={m.aipanel_regenerate_title()}
-                        >
-                          <RefreshCw className="size-3" /> {m.label_regenerate()}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            clearChat();
-                            setAnalysis(null);
-                            setUsage(null);
-                            setAnalysisOpen(false);
-                            onHighlightsChange?.([]);
-                          }}
-                          className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-red-400 px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
-                          title={m.aipanel_clear_title()}
-                        >
-                          <Trash2 className="size-3" /> {m.common_clear()}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>,
-            document.body,
-          )}
+              onClear={() => {
+                clearChat();
+                setAnalysis(null);
+                setUsage(null);
+                setAnalysisOpen(false);
+                onHighlightsChange?.([]);
+              }}
+            />
+          </AnalysisModalShell>
+        )}
 
         {/* Chat continues the conversation, below the analysis card. Only
             mounted once analysis exists (or chat has been used before) so

--- a/client/src/components/AiPanel.tsx
+++ b/client/src/components/AiPanel.tsx
@@ -432,19 +432,19 @@ export const AiPanel = forwardRef<AiPanelHandle, AiPanelProps>(function AiPanel(
                 onHighlightsChange?.([]);
               }}
             />
-          </AnalysisModalShell>
-        )}
 
-        {/* Chat continues the conversation, below the analysis card. Only
-            mounted once analysis exists (or chat has been used before) so
-            the panel doesn't show an empty composer with nothing to discuss
-            yet — matches the old gating behaviour. */}
-        {!loading && analysis && (
-          <div className="flex justify-end -mb-1">
-            <button type="button" onClick={clearChat} className="text-[9px] text-app-text-muted hover:text-red-400 transition-colors">
-              <Trash2 className="size-3" />
-            </button>
-          </div>
+            {/* Clear-chat lives here rather than loose in the panel, where it
+                was an unlabelled bin floating under the summary row. */}
+            <div className="flex justify-end pt-2">
+              <button
+                type="button"
+                onClick={clearChat}
+                className="flex items-center gap-1 text-[10px] text-app-text-muted hover:text-red-400 px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
+              >
+                <Trash2 className="size-3" /> {m.compare_clear_chat()}
+              </button>
+            </div>
+          </AnalysisModalShell>
         )}
       </div>
 

--- a/client/src/components/ai/analysis-display.tsx
+++ b/client/src/components/ai/analysis-display.tsx
@@ -1,5 +1,5 @@
-import { AlertTriangle, ChevronRight, CircleDot, Download, Gauge, Lightbulb, RefreshCw, Sliders, Sparkles, Trash2, Wrench, X, Zap } from "lucide-react";
-import { type ReactNode, useRef, useState } from "react";
+import { AlertTriangle, CircleDot, Download, Gauge, Lightbulb, RefreshCw, Sliders, Sparkles, Trash2, Zap } from "lucide-react";
+import { type ReactNode, useRef } from "react";
 import { m } from "@/paraglide/messages";
 
 export interface AnalysisHighlight {
@@ -222,14 +222,27 @@ export function TrackCard({
   children: ReactNode;
 }) {
   const clickable = !!(seg && onJumpToFrac);
+  const activate = () => {
+    if (!seg) return;
+    onJumpToFrac?.((seg.startFrac + seg.endFrac) / 2);
+    onHighlightsChange?.([{ startFrac: seg.startFrac, endFrac: seg.endFrac, color, label: seg.name }]);
+  };
   return (
     <div
       className={`${className ?? ""} ${clickable ? "cursor-pointer hover:brightness-110 transition" : ""}`}
-      onClick={() => {
-        if (!seg) return;
-        onJumpToFrac?.((seg.startFrac + seg.endFrac) / 2);
-        onHighlightsChange?.([{ startFrac: seg.startFrac, endFrac: seg.endFrac, color, label: seg.name }]);
-      }}
+      {...(clickable
+        ? {
+            role: "button" as const,
+            tabIndex: 0,
+            onClick: activate,
+            onKeyDown: (e: React.KeyboardEvent) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                activate();
+              }
+            },
+          }
+        : {})}
     >
       {children}
     </div>
@@ -246,12 +259,11 @@ export function SectionHeader({ icon, title }: { icon: ReactNode; title: string 
 }
 
 /**
- * Setup recommendations collapse into a single button so the analysis panel
- * stays scannable when the model returns 10+ entries. Clicking opens a
- * fixed-overlay modal that renders the full grid — same TrackCard + TuneBar
- * content as before, with a close button.
+ * The setup recommendations themselves — just the list. Hosts decide where it
+ * lives; the analysis modal renders it as a tab rather than stacking a second
+ * modal on top of itself.
  */
-export function SetupSection({
+export function SetupList({
   setup,
   hasTune,
   lookupSegs,
@@ -264,97 +276,57 @@ export function SetupSection({
   onJumpToFrac?: (frac: number) => void;
   onHighlightsChange?: (h: AnalysisHighlight[]) => void;
 }) {
-  const [open, setOpen] = useState(false);
   return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className="w-full flex items-center gap-2 rounded-lg border border-app-border-input/60 bg-app-surface-alt/40 hover:border-app-border-input hover:bg-app-surface-alt/70 transition-colors px-3 py-2 text-left"
-      >
-        <Wrench className="size-3.5 text-app-text-secondary" />
-        <span className="text-[11px] font-semibold text-app-text uppercase tracking-wider">{m.aidisplay_setup()}</span>
-        <span className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-app-border-input/30 text-app-text-secondary">{setup.length}</span>
-        {!hasTune && (
-          <span className="text-[8px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-400/15 text-amber-400 border border-amber-400/20">{m.aidisplay_best_guess()}</span>
-        )}
-        <ChevronRight className="ml-auto size-3.5 text-app-text-muted" />
-      </button>
-
-      {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={() => setOpen(false)}>
-          <div className="relative w-full max-w-2xl max-h-[85vh] bg-app-surface border border-app-border-input rounded-lg shadow-xl flex flex-col" onClick={(e) => e.stopPropagation()}>
-            <div className="flex items-center gap-2 px-4 py-3 border-b border-app-border-input/50 rounded-t-lg shrink-0">
-              <Wrench className="size-4 text-app-text-secondary" />
-              <h2 className="text-sm font-semibold text-app-text">{m.aidisplay_setup_recommendations()}</h2>
-              <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-app-border-input/30 text-app-text-secondary">{setup.length}</span>
-              {!hasTune && (
-                <span className="text-[9px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-400/15 text-amber-400 border border-amber-400/20">{m.aidisplay_best_guess()}</span>
-              )}
-              <button
-                type="button"
-                onClick={() => setOpen(false)}
-                className="ml-auto p-1 rounded hover:bg-app-border-input/30 text-app-text-muted hover:text-app-text"
-                aria-label={m.aidisplay_close_setup()}
-              >
-                <X className="size-4" />
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto px-4 py-3 space-y-2">
-              {!hasTune && <p className="text-[10px] text-amber-400/70 leading-snug">No tune data linked — values are estimated from telemetry. Link a tune for accurate setup suggestions.</p>}
-              {setup.map((item, i) => {
-                const extractNum = (s?: string) => {
-                  const m = s?.match(/-?\d+\.?\d*/);
-                  return m ? parseFloat(m[0]) : NaN;
-                };
-                const currentNum = extractNum(item.current);
-                const targetNum = extractNum(item.target);
-                const hasBoth = !isNaN(currentNum) && !isNaN(targetNum) && currentNum !== targetNum;
-                return (
-                  <TrackCard
-                    key={i}
-                    seg={findSegment(lookupSegs, item.symptom, item.fix)}
-                    color="warning"
-                    onJumpToFrac={onJumpToFrac}
-                    onHighlightsChange={onHighlightsChange}
-                    className="bg-app-surface-alt/40 border border-app-border-input/40 rounded-lg px-3 py-2.5"
-                  >
-                    <span className="text-[12px] font-semibold text-app-text block mb-1">{item.component}</span>
-                    <span
-                      className={`text-[10px] font-mono px-1.5 py-0.5 rounded ${
-                        item.direction === "increase" ? "bg-emerald-400/10 text-emerald-400" : item.direction === "decrease" ? "bg-red-400/10 text-red-400" : "bg-amber-400/10 text-amber-400"
-                      }`}
-                    >
-                      {item.current} → {item.target}
-                    </span>
-                    {hasBoth && <TuneBar current={currentNum} target={targetNum} component={item.component} />}
-                    <p className="text-[11px] text-app-text-secondary mt-1.5">
-                      <span className="text-red-400/70">{m.aidisplay_symptom()}</span> {item.symptom}
-                    </p>
-                    <p className="text-[11px] text-app-text-secondary mt-0.5">
-                      <span className="text-emerald-400/70">{m.aidisplay_fix()}</span> {item.fix}
-                    </p>
-                  </TrackCard>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      )}
-    </>
+    <div className="space-y-2">
+      {!hasTune && <p className="text-[10px] text-amber-400/70 leading-snug">{m.aidisplay_no_tune_linked()}</p>}
+      {setup.map((item) => {
+        const extractNum = (s?: string) => {
+          const match = s?.match(/-?\d+\.?\d*/);
+          return match ? parseFloat(match[0]) : NaN;
+        };
+        const currentNum = extractNum(item.current);
+        const targetNum = extractNum(item.target);
+        const hasBoth = !Number.isNaN(currentNum) && !Number.isNaN(targetNum) && currentNum !== targetNum;
+        return (
+          <TrackCard
+            key={`${item.component}-${item.symptom}`}
+            seg={findSegment(lookupSegs, item.symptom, item.fix)}
+            color="warning"
+            onJumpToFrac={onJumpToFrac}
+            onHighlightsChange={onHighlightsChange}
+            className="bg-app-surface-alt/40 border border-app-border-input/40 rounded-lg px-3 py-2.5"
+          >
+            <span className="text-[12px] font-semibold text-app-text block mb-1">{item.component}</span>
+            <span
+              className={`text-[10px] font-mono px-1.5 py-0.5 rounded ${
+                item.direction === "increase" ? "bg-emerald-400/10 text-emerald-400" : item.direction === "decrease" ? "bg-red-400/10 text-red-400" : "bg-amber-400/10 text-amber-400"
+              }`}
+            >
+              {item.current} → {item.target}
+            </span>
+            {hasBoth && <TuneBar current={currentNum} target={targetNum} component={item.component} />}
+            <p className="text-[11px] text-app-text-secondary mt-1.5">
+              <span className="text-red-400/70">{m.aidisplay_symptom()}</span> {item.symptom}
+            </p>
+            <p className="text-[11px] text-app-text-secondary mt-0.5">
+              <span className="text-emerald-400/70">{m.aidisplay_fix()}</span> {item.fix}
+            </p>
+          </TrackCard>
+        );
+      })}
+    </div>
   );
 }
 
 /**
- * Renders the structured analysis cards (verdict, pace, handling, corners, braking,
- * throttle, coaching, setup) plus an optional actions bar. Used by the analyse-view
- * AiPanel and the compare-view analysis modal.
+ * Renders the structured analysis cards (verdict, pace, handling, corners,
+ * braking, throttle, coaching) plus an optional actions bar. Setup is not
+ * included — it is a sibling tab in the analysis modal, rendered by SetupList.
  */
 export function AnalysisDisplay({
   analysis,
   cornerFracs,
   segments,
-  hasTune,
   usage,
   onJumpToFrac,
   onHighlightsChange,
@@ -367,7 +339,6 @@ export function AnalysisDisplay({
   analysis: AnalysisData;
   cornerFracs?: Segment[];
   segments?: Segment[] | null;
-  hasTune?: boolean;
   usage?: AnalysisUsage | null;
   onJumpToFrac?: (frac: number) => void;
   onHighlightsChange?: (h: AnalysisHighlight[]) => void;
@@ -391,8 +362,8 @@ export function AnalysisDisplay({
         <div>
           <SectionHeader icon={<Gauge className="size-3" />} title={m.label_pace()} />
           <div className="grid grid-cols-1 gap-1.5">
-            {analysis.pace.map((item, i) => (
-              <MetricCard key={i} item={item} />
+            {analysis.pace.map((item) => (
+              <MetricCard key={item.label} item={item} />
             ))}
           </div>
         </div>
@@ -403,8 +374,8 @@ export function AnalysisDisplay({
         <div>
           <SectionHeader icon={<Sliders className="size-3" />} title={m.label_handling()} />
           <div className="grid grid-cols-1 gap-1.5">
-            {analysis.handling.map((item, i) => (
-              <MetricCard key={i} item={item} />
+            {analysis.handling.map((item) => (
+              <MetricCard key={item.label} item={item} />
             ))}
           </div>
         </div>
@@ -415,9 +386,9 @@ export function AnalysisDisplay({
         <div>
           <SectionHeader icon={<AlertTriangle className="size-3" />} title={m.label_problem_corners()} />
           <div className="space-y-1.5">
-            {analysis.corners.map((corner, i) => (
+            {analysis.corners.map((corner) => (
               <TrackCard
-                key={i}
+                key={corner.name}
                 seg={findSegment(lookupSegs, corner.name)}
                 color={corner.severity === "major" ? "critical" : corner.severity === "moderate" ? "warning" : "good"}
                 onJumpToFrac={onJumpToFrac}
@@ -441,9 +412,9 @@ export function AnalysisDisplay({
         <div>
           <SectionHeader icon={<CircleDot className="size-3" />} title={m.label_braking_points()} />
           <div className="space-y-1.5">
-            {analysis.braking.map((item, i) => (
+            {analysis.braking.map((item) => (
               <TrackCard
-                key={i}
+                key={item.corner}
                 seg={findSegment(lookupSegs, item.corner)}
                 color={item.assessment}
                 onJumpToFrac={onJumpToFrac}
@@ -466,9 +437,9 @@ export function AnalysisDisplay({
         <div>
           <SectionHeader icon={<Zap className="size-3" />} title={m.label_throttle_application()} />
           <div className="space-y-1.5">
-            {analysis.throttle.map((item, i) => (
+            {analysis.throttle.map((item) => (
               <TrackCard
-                key={i}
+                key={item.corner}
                 seg={findSegment(lookupSegs, item.corner)}
                 color={item.assessment}
                 onJumpToFrac={onJumpToFrac}
@@ -492,7 +463,7 @@ export function AnalysisDisplay({
           <SectionHeader icon={<Lightbulb className="size-3" />} title={m.label_coaching()} />
           <div className="space-y-1.5">
             {analysis.coaching.map((item, i) => (
-              <TrackCard key={i} seg={findSegment(lookupSegs, item.tip, item.detail)} color="warning" onJumpToFrac={onJumpToFrac} onHighlightsChange={onHighlightsChange} className="flex gap-2">
+              <TrackCard key={item.tip} seg={findSegment(lookupSegs, item.tip, item.detail)} color="warning" onJumpToFrac={onJumpToFrac} onHighlightsChange={onHighlightsChange} className="flex gap-2">
                 <span className="text-amber-400/60 text-[10px] font-mono mt-0.5">{i + 1}.</span>
                 <div>
                   <span className="text-[11px] font-medium text-app-text">{item.tip}</span>
@@ -504,8 +475,7 @@ export function AnalysisDisplay({
         </div>
       )}
 
-      {/* Setup — compact button, details in a modal */}
-      {analysis.setup?.length > 0 && <SetupSection setup={analysis.setup} hasTune={hasTune} lookupSegs={lookupSegs} onJumpToFrac={onJumpToFrac} onHighlightsChange={onHighlightsChange} />}
+      {/* Setup lives in its own tab alongside this card — see AnalysisModalShell. */}
 
       {/* Actions bar */}
       {(usage || onExport || onRegenerate || onClear) && (
@@ -517,6 +487,7 @@ export function AnalysisDisplay({
           )}
           {onExport && (
             <button
+              type="button"
               onClick={onExport}
               className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
               title={m.label_export_as_image()}
@@ -526,6 +497,7 @@ export function AnalysisDisplay({
           )}
           {onRegenerate && (
             <button
+              type="button"
               onClick={onRegenerate}
               disabled={loading}
               className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-app-text px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors disabled:opacity-50"
@@ -536,6 +508,7 @@ export function AnalysisDisplay({
           )}
           {onClear && (
             <button
+              type="button"
               onClick={onClear}
               className="flex items-center gap-1 text-[9px] text-app-text-muted hover:text-red-400 px-1.5 py-0.5 rounded border border-transparent hover:border-app-border-input transition-colors"
               title={m.aipanel_clear_title()}

--- a/client/src/components/ai/analysis-summary.tsx
+++ b/client/src/components/ai/analysis-summary.tsx
@@ -1,0 +1,60 @@
+import { Eye, Sparkles, X } from "lucide-react";
+import type { ReactNode } from "react";
+import { createPortal } from "react-dom";
+import { m } from "@/paraglide/messages";
+
+/**
+ * Collapsed representation of a finished analysis: one row with a headline and
+ * a counts line, click to open the full breakdown. Shared by the compare panel
+ * (one row per lap, plus the inputs comparison) and the analyse panel (one row
+ * for the lap being analysed) so both pages collapse the same way.
+ */
+export function AnalysisSummaryRow({ title, detail, onView }: { title?: string; detail: string; onView: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onView}
+      className="w-full flex items-center gap-2 px-2 py-1.5 rounded bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors text-left"
+    >
+      <Sparkles className="size-3 text-emerald-400 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="text-[10px] font-semibold text-emerald-300 uppercase tracking-wider">{title ?? m.compare_analysis_complete()}</div>
+        <div className="text-[9px] text-app-text-muted font-mono">{detail}</div>
+      </div>
+      <span className="flex items-center gap-1 text-[10px] text-app-text-secondary shrink-0">
+        <Eye className="size-3" /> {m.label_view()}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Portal modal chrome for whatever an AnalysisSummaryRow opens — backdrop
+ * click-to-close, header with title and optional subtitle, scrollable body.
+ */
+export function AnalysisModalShell({ subtitle, onClose, children }: { subtitle?: string; onClose: () => void; children: ReactNode }) {
+  return createPortal(
+    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-app-surface border border-app-border rounded-lg shadow-xl w-[640px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden">
+        <div className="flex items-center justify-between px-4 py-3 border-b border-app-border shrink-0">
+          <div className="flex items-center gap-2 min-w-0">
+            <Sparkles className="size-3.5 text-amber-400" />
+            <span className="text-[11px] font-semibold text-app-text uppercase tracking-wider shrink-0">{m.label_ai_analysis()}</span>
+            {subtitle && <span className="text-[11px] text-app-text-secondary truncate">{subtitle}</span>}
+          </div>
+          <button type="button" onClick={onClose} className="text-app-text-muted hover:text-app-text shrink-0">
+            <X className="size-4" />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto px-4 py-3">{children}</div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/client/src/components/ai/analysis-summary.tsx
+++ b/client/src/components/ai/analysis-summary.tsx
@@ -28,11 +28,36 @@ export function AnalysisSummaryRow({ title, detail, onView }: { title?: string; 
   );
 }
 
+export interface AnalysisModalTab {
+  key: string;
+  label: string;
+  /** Small count pill after the label, e.g. the number of setup entries. */
+  badge?: number;
+  /** Amber "best guess" style flag, used when no tune is linked. */
+  flag?: string;
+}
+
 /**
  * Portal modal chrome for whatever an AnalysisSummaryRow opens — backdrop
  * click-to-close, header with title and optional subtitle, scrollable body.
+ * Optional tabs switch the body between sections (analysis / setup) instead of
+ * stacking a second modal on top of this one.
  */
-export function AnalysisModalShell({ subtitle, onClose, children }: { subtitle?: string; onClose: () => void; children: ReactNode }) {
+export function AnalysisModalShell({
+  subtitle,
+  onClose,
+  tabs,
+  activeTab,
+  onTabChange,
+  children,
+}: {
+  subtitle?: string;
+  onClose: () => void;
+  tabs?: AnalysisModalTab[];
+  activeTab?: string;
+  onTabChange?: (key: string) => void;
+  children: ReactNode;
+}) {
   return createPortal(
     // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close
     <div
@@ -52,6 +77,27 @@ export function AnalysisModalShell({ subtitle, onClose, children }: { subtitle?:
             <X className="size-4" />
           </button>
         </div>
+        {tabs && tabs.length > 1 && (
+          <div className="flex items-center gap-1 px-3 pt-2 border-b border-app-border shrink-0">
+            {tabs.map((tab) => {
+              const active = tab.key === activeTab;
+              return (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => onTabChange?.(tab.key)}
+                  className={`flex items-center gap-1.5 px-3 py-1.5 -mb-px border-b-2 text-[11px] font-semibold uppercase tracking-wider transition-colors ${
+                    active ? "border-amber-400 text-app-text" : "border-transparent text-app-text-muted hover:text-app-text-secondary"
+                  }`}
+                >
+                  {tab.label}
+                  {tab.badge !== undefined && <span className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-app-border-input/30 text-app-text-secondary">{tab.badge}</span>}
+                  {tab.flag && <span className="text-[8px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-400/15 text-amber-400 border border-amber-400/20">{tab.flag}</span>}
+                </button>
+              );
+            })}
+          </div>
+        )}
         <div className="flex-1 overflow-y-auto px-4 py-3">{children}</div>
       </div>
     </div>,

--- a/client/src/components/ai/analysis-summary.tsx
+++ b/client/src/components/ai/analysis-summary.tsx
@@ -67,37 +67,35 @@ export function AnalysisModalShell({
       }}
     >
       <div className="bg-app-surface border border-app-border rounded-lg shadow-xl w-[640px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-app-border shrink-0">
-          <div className="flex items-center gap-2 min-w-0">
-            <Sparkles className="size-3.5 text-amber-400" />
-            <span className="text-[11px] font-semibold text-app-text uppercase tracking-wider shrink-0">{m.label_ai_analysis()}</span>
-            {subtitle && <span className="text-[11px] text-app-text-secondary truncate">{subtitle}</span>}
-          </div>
-          <button type="button" onClick={onClose} className="text-app-text-muted hover:text-app-text shrink-0">
+        {/* One header row: the tabs are the title. With a single section the
+            active tab reads as a plain heading, so there is no second copy of
+            "AI Analysis" below it. */}
+        <div className="flex items-center gap-2 px-4 py-2.5 border-b border-app-border shrink-0">
+          <Sparkles className="size-3.5 text-amber-400 shrink-0" />
+          {(tabs?.length ? tabs : [{ key: "__title", label: m.label_ai_analysis() } as AnalysisModalTab]).map((tab) => {
+            const active = !tabs?.length || tab.key === activeTab;
+            const interactive = (tabs?.length ?? 0) > 1;
+            return (
+              <button
+                key={tab.key}
+                type="button"
+                disabled={!interactive}
+                onClick={() => onTabChange?.(tab.key)}
+                className={`flex items-center gap-1.5 rounded px-2 py-1 text-[11px] font-semibold uppercase tracking-wider transition-colors ${
+                  active ? "text-app-text" : "text-app-text-muted hover:text-app-text-secondary"
+                } ${interactive ? (active ? "bg-app-border-input/30" : "hover:bg-app-border-input/20") : "px-0"}`}
+              >
+                {tab.label}
+                {tab.badge !== undefined && <span className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-app-border-input/30 text-app-text-secondary">{tab.badge}</span>}
+                {tab.flag && <span className="text-[8px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-400/15 text-amber-400 border border-amber-400/20">{tab.flag}</span>}
+              </button>
+            );
+          })}
+          {subtitle && <span className="text-[11px] text-app-text-secondary truncate ml-2">{subtitle}</span>}
+          <button type="button" onClick={onClose} className="ml-auto pl-2 text-app-text-muted hover:text-app-text shrink-0">
             <X className="size-4" />
           </button>
         </div>
-        {tabs && tabs.length > 1 && (
-          <div className="flex items-center gap-1 px-3 pt-2 border-b border-app-border shrink-0">
-            {tabs.map((tab) => {
-              const active = tab.key === activeTab;
-              return (
-                <button
-                  key={tab.key}
-                  type="button"
-                  onClick={() => onTabChange?.(tab.key)}
-                  className={`flex items-center gap-1.5 px-3 py-1.5 -mb-px border-b-2 text-[11px] font-semibold uppercase tracking-wider transition-colors ${
-                    active ? "border-amber-400 text-app-text" : "border-transparent text-app-text-muted hover:text-app-text-secondary"
-                  }`}
-                >
-                  {tab.label}
-                  {tab.badge !== undefined && <span className="text-[9px] font-mono px-1.5 py-0.5 rounded bg-app-border-input/30 text-app-text-secondary">{tab.badge}</span>}
-                  {tab.flag && <span className="text-[8px] font-semibold uppercase tracking-wider px-1.5 py-0.5 rounded bg-amber-400/15 text-amber-400 border border-amber-400/20">{tab.flag}</span>}
-                </button>
-              );
-            })}
-          </div>
-        )}
         <div className="flex-1 overflow-y-auto px-4 py-3">{children}</div>
       </div>
     </div>,

--- a/client/src/components/comparison/CompareAiPanel.tsx
+++ b/client/src/components/comparison/CompareAiPanel.tsx
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import { Eye, RefreshCw, Sparkles, Trash2, X } from "lucide-react";
+import { RefreshCw, Sparkles, Trash2, X } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import { createPortal } from "react-dom";
 import { useSettings } from "../../hooks/queries";
@@ -8,6 +8,7 @@ import { client } from "../../lib/rpc";
 import { m } from "../../paraglide/messages";
 import { useUiStore } from "../../stores/ui";
 import { type AnalysisData, AnalysisDisplay } from "../ai/analysis-display";
+import { AnalysisModalShell, AnalysisSummaryRow } from "../ai/analysis-summary";
 import { ChatPanel } from "../ai-chat/ChatPanel";
 import { Button } from "../ui/button";
 
@@ -239,22 +240,7 @@ function InputsSection({ lapAId, lapBId, panelOpen, onView }: { lapAId: number; 
       )}
 
       {analysis && (
-        <button
-          type="button"
-          onClick={() => onView(analysis)}
-          className="w-full flex items-center gap-2 px-2 py-1.5 rounded bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors text-left"
-        >
-          <Sparkles className="size-3 text-emerald-400 shrink-0" />
-          <div className="flex-1 min-w-0">
-            <div className="text-[10px] font-semibold text-emerald-300 uppercase tracking-wider">{m.compare_inputs_analysed()}</div>
-            <div className="text-[9px] text-app-text-muted font-mono">
-              {analysis.segments?.length ?? 0} segments · {analysis.coaching?.length ?? 0} tips
-            </div>
-          </div>
-          <span className="flex items-center gap-1 text-[10px] text-app-text-secondary shrink-0">
-            <Eye className="size-3" /> {m.label_view()}
-          </span>
-        </button>
+        <AnalysisSummaryRow title={m.compare_inputs_analysed()} detail={`${analysis.segments?.length ?? 0} segments · ${analysis.coaching?.length ?? 0} tips`} onView={() => onView(analysis)} />
       )}
     </div>
   );
@@ -318,24 +304,7 @@ function LapSection({
         </div>
       )}
 
-      {summary && (
-        <button
-          type="button"
-          onClick={() => onView(lap.label, summary)}
-          className="w-full flex items-center gap-2 px-2 py-1.5 rounded bg-emerald-500/10 border border-emerald-500/30 hover:bg-emerald-500/15 transition-colors text-left"
-        >
-          <Sparkles className="size-3 text-emerald-400 shrink-0" />
-          <div className="flex-1 min-w-0">
-            <div className="text-[10px] font-semibold text-emerald-300 uppercase tracking-wider">{m.compare_analysis_complete()}</div>
-            <div className="text-[9px] text-app-text-muted font-mono">
-              {summary.cornerCount} corners · {summary.coachingCount} tips · {summary.setupCount} setup
-            </div>
-          </div>
-          <span className="flex items-center gap-1 text-[10px] text-app-text-secondary shrink-0">
-            <Eye className="size-3" /> {m.label_view()}
-          </span>
-        </button>
-      )}
+      {summary && <AnalysisSummaryRow detail={`${summary.cornerCount} corners · ${summary.coachingCount} tips · ${summary.setupCount} setup`} onView={() => onView(lap.label, summary)} />}
     </div>
   );
 }
@@ -461,31 +430,10 @@ function InputsModal({
 
 function AnalysisModal({ label, summary, onClose }: { label: string; summary: AnalysisSummary; onClose: () => void }) {
   const a = summary.raw ?? {};
-  return createPortal(
-    // biome-ignore lint/a11y/noStaticElementInteractions: backdrop click-to-close
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
-      }}
-    >
-      <div className="bg-app-surface border border-app-border rounded-lg shadow-xl w-[640px] max-w-[95vw] max-h-[85vh] flex flex-col overflow-hidden">
-        <div className="flex items-center justify-between px-4 py-3 border-b border-app-border shrink-0">
-          <div className="flex items-center gap-2">
-            <Sparkles className="size-3.5 text-amber-400" />
-            <span className="text-[11px] font-semibold text-app-text uppercase tracking-wider">{m.label_ai_analysis()}</span>
-            <span className="text-[11px] text-app-text-secondary truncate max-w-[300px]">{label}</span>
-          </div>
-          <button type="button" onClick={onClose} className="text-app-text-muted hover:text-app-text">
-            <X className="size-4" />
-          </button>
-        </div>
-        <div className="flex-1 overflow-y-auto px-4 py-3">
-          <AnalysisDisplay analysis={a as AnalysisData} />
-        </div>
-      </div>
-    </div>,
-    document.body,
+  return (
+    <AnalysisModalShell subtitle={label} onClose={onClose}>
+      <AnalysisDisplay analysis={a as AnalysisData} />
+    </AnalysisModalShell>
   );
 }
 

--- a/client/src/components/comparison/CompareAiPanel.tsx
+++ b/client/src/components/comparison/CompareAiPanel.tsx
@@ -7,7 +7,7 @@ import { isAiConfigured } from "../../lib/is-ai-configured";
 import { client } from "../../lib/rpc";
 import { m } from "../../paraglide/messages";
 import { useUiStore } from "../../stores/ui";
-import { type AnalysisData, AnalysisDisplay } from "../ai/analysis-display";
+import { type AnalysisData, AnalysisDisplay, SetupList } from "../ai/analysis-display";
 import { AnalysisModalShell, AnalysisSummaryRow } from "../ai/analysis-summary";
 import { ChatPanel } from "../ai-chat/ChatPanel";
 import { Button } from "../ui/button";
@@ -429,10 +429,18 @@ function InputsModal({
 }
 
 function AnalysisModal({ label, summary, onClose }: { label: string; summary: AnalysisSummary; onClose: () => void }) {
-  const a = summary.raw ?? {};
+  const a = (summary.raw ?? {}) as AnalysisData;
+  const [tab, setTab] = useState("analysis");
+  const setup = a.setup ?? [];
   return (
-    <AnalysisModalShell subtitle={label} onClose={onClose}>
-      <AnalysisDisplay analysis={a as AnalysisData} />
+    <AnalysisModalShell
+      subtitle={label}
+      onClose={onClose}
+      tabs={[{ key: "analysis", label: m.label_ai_analysis() }, ...(setup.length ? [{ key: "setup", label: m.aidisplay_setup(), badge: setup.length }] : [])]}
+      activeTab={tab}
+      onTabChange={setTab}
+    >
+      {tab === "setup" ? <SetupList setup={setup} lookupSegs={null} /> : <AnalysisDisplay analysis={a} />}
     </AnalysisModalShell>
   );
 }

--- a/client/src/stories/AiAnalysis.stories.tsx
+++ b/client/src/stories/AiAnalysis.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
-import { type AnalysisData, AnalysisDisplay, type Segment } from "../components/ai/analysis-display";
+import { type AnalysisData, AnalysisDisplay, type Segment, SetupList } from "../components/ai/analysis-display";
 import { AnalysisModalShell, AnalysisSummaryRow } from "../components/ai/analysis-summary";
 
 // Fixed, deterministic analysis for a Forza lap at Spa. Covers every section
@@ -98,34 +98,57 @@ export const SummaryRowCustomTitle: StoryObj = {
   ),
 };
 
-/** The full breakdown, as rendered inside the modal body. */
+/** The analysis tab body, as rendered inside the modal. */
 export const Display: StoryObj = {
   render: () => (
     <div className="w-[600px]">
-      <AnalysisDisplay analysis={analysis} segments={segments} hasTune usage={usage} onJumpToFrac={() => {}} onExport={() => {}} onRegenerate={() => {}} onClear={() => {}} />
+      <AnalysisDisplay analysis={analysis} segments={segments} usage={usage} onJumpToFrac={() => {}} onExport={() => {}} onRegenerate={() => {}} onClear={() => {}} />
     </div>
   ),
 };
 
-/** Analysis with no linked tune — setup values are flagged as best-guess. */
-export const DisplayWithoutTune: StoryObj = {
+/** The setup tab body, with a linked tune. */
+export const SetupTab: StoryObj = {
   render: () => (
     <div className="w-[600px]">
-      <AnalysisDisplay analysis={analysis} segments={segments} usage={usage} onJumpToFrac={() => {}} />
+      <SetupList setup={analysis.setup} hasTune lookupSegs={segments} onJumpToFrac={() => {}} />
     </div>
   ),
 };
 
-/** Row plus modal wired together — click through the collapsed state. */
+/** Setup with no linked tune — values are estimated, so the note shows. */
+export const SetupTabWithoutTune: StoryObj = {
+  render: () => (
+    <div className="w-[600px]">
+      <SetupList setup={analysis.setup} lookupSegs={segments} onJumpToFrac={() => {}} />
+    </div>
+  ),
+};
+
+/** Row plus the tabbed modal — click View, then switch between the tabs. */
 export const RowOpensModal: StoryObj = {
   render: () => {
     const [open, setOpen] = useState(true);
+    const [tab, setTab] = useState("analysis");
     return (
       <SidebarFrame>
         <AnalysisSummaryRow detail={`${analysis.corners.length} corners · ${analysis.coaching.length} tips · ${analysis.setup.length} setup`} onView={() => setOpen(true)} />
         {open && (
-          <AnalysisModalShell subtitle="Porsche 911 GT3 R · Spa-Francorchamps" onClose={() => setOpen(false)}>
-            <AnalysisDisplay analysis={analysis} segments={segments} hasTune usage={usage} onJumpToFrac={() => {}} onExport={() => {}} onRegenerate={() => {}} onClear={() => setOpen(false)} />
+          <AnalysisModalShell
+            subtitle="Porsche 911 GT3 R · Spa-Francorchamps"
+            onClose={() => setOpen(false)}
+            tabs={[
+              { key: "analysis", label: "AI Analysis" },
+              { key: "setup", label: "Setup", badge: analysis.setup.length },
+            ]}
+            activeTab={tab}
+            onTabChange={setTab}
+          >
+            {tab === "setup" ? (
+              <SetupList setup={analysis.setup} hasTune lookupSegs={segments} onJumpToFrac={() => {}} />
+            ) : (
+              <AnalysisDisplay analysis={analysis} segments={segments} usage={usage} onJumpToFrac={() => {}} onExport={() => {}} onRegenerate={() => {}} onClear={() => setOpen(false)} />
+            )}
           </AnalysisModalShell>
         )}
       </SidebarFrame>

--- a/client/src/stories/AiAnalysis.stories.tsx
+++ b/client/src/stories/AiAnalysis.stories.tsx
@@ -1,0 +1,134 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { type AnalysisData, AnalysisDisplay, type Segment } from "../components/ai/analysis-display";
+import { AnalysisModalShell, AnalysisSummaryRow } from "../components/ai/analysis-summary";
+
+// Fixed, deterministic analysis for a Forza lap at Spa. Covers every section
+// AnalysisDisplay renders (pace, handling, problem corners, braking, throttle,
+// coaching, setup) plus the usage/actions bar, so the stories exercise the
+// full card rather than a happy-path subset.
+const analysis: AnalysisData = {
+  verdict: "Strong sector 1, but you're losing roughly 0.9s through the middle sector — mostly late throttle out of the slow corners and an over-slow entry into Les Combes.",
+  pace: [
+    { label: "Top speed", value: "287 km/h", assessment: "good", detail: "Reached on the Kemmel straight, in line with the car's potential." },
+    { label: "Min corner speed", value: "78 km/h", assessment: "warning", detail: "La Source is 6 km/h slower than your best lap on this setup." },
+    { label: "Sector 2 delta", value: "+0.91s", assessment: "critical", detail: "Almost all the lap deficit lives between Les Combes and Stavelot." },
+  ],
+  handling: [
+    { label: "Entry balance", value: "Understeer", assessment: "warning", detail: "Front washes wide on turn-in at Les Combes and Rivage." },
+    { label: "Exit traction", value: "Stable", assessment: "good", detail: "No meaningful wheelspin on corner exit — throttle can come in earlier." },
+  ],
+  corners: [
+    { name: "La Source", issue: "Braking 12 m too early, then coasting to the apex.", fix: "Carry the brake deeper and release progressively into the apex.", severity: "major" },
+    { name: "Les Combes", issue: "Entry speed 9 km/h low, so the car is never loaded on turn-in.", fix: "Trail brake to the apex instead of braking in a straight line.", severity: "moderate" },
+    { name: "Stavelot", issue: "Small lift mid-corner unsettles the rear.", fix: "Hold a steady 40% throttle through the middle of the corner.", severity: "minor" },
+  ],
+  braking: [
+    { corner: "La Source", assessment: "critical", brakePoint: "-12 m", detail: "Earliest brake point of the lap; costs 0.31s on its own." },
+    { corner: "Les Combes", assessment: "warning", brakePoint: "-4 m", detail: "Slightly early, and the release is abrupt." },
+    { corner: "Bus Stop", assessment: "good", brakePoint: "+1 m", detail: "Well judged — repeatable across all laps in the session." },
+  ],
+  throttle: [
+    { corner: "La Source", assessment: "warning", throttlePoint: "+0.4s", detail: "Full throttle arrives late onto the Kemmel straight." },
+    { corner: "Pouhon", assessment: "good", throttlePoint: "-0.1s", detail: "Confident, progressive application through the double-left." },
+  ],
+  coaching: [
+    { tip: "Brake later into La Source", detail: "Move the brake point 10 m later and keep the car rolling to the apex." },
+    { tip: "Trail brake into Les Combes", detail: "Carrying brake pressure to the apex keeps the front loaded and kills the understeer." },
+    { tip: "Commit through Stavelot", detail: "Hold a steady throttle rather than lifting — the rear is stable enough." },
+  ],
+  setup: [
+    { component: "Front anti-roll bar", symptom: "Entry understeer at Les Combes and Rivage", fix: "Soften the front bar", current: "28.5", target: "24.0", direction: "decrease" },
+    { component: "Rear wing", symptom: "Low top speed on Kemmel", fix: "Trim rear downforce", current: "8", target: "6", direction: "decrease" },
+    { component: "Front tyre pressure", symptom: "Front tyres over temperature after three laps", fix: "Drop cold pressure", current: "2.05", target: "1.95", direction: "decrease" },
+  ],
+};
+
+// Named segments let the TrackCards resolve to a lap fraction, so cards render
+// in their clickable state exactly as they do in the app.
+const segments: Segment[] = [
+  { type: "corner", name: "La Source", startFrac: 0.01, endFrac: 0.05 },
+  { type: "corner", name: "Les Combes", startFrac: 0.28, endFrac: 0.34 },
+  { type: "corner", name: "Rivage", startFrac: 0.4, endFrac: 0.44 },
+  { type: "corner", name: "Pouhon", startFrac: 0.55, endFrac: 0.6 },
+  { type: "corner", name: "Stavelot", startFrac: 0.68, endFrac: 0.72 },
+  { type: "corner", name: "Bus Stop", startFrac: 0.93, endFrac: 0.97 },
+];
+
+const usage = { inputTokens: 18432, outputTokens: 1204, costUsd: 0.0631, durationMs: 8420, model: "claude-sonnet-5" };
+
+/** Sidebar-width frame — the AI panel is a fixed 22rem column in the app. */
+function SidebarFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="w-[22rem] border border-app-border bg-app-surface/50 p-3" style={{ background: "var(--app-bg)" }}>
+      {children}
+    </div>
+  );
+}
+
+const meta: Meta = {
+  title: "AI/Analysis",
+  parameters: { layout: "centered" },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: "2rem", background: "var(--app-bg)", minHeight: "100vh" }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+/** Collapsed state: what the analyse and compare panels show by default. */
+export const SummaryRow: StoryObj = {
+  render: () => (
+    <SidebarFrame>
+      <AnalysisSummaryRow detail={`${analysis.corners.length} corners · ${analysis.coaching.length} tips · ${analysis.setup.length} setup`} onView={() => {}} />
+    </SidebarFrame>
+  ),
+};
+
+/** Same row with a custom headline — the compare panel's inputs comparison. */
+export const SummaryRowCustomTitle: StoryObj = {
+  render: () => (
+    <SidebarFrame>
+      <AnalysisSummaryRow title="Inputs analysed" detail="14 segments · 3 tips" onView={() => {}} />
+    </SidebarFrame>
+  ),
+};
+
+/** The full breakdown, as rendered inside the modal body. */
+export const Display: StoryObj = {
+  render: () => (
+    <div className="w-[600px]">
+      <AnalysisDisplay analysis={analysis} segments={segments} hasTune usage={usage} onJumpToFrac={() => {}} onExport={() => {}} onRegenerate={() => {}} onClear={() => {}} />
+    </div>
+  ),
+};
+
+/** Analysis with no linked tune — setup values are flagged as best-guess. */
+export const DisplayWithoutTune: StoryObj = {
+  render: () => (
+    <div className="w-[600px]">
+      <AnalysisDisplay analysis={analysis} segments={segments} usage={usage} onJumpToFrac={() => {}} />
+    </div>
+  ),
+};
+
+/** Row plus modal wired together — click through the collapsed state. */
+export const RowOpensModal: StoryObj = {
+  render: () => {
+    const [open, setOpen] = useState(true);
+    return (
+      <SidebarFrame>
+        <AnalysisSummaryRow detail={`${analysis.corners.length} corners · ${analysis.coaching.length} tips · ${analysis.setup.length} setup`} onView={() => setOpen(true)} />
+        {open && (
+          <AnalysisModalShell subtitle="Porsche 911 GT3 R · Spa-Francorchamps" onClose={() => setOpen(false)}>
+            <AnalysisDisplay analysis={analysis} segments={segments} hasTune usage={usage} onJumpToFrac={() => {}} onExport={() => {}} onRegenerate={() => {}} onClear={() => setOpen(false)} />
+          </AnalysisModalShell>
+        )}
+      </SidebarFrame>
+    );
+  },
+};


### PR DESCRIPTION
## Problem

On the analyse page (`/fm23/analyse?track=...&car=...&lap=...`), the AI sidebar rendered the whole structured lap analysis inline above the chat. With a long analysis (pace + handling + corners + braking + throttle + coaching + setup) the chat composer ends up far down the scroll — the panel is effectively an analysis dump with a chat hidden underneath.

The compare page already solved this: a one-line summary row per lap, full breakdown in a modal. The analyse panel just never got it, and it also carried its own copy of markup `AnalysisDisplay` already renders.

## Change

Analyse now behaves exactly like compare, using the *same* components rather than a second copy:

- New `client/src/components/ai/analysis-summary.tsx` — `AnalysisSummaryRow` (headline + counts + View) and `AnalysisModalShell` (portal, backdrop click-to-close, header, scrollable body).
- `AiPanel` renders the row, and the modal wraps the existing shared `AnalysisDisplay`. Its ~250 lines of duplicated section markup, plus local `MetricCard` / `TrackCard` / `SectionHeader` / `findSegment` / assessment constants / analysis interfaces, are deleted in favour of `ai/analysis-display`.
- `CompareAiPanel` drops its inline row markup (lap rows and the inputs row) and its bespoke modal chrome, using the two shared components instead.

Net: -397 / +107 lines in `client/src`.

Behaviour inside the modal is unchanged — clickable TrackCards that jump the track map, setup modal, export-as-image, regenerate, clear, token/cost usage line. Clearing also closes the modal.

## Test

- `cd client && bun run build` — passes (tsc + vite)
- `biome check` on all touched files — clean
- lefthook pre-commit lint + typecheck — passes

Generated with [Claude Code](https://claude.com/claude-code)