### PR TITLE
fix(vite): use import.meta.dirname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Consolidated shared sessions, chats, analysis, driver, and experiment routes across all supported games
 - Tolerate sparse screenshot antialiasing differences while preserving substantial visual regression reporting
 - Updated workspace dependencies and regenerated root Bun lockfile
+- Use `import.meta.dirname` in Vite config for native config-loader compatibility
 
 ## v0.13.0 - 2026-07-16
 

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -57,8 +57,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@": path.resolve(__dirname, "src"),
-      "@shared": path.resolve(__dirname, "../shared"),
+      "@": path.resolve(import.meta.dirname, "src"),
+      "@shared": path.resolve(import.meta.dirname, "../shared"),
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- replace deprecated `__dirname` usage in `client/vite.config.ts`
- use `import.meta.dirname` for Vite native config-loader compatibility
- document the maintenance fix in `CHANGELOG.md`

## Verification
- Vite dev server starts without the native config-loader warning
- `cd client && bun run build`
- `bun test test/changelog.test.ts --timeout 60000`
- `git diff --check`