### PR TITLE
fix: merge server and game connection status into single header status (#152)

### DIFF
--- a/client/src/components/ConnectionStatus.tsx
+++ b/client/src/components/ConnectionStatus.tsx
@@ -24,20 +24,33 @@ export function ConnectionStatus({ connected, packetsPerSec, forzaReceiving }: P
 
   // Localize the display text here (connection-status-logic stays pure/testable).
   // gameLabel is the game's display name (proper noun) — kept verbatim.
-  const serverText = view.serverLabel === "Server" ? m.status_server() : m.status_disconnected();
-  const gameText = forzaReceiving ? (view.gameLabel ?? m.status_receiving()) : view.gameLabel ? `${view.gameLabel} — ${m.status_waiting()}` : m.status_no_signal();
+  let statusText: string;
+  switch (view.statusKind) {
+    case "disconnected":
+      statusText = m.status_disconnected();
+      break;
+    case "server":
+      statusText = m.status_server();
+      break;
+    case "receiving":
+      statusText = view.gameLabel ?? m.status_receiving();
+      break;
+    case "waiting":
+      statusText = view.gameLabel ? `${view.gameLabel} — ${m.status_waiting()}` : m.status_waiting();
+      break;
+  }
 
   return (
-    <div className="flex items-center gap-4 px-4 self-stretch bg-app-surface">
-      <div className="flex items-center gap-2 w-28 shrink-0">
-        <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${connected ? DOT_CLASS.green : DOT_CLASS.red}`} />
-        <span className="text-sm font-medium text-app-text whitespace-nowrap">{serverText}</span>
-      </div>
+    <div className="flex items-center gap-3 px-4 self-stretch bg-app-surface">
       <div className="flex items-center gap-2 shrink-0">
         <div className={`w-2.5 h-2.5 rounded-full shrink-0 ${DOT_CLASS[view.dotColor]}`} />
-        <span className="text-sm font-medium text-app-text whitespace-nowrap">{gameText}</span>
+        <span className="text-sm font-medium text-app-text whitespace-nowrap">{statusText}</span>
       </div>
-      <span className="text-sm text-app-text-muted font-mono tabular-nums whitespace-nowrap shrink-0">{forzaReceiving ? `${packetsPerSec} pkt/s · ${displaySettings.wsRefreshRate ?? 60}Hz` : ""}</span>
+      {forzaReceiving && (
+        <span className="text-sm text-app-text-muted font-mono tabular-nums whitespace-nowrap shrink-0">
+          {packetsPerSec} pkt/s · {displaySettings.wsRefreshRate ?? 60}Hz
+        </span>
+      )}
     </div>
   );
 }

--- a/client/src/components/connection-status-logic.ts
+++ b/client/src/components/connection-status-logic.ts
@@ -14,6 +14,7 @@ export interface ConnectionStatusView {
   gameLabel: string | null;
   gameText: string;
   dotColor: "green" | "red" | "cyan" | "amber" | "dim";
+  statusKind: "disconnected" | "server" | "waiting" | "receiving";
 }
 
 export function deriveConnectionStatusView(inputs: ConnectionStatusInputs): ConnectionStatusView {
@@ -21,24 +22,41 @@ export function deriveConnectionStatusView(inputs: ConnectionStatusInputs): Conn
 
   const gameLabel = detectedGame?.name ?? null;
 
-  let gameText: string;
-  if (forzaReceiving) {
-    gameText = gameLabel ?? "Receiving";
-  } else if (gameLabel) {
-    gameText = `${gameLabel} — Waiting`;
-  } else {
-    gameText = "No Signal";
+  if (!connected) {
+    return {
+      serverLabel: "Disconnected",
+      gameLabel: null,
+      gameText: "Disconnected",
+      dotColor: "red",
+      statusKind: "disconnected",
+    };
   }
 
-  let dotColor: ConnectionStatusView["dotColor"];
-  if (forzaReceiving) dotColor = "cyan";
-  else if (gameLabel) dotColor = "amber";
-  else dotColor = "dim";
+  if (forzaReceiving) {
+    return {
+      serverLabel: "Server",
+      gameLabel,
+      gameText: gameLabel ?? "Receiving",
+      dotColor: "cyan",
+      statusKind: "receiving",
+    };
+  }
+
+  if (gameLabel) {
+    return {
+      serverLabel: "Server",
+      gameLabel,
+      gameText: `${gameLabel} — Waiting`,
+      dotColor: "amber",
+      statusKind: "waiting",
+    };
+  }
 
   return {
-    serverLabel: connected ? "Server" : "Disconnected",
-    gameLabel,
-    gameText,
-    dotColor,
+    serverLabel: "Server",
+    gameLabel: null,
+    gameText: "Server",
+    dotColor: "green",
+    statusKind: "server",
   };
 }

--- a/test/connection-status-logic.test.ts
+++ b/test/connection-status-logic.test.ts
@@ -4,28 +4,32 @@ import { deriveConnectionStatusView } from "../client/src/components/connection-
 const F1 = { id: "f1-2025", name: "F1 25" } as const;
 const FORZA = { id: "fm-2023", name: "Forza Motorsport" } as const;
 
-describe("deriveConnectionStatusView — server label", () => {
-  test("shows 'Server' when connected", () => {
-    const view = deriveConnectionStatusView({ connected: true, forzaReceiving: false, detectedGame: null });
-    expect(view.serverLabel).toBe("Server");
-  });
-
-  test("shows 'Disconnected' when not connected", () => {
+describe("deriveConnectionStatusView — merged connection status", () => {
+  test("shows 'Disconnected' / red when server is not connected", () => {
     const view = deriveConnectionStatusView({ connected: false, forzaReceiving: false, detectedGame: null });
-    expect(view.serverLabel).toBe("Disconnected");
+    expect(view.statusKind).toBe("disconnected");
+    expect(view.gameText).toBe("Disconnected");
+    expect(view.dotColor).toBe("red");
   });
-});
 
-describe("deriveConnectionStatusView — game text", () => {
-  test("no game detected, no packets → 'No Signal' / dim", () => {
+  test("server disconnected overrides cached game detection", () => {
+    const view = deriveConnectionStatusView({ connected: false, forzaReceiving: false, detectedGame: F1 });
+    expect(view.statusKind).toBe("disconnected");
+    expect(view.gameText).toBe("Disconnected");
+    expect(view.dotColor).toBe("red");
+  });
+
+  test("server connected, no game detected → base 'Server' / green", () => {
     const view = deriveConnectionStatusView({ connected: true, forzaReceiving: false, detectedGame: null });
-    expect(view.gameText).toBe("No Signal");
+    expect(view.statusKind).toBe("server");
+    expect(view.gameText).toBe("Server");
     expect(view.gameLabel).toBeNull();
-    expect(view.dotColor).toBe("dim");
+    expect(view.dotColor).toBe("green");
   });
 
   test("game detected but not receiving → '<name> — Waiting' / amber", () => {
     const view = deriveConnectionStatusView({ connected: true, forzaReceiving: false, detectedGame: F1 });
+    expect(view.statusKind).toBe("waiting");
     expect(view.gameText).toBe("F1 25 — Waiting");
     expect(view.gameLabel).toBe("F1 25");
     expect(view.dotColor).toBe("amber");
@@ -33,6 +37,7 @@ describe("deriveConnectionStatusView — game text", () => {
 
   test("game detected AND receiving telemetry → '<name>' / cyan", () => {
     const view = deriveConnectionStatusView({ connected: true, forzaReceiving: true, detectedGame: FORZA });
+    expect(view.statusKind).toBe("receiving");
     expect(view.gameText).toBe("Forza Motorsport");
     expect(view.gameLabel).toBe("Forza Motorsport");
     expect(view.dotColor).toBe("cyan");
@@ -40,6 +45,7 @@ describe("deriveConnectionStatusView — game text", () => {
 
   test("receiving telemetry but no game label → 'Receiving' / cyan", () => {
     const view = deriveConnectionStatusView({ connected: true, forzaReceiving: true, detectedGame: null });
+    expect(view.statusKind).toBe("receiving");
     expect(view.gameText).toBe("Receiving");
     expect(view.gameLabel).toBeNull();
     expect(view.dotColor).toBe("cyan");
@@ -47,24 +53,18 @@ describe("deriveConnectionStatusView — game text", () => {
 });
 
 describe("deriveConnectionStatusView — regressions", () => {
-  test("game exit clears the label (no stale '<name> — Waiting')", () => {
-    // Simulate: was detected → detection cleared. UI must not cling to the old name.
+  test("game exit reverts to base 'Server' status (no stale '<name> — Waiting')", () => {
     const afterExit = deriveConnectionStatusView({ connected: true, forzaReceiving: false, detectedGame: null });
-    expect(afterExit.gameText).toBe("No Signal");
+    expect(afterExit.statusKind).toBe("server");
+    expect(afterExit.gameText).toBe("Server");
     expect(afterExit.gameLabel).toBeNull();
+    expect(afterExit.dotColor).toBe("green");
   });
 
-  test("undefined detectedGame behaves like null", () => {
+  test("undefined detectedGame behaves like null (falls back to base 'Server')", () => {
     const view = deriveConnectionStatusView({ connected: true, forzaReceiving: false, detectedGame: undefined });
-    expect(view.gameText).toBe("No Signal");
-    expect(view.dotColor).toBe("dim");
-  });
-
-  test("disconnected server still reports game detection when server-status cached", () => {
-    // Edge case: server dropped the WS but last known detectedGame was F1.
-    // The game chip is independent of the server chip.
-    const view = deriveConnectionStatusView({ connected: false, forzaReceiving: false, detectedGame: F1 });
-    expect(view.serverLabel).toBe("Disconnected");
-    expect(view.gameText).toBe("F1 25 — Waiting");
+    expect(view.statusKind).toBe("server");
+    expect(view.gameText).toBe("Server");
+    expect(view.dotColor).toBe("green");
   });
 });


### PR DESCRIPTION
Closes #152

Merges the server status and game connection status into a single status indicator in the top header bar:
- Base status when connected is `Server` (green dot).
- When a game is detected or active, game status overrides the base status in place with higher priority (`amber` dot when waiting, `cyan` dot when telemetry is actively streaming).
- When server is disconnected, shows `Disconnected` (red dot).