### PR TITLE
ci: separate snapshot gating from UI diffs

### DIFF
--- a/.github/workflows/pr-screenshots-comment.yml
+++ b/.github/workflows/pr-screenshots-comment.yml
@@ -111,13 +111,8 @@ jobs:
             echo "<sub>Rendered from Storybook and responsive app screenshot tests against current main.</sub>"
           } > body.md
 
-          existing=$(gh api "repos/${REPO}/issues/${PR}/comments" \
-            --jq ".[] | select(.body | contains(\"$marker\")) | .id" | head -1)
-          if [ -n "$existing" ]; then
-            gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" -F body=@body.md
-          else
-            gh api "repos/${REPO}/issues/${PR}/comments" -F body=@body.md
-          fi
+          # Keep each UI-diff report as a new comment for a visible run history.
+          gh api "repos/${REPO}/issues/${PR}/comments" -F body=@body.md
 
       - name: Label PR as a UI change
         if: steps.meta.outputs.changed == 'true'

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -111,12 +111,11 @@ jobs:
       - name: Render and compare against committed baselines
         id: storybook-render
         working-directory: client
-        # snapshot:test = `playwright test` (no --update). Dashboards whose
-        # render differs from the committed baseline fail and emit
-        # <Name>-{actual,expected,diff}.png into the results dir.
+        # This is the collaborator assertion: `snapshot:test` (no --update)
+        # fails when the PR render differs from its committed snapshot.
         run: bun run snapshot:test
-        # A visual change is expected, not a failure — keep going so we can
-        # collect and publish the diff.
+        # Keep running so the diff can be collected and posted as UI-change
+        # awareness even when the collaborator assertion fails.
         continue-on-error: true
 
       - name: Collect diffs
@@ -180,8 +179,10 @@ jobs:
           path: pr-preview/
           retention-days: 14
 
-      - name: Fail when visual diffs or screenshot renders fail
-        if: steps.collect.outputs.changed == '1' || steps.current-responsive.outcome == 'failure' || steps.main-responsive.outcome == 'failure' || steps.storybook-render.outcome == 'failure'
+      # Main-comparison diffs are informational and are posted by the companion
+      # workflow. Only the local committed-snapshot assertion is blocking.
+      - name: Fail when committed snapshots do not match
+        if: steps.storybook-render.outcome == 'failure'
         run: |
-          echo "::error::Screenshot differences or render failures detected. Review the PR comment and workflow logs."
+          echo "::error::Committed Storybook snapshots do not match the current render. Run 'bun run snapshot' to update them."
           exit 1


### PR DESCRIPTION
## Summary
- keep screenshot diffs against main informational and posted as new UI comments
- fail only when the local Playwright snapshot test differs from committed snapshots
- keep responsive screenshot failures non-blocking

## Verification
- Workflow YAML parsed successfully with Ruby YAML parser