### PR TITLE
Show all registered games in storage settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixes
 
+- Show all registered games in storage settings, including games with no recording files
+
 ### Internal
 - Consolidated live dashboard routing across all supported games while preserving game-specific URLs
 - Deterministic iRacing recording and replay coverage through the production parser pipeline

--- a/server/routes/misc-routes.ts
+++ b/server/routes/misc-routes.ts
@@ -34,6 +34,7 @@ import {
   decompressForzaLZX,
 } from "../../shared/lib/forza-lzx";
 import { scanRecordedFiles } from "../../shared/track-data";
+import { getAllGames } from "../../shared/games/registry";
 
 // ---------------------------------------------------------------------------
 // FM2023 extraction state
@@ -733,11 +734,14 @@ export const miscRoutes = new Hono()
   // GET /api/storage/sessions — recording file stats
   .get("/api/storage/sessions", async (c) => {
     const sessionsDir = resolve(resolveDataDir(), "sessions");
+    const byGame: Record<string, { binCount: number; gzCount: number; binBytes: number; gzBytes: number }> = {};
+    for (const game of getAllGames()) {
+      byGame[game.id] = { binCount: 0, gzCount: 0, binBytes: 0, gzBytes: 0 };
+    }
     if (!existsSync(sessionsDir)) {
-      return c.json({ total: 0, binCount: 0, gzCount: 0, totalBytes: 0, binBytes: 0, gzBytes: 0, byGame: {}, diskTotal: 0, diskFree: 0 });
+      return c.json({ total: 0, binCount: 0, gzCount: 0, totalBytes: 0, binBytes: 0, gzBytes: 0, byGame, diskTotal: 0, diskFree: 0 });
     }
     let binCount = 0, gzCount = 0, binBytes = 0, gzBytes = 0;
-    const byGame: Record<string, { binCount: number; gzCount: number; binBytes: number; gzBytes: number }> = {};
 
     function tally(gameId: string, file: string, size: number) {
       const g = byGame[gameId] ??= { binCount: 0, gzCount: 0, binBytes: 0, gzBytes: 0 };

--- a/test/storage-routes.test.ts
+++ b/test/storage-routes.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { miscRoutes } from "../server/routes/misc-routes";
+import { initGameAdapters } from "../shared/games/init";
+import { getAllGames } from "../shared/games/registry";
+import { existsSync } from "fs";
+import { join } from "path";
+import { resolveDataDir } from "../server/data-dir";
+
+initGameAdapters();
+
+describe("session storage stats", () => {
+  test("includes every registered game in byGame", async () => {
+    const response = await miscRoutes.request("/api/storage/sessions");
+    expect(response.status).toBe(200);
+
+    const body = await response.json() as {
+      byGame: Record<string, { binCount: number; gzCount: number; binBytes: number; gzBytes: number }>;
+    };
+
+    for (const game of getAllGames()) {
+      expect(body.byGame[game.id]).toBeDefined();
+      if (!existsSync(join(resolveDataDir(), "sessions", game.id))) {
+        expect(body.byGame[game.id]).toEqual({
+          binCount: 0,
+          gzCount: 0,
+          binBytes: 0,
+          gzBytes: 0,
+        });
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Seed storage stats from registered game adapters so empty games remain visible
- Add regression coverage for registered games without session folders
- Document fix in CHANGELOG.md

## Verification
- `bun test test/storage-routes.test.ts test/changelog.test.ts --timeout 60000`
- `bun run build`

Branch starts from latest `origin/main`.