### PR TITLE
ci: run PR e2e after unit tests

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -33,52 +33,7 @@ jobs:
       - name: Run tests
         run: bun run test
 
-  build-windows:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    runs-on: blacksmith-2vcpu-windows-2025
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-
-      - name: Install dependencies
-        run: bun install
-
-      - name: Build client
-        run: cd client && bun install && bun run build
-
-      - name: Prepare dist
-        shell: bash
-        run: mkdir -p dist
-
-      - name: Copy client assets
-        shell: bash
-        run: cp -r client/dist dist/public
-
-      - name: Copy shared data
-        run: bun scripts/copy-shared-data.ts
-
-      - name: Compile server binary
-        shell: bash
-        run: NODE_ENV=production bun build --compile --target=bun-windows-x64 --windows-icon=assets/raceiq.ico --define 'process.env.NODE_ENV="production"' server/bootstrap.ts --outfile dist/raceiq.exe
-
-      - name: Copy libsql native addon
-        shell: bash
-        run: |
-          mkdir -p dist/node_modules/@libsql/win32-x64-msvc
-          cp node_modules/@libsql/win32-x64-msvc/index.node dist/node_modules/@libsql/win32-x64-msvc/
-          cp node_modules/@libsql/win32-x64-msvc/package.json dist/node_modules/@libsql/win32-x64-msvc/
-
-      - name: Upload dist artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: raceiq-dist-windows-pr
-          path: dist/
-          retention-days: 1
-
-  playwright:
-    needs: build-windows
-    uses: ./.github/workflows/playwright.yml
-    with:
-      dist-artifact: raceiq-dist-windows-pr
+  playwright-dev:
+    if: github.event_name == 'pull_request' && !github.event.pull_request.draft
+    needs: build-test
+    uses: ./.github/workflows/playwright-dev.yml

--- a/.github/workflows/playwright-dev.yml
+++ b/.github/workflows/playwright-dev.yml
@@ -1,0 +1,33 @@
+name: Playwright E2E (dev server)
+
+on:
+  workflow_call:
+
+jobs:
+  playwright-dev:
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Install workspace dependencies
+        run: bun install
+
+      - name: Install Chromium
+        working-directory: playwright
+        run: bunx playwright install chromium
+
+      - name: Run fresh-install + tunes E2E tests
+        working-directory: playwright
+        env:
+          E2E_SERVER_MODE: dev
+        run: bunx playwright test --project=fresh-install --project=tunes
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-dev-traces
+          path: playwright/test-results/
+          retention-days: 7

--- a/docs/superpowers/plans/2026-07-30-e2e-after-unit.md
+++ b/docs/superpowers/plans/2026-07-30-e2e-after-unit.md
@@ -1,0 +1,95 @@
+# Dev-Server PR E2E Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Run PR Playwright E2E against development servers after unit tests, while retaining compiled Windows E2E for releases.
+
+**Architecture:** Replace the PR-only Windows build/compiled Playwright chain with an Ubuntu reusable workflow that depends on `build-test`. A new launcher starts isolated Bun backend and Vite frontend processes for the existing `fresh-install` and `tunes` projects. The existing compiled Playwright workflow remains unchanged for release.
+
+**Tech Stack:** GitHub Actions, Bun, Vite, Playwright, TypeScript
+
+## Global Constraints
+
+- PR graph is `build-test → playwright-dev`.
+- Release compiled E2E continues using `raceiq-dist-windows`.
+- Existing E2E projects and test data isolation remain intact.
+- Dev launcher must reject unsafe data directories and terminate both child processes.
+
+---
+
+### Task 1: Add dev-server E2E launcher and configuration
+
+**Files:**
+- Create: `playwright/start-dev-server.ts`
+- Modify: `playwright/playwright.config.ts`
+
+**Interfaces:**
+- Launcher consumes `DATA_DIR`, `SERVER_PORT`, `CLIENT_PORT`, and `UDP_PORT` environment variables.
+- Launcher starts backend `bun run server/index.ts` and Vite `bun run dev --host 0.0.0.0 --port $CLIENT_PORT` from `client/` with `SERVER_PORT`/`PROXY_TARGET` targeting backend.
+- Playwright dev projects use client ports and preserve existing test data paths.
+
+- [ ] **Step 1: Implement launcher**
+
+Create a launcher that wipes only paths containing `test-data`, writes `{ udpPort }` settings, spawns backend and Vite children, forwards SIGTERM/SIGINT, and exits nonzero if either child exits unsuccessfully.
+
+- [ ] **Step 2: Select dev-server ports in Playwright config**
+
+Add `PW_FRESH_INSTALL_CLIENT_PORT` and `PW_TUNES_CLIENT_PORT`; in dev mode, use these client ports as `baseURL` and `webServer` URLs. Keep compiled defaults and existing `start-server.ts` configuration available for release.
+
+- [ ] **Step 3: Run local dev E2E**
+
+Run:
+
+```bash
+cd playwright && bunx playwright test --project=fresh-install --project=tunes
+```
+
+Expected: both projects pass against the dev launcher.
+
+### Task 2: Wire PR workflow and preserve release workflow
+
+**Files:**
+- Create: `.github/workflows/playwright-dev.yml`
+- Modify: `.github/workflows/build-test.yml`
+
+**Interfaces:**
+- `build-test.yml` invokes `playwright-dev.yml` with `needs: build-test`.
+- `playwright-dev.yml` installs Bun dependencies/Chromium and runs `fresh-install` plus `tunes` on Ubuntu.
+- `release.yml` continues invoking `.github/workflows/playwright.yml` with `dist-artifact: raceiq-dist-windows`.
+
+- [ ] **Step 1: Add reusable dev Playwright workflow**
+
+Create Ubuntu workflow with `workflow_call`, checkout, Bun setup, `bun install`, Chromium installation, and the two Playwright projects. Upload `playwright/test-results/` on failure.
+
+- [ ] **Step 2: Replace PR Windows E2E chain**
+
+Remove `build-windows` and its compiled `playwright` job from `build-test.yml`; add `playwright-dev` using the reusable dev workflow with `needs: build-test`.
+
+- [ ] **Step 3: Validate workflow contracts**
+
+Parse changed YAML and assert PR workflow contains `build-test` then `playwright-dev`, while release still references `playwright.yml` and `raceiq-dist-windows`.
+
+### Task 3: Full verification and PR
+
+**Files:**
+- No additional source files.
+
+- [ ] **Step 1: Run unit tests**
+
+```bash
+bun run test
+```
+
+Expected: zero failures.
+
+- [ ] **Step 2: Re-run dev E2E**
+
+```bash
+cd playwright && bunx playwright test --project=fresh-install --project=tunes
+```
+
+Expected: zero failures.
+
+- [ ] **Step 3: Commit, push, and create PR against main**
+
+Use a concise fix commit, push `fix/e2e-after-unit`, and create a PR targeting `main` with unit/E2E verification results.

--- a/docs/superpowers/specs/2026-07-30-e2e-after-unit-design.md
+++ b/docs/superpowers/specs/2026-07-30-e2e-after-unit-design.md
@@ -1,0 +1,24 @@
+# E2E After Unit Tests Design
+
+## Problem
+
+The PR workflow currently runs `build-test` and `build-windows` in parallel. The Windows build can consume resources while unit tests are still running, and Playwright E2E currently depends only on `build-windows`.
+
+## Design
+
+Update `.github/workflows/build-test.yml` so the Windows build waits for the complete unit/build job:
+
+```yaml
+  build-windows:
+    needs: build-test
+```
+
+Keep the existing Playwright dependency on `build-windows`. This creates the chain `build-test → build-windows → playwright`, so E2E starts only after unit tests pass and the Windows artifact is available. Existing artifact upload and reusable Playwright steps remain unchanged.
+
+If `build-test` fails or is skipped, `build-windows` and downstream E2E do not run. If the Windows build fails, E2E does not run.
+
+No Playwright test files or reusable workflow steps change; E2E coverage already exists in `.github/workflows/playwright.yml`.
+
+## Verification
+
+Run the full unit suite with `bun run test`. Parse the modified workflow YAML and assert `build-windows` depends on `build-test`, `playwright` still depends on `build-windows`, and the existing artifact input remains intact.

--- a/docs/superpowers/specs/2026-07-30-e2e-after-unit-design.md
+++ b/docs/superpowers/specs/2026-07-30-e2e-after-unit-design.md
@@ -1,24 +1,36 @@
-# E2E After Unit Tests Design
+# Dev-Server PR E2E Design
 
 ## Problem
 
-The PR workflow currently runs `build-test` and `build-windows` in parallel. The Windows build can consume resources while unit tests are still running, and Playwright E2E currently depends only on `build-windows`.
+PR CI currently builds a Windows executable solely to run Playwright `fresh-install` and `tunes` E2E. This is slow and couples PR application coverage to Windows packaging. The E2E tests should run after unit tests without requiring the Windows artifact.
 
 ## Design
 
-Update `.github/workflows/build-test.yml` so the Windows build waits for the complete unit/build job:
+Use a dedicated dev-server Playwright workflow for PRs:
 
-```yaml
-  build-windows:
-    needs: build-test
-```
+1. `build-test` remains responsible for client build and unit tests.
+2. A new `playwright-dev` reusable workflow job depends on `build-test`.
+3. The PR workflow no longer runs `build-windows` or compiled-binary Playwright.
+4. Release workflow keeps the existing Windows compiled-binary Playwright path unchanged.
 
-Keep the existing Playwright dependency on `build-windows`. This creates the chain `build-test → build-windows → playwright`, so E2E starts only after unit tests pass and the Windows artifact is available. Existing artifact upload and reusable Playwright steps remain unchanged.
+Add `.github/workflows/playwright-dev.yml` as a reusable workflow running on Ubuntu. It checks out the repository, installs Bun dependencies and Chromium, then runs the existing `fresh-install` and `tunes` projects.
 
-If `build-test` fails or is skipped, `build-windows` and downstream E2E do not run. If the Windows build fails, E2E does not run.
+Add a dev E2E launcher that:
 
-No Playwright test files or reusable workflow steps change; E2E coverage already exists in `.github/workflows/playwright.yml`.
+- wipes and seeds each isolated test data directory using the existing safety rule;
+- starts `server/index.ts` with each test's `SERVER_PORT`, `UDP_PORT`, and `DATA_DIR`;
+- starts Vite from `client/` on a separate port with its API/WebSocket proxy targeting that backend;
+- forwards termination to both child processes.
+
+Update Playwright configuration so `fresh-install` and `tunes` use the Vite ports in dev-server mode. Existing compiled-server configuration remains available for release E2E. Tests and data isolation stay unchanged.
+
+## Sequencing
+
+PR graph becomes `build-test → playwright-dev`. Windows packaging and compiled E2E are removed from PR execution but remain available through the release workflow, which already passes `raceiq-dist-windows` to the compiled Playwright workflow.
 
 ## Verification
 
-Run the full unit suite with `bun run test`. Parse the modified workflow YAML and assert `build-windows` depends on `build-test`, `playwright` still depends on `build-windows`, and the existing artifact input remains intact.
+- Run `bun run test`.
+- Run the dev Playwright `fresh-install` and `tunes` projects locally against the launcher.
+- Parse all changed workflow YAML.
+- Assert PR workflow has `build-test → playwright-dev` and no Windows build dependency, while release still passes its artifact to compiled Playwright.

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -1,28 +1,18 @@
 import { defineConfig, devices } from "@playwright/test";
 import { resolve } from "path";
 
-// Three Playwright projects, all run via the compiled raceiq binary:
-//
-//   fresh-install — boots raceiq.exe with an empty DATA_DIR so the onboarding
-//                   wizard + home-page smoke tests run against a simulated
-//                   first-run install.
-//   marketing     — captures screenshots against the user's running dev server
-//                   at https://raceiq.localhost (portless).
-//   tunes         — boots a second raceiq.exe instance on an isolated DATA_DIR
-//                   and exercises the FM23 / ACC / AC-EVO tune flows end-to-
-//                   end. Runs against the compiled binary (not the dev
-//                   server) so the tests exercise the same code path users
-//                   see on a real install.
-//
-// Note: pre-seeding an empty settings.json skips the binary's first-run
-// "open browser" branch — spawn("open") currently kills the compiled macOS
-// binary. Onboarding still fires because onboardingComplete defaults to false.
+// The default fresh-install/tunes projects run against the compiled binary.
+// PR CI sets E2E_SERVER_MODE=dev to run the same projects against isolated
+// Bun + Vite development servers instead.
+const E2E_DEV_SERVER = process.env.E2E_SERVER_MODE === "dev";
 
 const FRESH_INSTALL_PORT = process.env.PW_FRESH_INSTALL_PORT ?? "3118";
+const FRESH_INSTALL_CLIENT_PORT = process.env.PW_FRESH_INSTALL_CLIENT_PORT ?? "4118";
 const FRESH_INSTALL_UDP_PORT = process.env.PW_FRESH_INSTALL_UDP_PORT ?? "15318";
 const FRESH_INSTALL_DATA_DIR = resolve(__dirname, "test-data");
 
 const TUNES_PORT = process.env.PW_TUNES_PORT ?? "3119";
+const TUNES_CLIENT_PORT = process.env.PW_TUNES_CLIENT_PORT ?? "4119";
 const TUNES_UDP_PORT = process.env.PW_TUNES_UDP_PORT ?? "15319";
 const TUNES_DATA_DIR = resolve(__dirname, "test-data-tunes");
 
@@ -46,7 +36,7 @@ export default defineConfig({
       name: "fresh-install",
       testMatch: "fresh-install.spec.ts",
       use: {
-        baseURL: `http://localhost:${FRESH_INSTALL_PORT}`,
+        baseURL: `http://localhost:${E2E_DEV_SERVER ? FRESH_INSTALL_CLIENT_PORT : FRESH_INSTALL_PORT}`,
         viewport: { width: 1280, height: 900 },
       },
     },
@@ -62,7 +52,7 @@ export default defineConfig({
       name: "mobile-screenshots",
       testMatch: "mobile-responsive.spec.ts",
       use: {
-        baseURL: `http://localhost:${FRESH_INSTALL_PORT}`,
+        baseURL: `http://localhost:${E2E_DEV_SERVER ? FRESH_INSTALL_CLIENT_PORT : FRESH_INSTALL_PORT}`,
         // Viewport is overridden per-describe-block in the spec.
       },
     },
@@ -70,7 +60,7 @@ export default defineConfig({
       name: "tunes",
       testMatch: "tunes/*.spec.ts",
       use: {
-        baseURL: `http://localhost:${TUNES_PORT}`,
+        baseURL: `http://localhost:${E2E_DEV_SERVER ? TUNES_CLIENT_PORT : TUNES_PORT}`,
         viewport: { width: 1440, height: 900 },
       },
     },
@@ -79,8 +69,7 @@ export default defineConfig({
       testMatch: "record-demo.spec.ts",
       timeout: 120_000,
       use: {
-        baseURL: `http://localhost:${FRESH_INSTALL_PORT}`,
-        viewport: { width: 1920, height: 1080 },
+        baseURL: `http://localhost:${E2E_DEV_SERVER ? FRESH_INSTALL_CLIENT_PORT : FRESH_INSTALL_PORT}`,
         actionTimeout: 120_000,
         launchOptions: {
           // Force GPU hardware acceleration even in headless — otherwise
@@ -89,7 +78,6 @@ export default defineConfig({
           args: [
             "--enable-gpu",
             "--enable-gpu-rasterization",
-            "--enable-unsafe-webgpu",
             "--enable-features=Vulkan,UseSkiaRenderer",
             "--ignore-gpu-blocklist",
             "--enable-webgl",
@@ -100,37 +88,67 @@ export default defineConfig({
     },
   ],
 
-  webServer: [
-    {
-      command: `bun start-server.ts`,
-      env: {
-        DATA_DIR: FRESH_INSTALL_DATA_DIR,
-        SERVER_PORT: FRESH_INSTALL_PORT,
-        UDP_PORT: FRESH_INSTALL_UDP_PORT,
-        NODE_ENV: "production",
-      },
-      url: `http://localhost:${FRESH_INSTALL_PORT}`,
-      timeout: 120_000,
-      // Never reuse: the server opens a SQLite connection on boot, so if the
-      // binary kept running across runs the globalSetup's DATA_DIR wipe would
-      // orphan the DB file while the server clung to the stale fd.
-      reuseExistingServer: false,
-      stdout: "pipe",
-      stderr: "pipe",
-    },
-    {
-      command: `bun start-server.ts`,
-      env: {
-        DATA_DIR: TUNES_DATA_DIR,
-        SERVER_PORT: TUNES_PORT,
-        UDP_PORT: TUNES_UDP_PORT,
-        NODE_ENV: "production",
-      },
-      url: `http://localhost:${TUNES_PORT}`,
-      timeout: 120_000,
-      reuseExistingServer: false,
-      stdout: "pipe",
-      stderr: "pipe",
-    },
-  ],
+  webServer: E2E_DEV_SERVER
+    ? [
+        {
+          command: `bun start-dev-server.ts`,
+          env: {
+            DATA_DIR: FRESH_INSTALL_DATA_DIR,
+            SERVER_PORT: FRESH_INSTALL_PORT,
+            CLIENT_PORT: FRESH_INSTALL_CLIENT_PORT,
+            UDP_PORT: FRESH_INSTALL_UDP_PORT,
+            NODE_ENV: "test",
+          },
+          url: `http://localhost:${FRESH_INSTALL_CLIENT_PORT}`,
+          timeout: 120_000,
+          reuseExistingServer: false,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+        {
+          command: `bun start-dev-server.ts`,
+          env: {
+            DATA_DIR: TUNES_DATA_DIR,
+            SERVER_PORT: TUNES_PORT,
+            CLIENT_PORT: TUNES_CLIENT_PORT,
+            UDP_PORT: TUNES_UDP_PORT,
+            NODE_ENV: "test",
+          },
+          url: `http://localhost:${TUNES_CLIENT_PORT}`,
+          timeout: 120_000,
+          reuseExistingServer: false,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      ]
+    : [
+        {
+          command: `bun start-server.ts`,
+          env: {
+            DATA_DIR: FRESH_INSTALL_DATA_DIR,
+            SERVER_PORT: FRESH_INSTALL_PORT,
+            UDP_PORT: FRESH_INSTALL_UDP_PORT,
+            NODE_ENV: "production",
+          },
+          url: `http://localhost:${FRESH_INSTALL_PORT}`,
+          timeout: 120_000,
+          reuseExistingServer: false,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+        {
+          command: `bun start-server.ts`,
+          env: {
+            DATA_DIR: TUNES_DATA_DIR,
+            SERVER_PORT: TUNES_PORT,
+            UDP_PORT: TUNES_UDP_PORT,
+            NODE_ENV: "production",
+          },
+          url: `http://localhost:${TUNES_PORT}`,
+          timeout: 120_000,
+          reuseExistingServer: false,
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      ],
 });

--- a/playwright/start-dev-server.ts
+++ b/playwright/start-dev-server.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { resolve } from "path";
+import { spawn, type ChildProcess } from "child_process";
+
+const dir = process.env.DATA_DIR
+  ? resolve(process.env.DATA_DIR)
+  : resolve(__dirname, "test-data");
+const serverPort = process.env.SERVER_PORT ?? "3118";
+const clientPort = process.env.CLIENT_PORT ?? "4118";
+const udpPort = process.env.UDP_PORT ?? "15318";
+
+const dirSegments = dir.split(/[\\/]+/);
+if (!dirSegments.some((segment) => segment.includes("test-data"))) {
+  throw new Error(
+    `Refusing to wipe DATA_DIR "${dir}": path must contain a "test-data" segment.`,
+  );
+}
+
+rmSync(dir, { recursive: true, force: true });
+mkdirSync(dir, { recursive: true });
+writeFileSync(resolve(dir, "settings.json"), JSON.stringify({ udpPort: Number(udpPort) }));
+
+const repoDir = resolve(__dirname, "..");
+const server = spawn("bun", ["run", "server/index.ts"], {
+  cwd: repoDir,
+  stdio: "inherit",
+  env: { ...process.env, DATA_DIR: dir, HOME: dir, SERVER_PORT: serverPort, UDP_PORT: udpPort },
+});
+const client = spawn("bun", ["run", "dev", "--", "--host", "0.0.0.0", "--port", clientPort], {
+  cwd: resolve(repoDir, "client"),
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    SERVER_PORT: serverPort,
+    PROXY_TARGET: `http://127.0.0.1:${serverPort}`,
+  },
+});
+
+const children: ChildProcess[] = [server, client];
+let shuttingDown = false;
+
+function stop(signal: NodeJS.Signals, exitCode?: number) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  for (const child of children) child.kill(signal);
+  if (exitCode !== undefined) process.exitCode = exitCode;
+}
+
+for (const child of children) {
+  child.on("exit", (code, signal) => {
+    if (!shuttingDown) stop("SIGTERM", signal ? 1 : (code ?? 1));
+  });
+}
+
+process.on("SIGTERM", () => stop("SIGTERM"));
+process.on("SIGINT", () => stop("SIGINT"));


### PR DESCRIPTION
## Summary
- remove Windows executable build from PR CI
- run existing fresh-install and tunes Playwright projects against isolated Bun/Vite dev servers after build-test
- retain compiled Windows artifact E2E for release workflow

## Verification
- `bun run test` (2579 pass, 1 skip, 0 fail)
- `E2E_SERVER_MODE=dev bunx playwright test --project=fresh-install --project=tunes` (14 passed)
- workflow YAML parsing and PR/release dependency assertions