### PR TITLE
fix: prevent Mastra DuckDB lock in seed tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Tolerate sparse screenshot antialiasing differences while preserving substantial visual regression reporting
 - Updated workspace dependencies and regenerated root Bun lockfile
 - Use `import.meta.dirname` in Vite config for native config-loader compatibility
+- Avoid initializing Mastra observability during standalone database seeding
 
 ## v0.13.0 - 2026-07-16
 

--- a/server/ai/agents.ts
+++ b/server/ai/agents.ts
@@ -55,8 +55,14 @@ let compareChatAgent: CompareChatAgent = rawCompareChatAgent;
 let setupEngineerAgent: SetupEngineerAgent = rawSetupEngineerAgent;
 let driverProfilerAgent: DriverProfilerAgent = rawDriverProfilerAgent;
 let driverCoachAgent: DriverCoachAgent = rawDriverCoachAgent;
+export function shouldUseMastraRuntime(
+  nodeEnv = process.env.NODE_ENV,
+  argv = process.argv,
+): boolean {
+  return nodeEnv !== "production" && argv.some((arg) => /(?:^|[\\/])server[\\/]index\.ts$/.test(arg));
+}
 
-if (process.env.NODE_ENV !== "production") {
+if (shouldUseMastraRuntime()) {
   try {
     const { mastra } = await import("../../mastra");
     lapAnalystAgent = mastra.getAgent("lap-analyst") as unknown as LapAnalystAgent;

--- a/test/mastra-agents.test.ts
+++ b/test/mastra-agents.test.ts
@@ -1,5 +1,15 @@
 import { describe, test, expect } from "bun:test";
-import { isMastraSignalMigrationRequiredError } from "../server/ai/agents";
+import { isMastraSignalMigrationRequiredError, shouldUseMastraRuntime } from "../server/ai/agents";
+
+describe("shouldUseMastraRuntime", () => {
+  test("does not enable Mastra for standalone seed commands", () => {
+    expect(shouldUseMastraRuntime("development", ["bun", "scripts/seed-db.ts"])).toBe(false);
+  });
+
+  test("enables Mastra for the development server", () => {
+    expect(shouldUseMastraRuntime("development", ["bun", "server/index.ts"])).toBe(true);
+  });
+});
 
 describe("isMastraSignalMigrationRequiredError", () => {
   test("matches duckdb migration error id", () => {


### PR DESCRIPTION
Keep standalone seed commands from initializing Mastra observability while retaining Mastra for the development server. Add regression coverage. Closes #187. Focused seed tests pass twice; no DuckDB or temp-directory leftovers. Full suite has 2570 passes and 3 unrelated existing @/paraglide module-resolution failures.