### PR TITLE
Fix duplicate development WebSocket connections

### DIFF
--- a/client/src/hooks/useWebSocket.ts
+++ b/client/src/hooks/useWebSocket.ts
@@ -4,6 +4,9 @@ import { queryClient } from "../lib/queryClient";
 import { client } from "../lib/rpc";
 import type { VersionInfo } from "../stores/telemetry";
 import { useTelemetryStore } from "../stores/telemetry";
+import { buildWebSocketUrl, type DevWebSocketTarget } from "./websocket-url";
+
+declare const __RACEIQ_DEV_WS_TARGET__: DevWebSocketTarget;
 
 function fetchVersionInfo() {
   client.api.version
@@ -27,8 +30,8 @@ export function useWebSocket() {
         wsRef.current = null;
       }
 
-      const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-      const ws = new WebSocket(`${protocol}//${window.location.host}/ws`);
+      const devTarget = import.meta.env.DEV ? __RACEIQ_DEV_WS_TARGET__ : undefined;
+      const ws = new WebSocket(buildWebSocketUrl(window.location, devTarget));
       wsRef.current = ws;
 
       // Read store actions via getState() — stable, no dependency issues

--- a/client/src/hooks/websocket-url.ts
+++ b/client/src/hooks/websocket-url.ts
@@ -1,0 +1,22 @@
+export interface DevWebSocketTarget {
+  protocol: "ws:" | "wss:";
+  hostname: string;
+  port: string;
+}
+
+interface WebSocketLocation {
+  protocol: string;
+  host: string;
+  hostname: string;
+}
+
+export function buildWebSocketUrl(location: WebSocketLocation, devTarget?: DevWebSocketTarget): string {
+  if (devTarget) {
+    const hostname = devTarget.hostname || location.hostname;
+    const port = devTarget.port ? `:${devTarget.port}` : "";
+    return `${devTarget.protocol}//${hostname}${port}/ws`;
+  }
+
+  const protocol = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${protocol}//${location.host}/ws`;
+}

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,9 +1,20 @@
-import { createLogger, defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { paraglideVitePlugin } from "@inlang/paraglide-js";
 import tailwindcss from "@tailwindcss/vite";
 import { TanStackRouterVite } from "@tanstack/router-vite-plugin";
-import { paraglideVitePlugin } from "@inlang/paraglide-js";
+import react from "@vitejs/plugin-react";
 import path from "path";
+import { createLogger, defineConfig } from "vite";
+
+const configuredServerTarget = process.env.PROXY_TARGET;
+const serverTarget = configuredServerTarget ?? `http://localhost:${process.env.SERVER_PORT ?? "3117"}`;
+const serverUrl = new URL(serverTarget);
+const devWebSocketTarget = {
+  protocol: serverUrl.protocol === "https:" ? "wss:" : "ws:",
+  // With the default local target, use the page hostname so LAN development
+  // still reaches the machine serving RaceIQ. An explicit target owns its host.
+  hostname: configuredServerTarget ? serverUrl.hostname : "",
+  port: serverUrl.port,
+};
 
 // Deduplicate proxy error logs — show once, then suppress repeats
 const logger = createLogger();
@@ -41,6 +52,9 @@ export default defineConfig({
     }),
   ],
   customLogger: logger,
+  define: {
+    __RACEIQ_DEV_WS_TARGET__: JSON.stringify(devWebSocketTarget),
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "src"),
@@ -55,18 +69,14 @@ export default defineConfig({
     host: true,
     proxy: {
       "/api": {
-        target: process.env.PROXY_TARGET ?? "http://localhost:3117",
+        target: serverTarget,
         changeOrigin: true,
       },
       // Dev-only Mastra Studio API (server/dev-studio.ts) — Studio reads it
       // through the portless hostname, so Vite must forward it to the server.
       "/studio-api": {
-        target: process.env.PROXY_TARGET ?? "http://localhost:3117",
+        target: serverTarget,
         changeOrigin: true,
-      },
-      "/ws": {
-        target: (process.env.PROXY_TARGET ?? "http://localhost:3117").replace(/^http/, "ws"),
-        ws: true,
       },
     },
   },

--- a/test/websocket-url.test.ts
+++ b/test/websocket-url.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { buildWebSocketUrl } from "../client/src/hooks/websocket-url";
+
+describe("RaceIQ WebSocket URL", () => {
+  test("uses the current origin outside development", () => {
+    expect(
+      buildWebSocketUrl({
+        protocol: "https:",
+        hostname: "app.raceiq.example",
+        host: "app.raceiq.example",
+      }),
+    ).toBe("wss://app.raceiq.example/ws");
+  });
+
+  test("bypasses the Vite proxy during local development", () => {
+    expect(
+      buildWebSocketUrl(
+        {
+          protocol: "http:",
+          hostname: "raceiq.localhost",
+          host: "raceiq.localhost:1355",
+        },
+        {
+          protocol: "ws:",
+          hostname: "",
+          port: "3117",
+        },
+      ),
+    ).toBe("ws://raceiq.localhost:3117/ws");
+  });
+
+  test("honours an explicitly configured development server target", () => {
+    expect(
+      buildWebSocketUrl(
+        {
+          protocol: "http:",
+          hostname: "raceiq.localhost",
+          host: "raceiq.localhost:1355",
+        },
+        {
+          protocol: "wss:",
+          hostname: "telemetry.internal",
+          port: "444",
+        },
+      ),
+    ).toBe("wss://telemetry.internal:444/ws");
+  });
+});


### PR DESCRIPTION
## Summary

- connect the development client directly to RaceIQ's Bun WebSocket server instead of routing telemetry through Vite's WebSocket proxy
- preserve the production same-origin WebSocket URL
- honor `SERVER_PORT` and explicit `PROXY_TARGET` development configuration, including LAN-host development
- add focused URL-selection regression tests

## Root cause

React StrictMode intentionally performs an extra Effect setup/cleanup/setup cycle. During development, the first browser WebSocket could close while Vite's Bun-hosted proxy was still upgrading it. The proxy retained the upstream RaceIQ socket, and renderer reloads or tab closes did not reliably release that upstream connection, so server-side clients accumulated.

The HTTP API and Studio routes remain proxied. Only the development telemetry WebSocket bypasses the leaking proxy.

## Validation

- `bun test --timeout 60000 test/websocket-url.test.ts` — 3 pass, 0 fail
- client-local Biome check — clean for changed client files
- `bun run build` — production client and Windows executable build passed
- pre-commit lint and typecheck/build — passed
- `git diff --check` — clean
- live development browser verification:
  - initial StrictMode cycle: `Active: 1 → 0 → 1`
  - renderer reload: old connection returned to `0`; replacement settled at `1`
  - tab close: returned to `Active: 0`

The full suite was not rerun per repository guidance for focused changes; CI remains the full-suite gate.

Closes #157
