### PR TITLE
Rename UdpRecorder to SessionRecorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Show all registered games in storage settings, including games with no recording files
 
 ### Internal
+- Renamed generic session recorder API to reflect support for UDP and shared-memory telemetry
 - Stabilized Storybook dashboard capture readiness, aligned PR preview comparison with Playwright's material-diff policy, and restricted baseline writes to the pinned Linux renderer
 - Made Storybook snapshots own an exact-port server and retry cold preview preparation
 - Restored the ACC live-dashboard fuel bar in fixture-backed previews

--- a/docs/ac-evo-recording-pipeline.md
+++ b/docs/ac-evo-recording-pipeline.md
@@ -31,7 +31,7 @@ tap that produces test fixtures, not user data. It is documented in
 `docs/dev-recordings.md` and deliberately left out here.
 
 The recorder that matters architecturally is the **session recorder**:
-`UdpRecorder`, owned by `Pipeline` (`server/pipeline.ts`) via
+`SessionRecorder`, owned by `Pipeline` (`server/pipeline.ts`) via
 `RealSessionRecorderAdapter`. It writes one packed triplet per record to
 `<DATA_DIR>/sessions/ac-evo/<timestamp>.bin`, each record carrying the `ACEP`
 magic (`ACEVO_PACKED_MAGIC`), and laps in the DB store a byte offset into it.
@@ -66,7 +66,7 @@ flowchart TD
     PACK --> PP["Pipeline.processPacket(packet, rawBuf)"]
 
     subgraph PIPE["server/pipeline.ts"]
-        PP --> OFF["snapshot byte offset<br/>recorder.writePacket(rawBuf)"]
+        PP --> OFF["snapshot byte offset<br/>recorder.writeRecord(rawBuf)"]
         OFF --> NORM["coord normalise + fillNormSuspension"]
         NORM --> LD["LapDetectorAcEvo.feed(packet, rawByteOffset)"]
         LD --> ST["SectorTracker + PitTracker"]
@@ -176,7 +176,7 @@ magic and `tryParse()` calls `unpackTriplet()` before re-parsing.
 Shared with every game. Per packet:
 
 1. Snapshot `recorder.getCurrentByteOffset()` **before** writing, then
-   `recorder.writePacket(rawBuf)`. The offset points at this packet.
+   `recorder.writeRecord(rawBuf)`. The offset points at this packet.
 2. Normalise coordinates (AC Evo is `standard-xyz`, so X is flipped) and fill
    `NormSuspensionTravel`.
 3. `detector.feed(packet, rawByteOffset)`.
@@ -190,9 +190,9 @@ Shared with every game. Per packet:
 Track calibration is skipped for AC Evo — `coordSystem === "standard-xyz"`
 already matches outline space.
 
-### 8. Session recorder file format — `UdpRecorder`
+### 8. Session recorder file format — `SessionRecorder`
 
-Despite the name, this is the generic session writer for all games.
+Generic session writer for all games:
 
 ```
 [meta frame: 0xFFFFFFFF u32le][payloadLen=4 u32le][totalFrames u32le]   (12 bytes)
@@ -201,8 +201,8 @@ Despite the name, this is the generic session writer for all games.
 
 Key behaviours:
 
-- **Lazy open.** The file is not created until the first `writePacket`. Sessions
-  that start and end without packets (menu flapping, shutdown) leave no file.
+- **Lazy open.** The file is not created until the first `writeRecord`. Sessions
+  that start and end without records (menu flapping, shutdown) leave no file.
 - **Append-only.** A hard kill truncates at most the last in-flight write.
 - `totalFrames` is patched into the header on `stop()`.
 - `flush()` is called periodically so DB lap offsets never point past EOF.
@@ -304,7 +304,7 @@ ends up truncated or zero-length, stranding lap byte offsets past EOF.
 | `server/games/shared/pack-triplet.ts` | `ACEP` pack/unpack |
 | `server/pipeline.ts` | Shared per-packet processing, session recorder ownership |
 | `server/pipeline-adapters.ts` | DB / WS / session-recorder adapter seams |
-| `server/udp-recorder.ts` | Session `.bin` writer |
+| `server/session-recorder.ts` | Session `.bin` writer |
 | `server/lap-detector-ac-evo.ts` | Lap boundaries, validity, byte offsets |
 | `server/reprocess.ts` | Replay a session through a fresh detector |
 | `server/session-compressor.ts` | Background gzip of old sessions |

--- a/docs/dev-recordings.md
+++ b/docs/dev-recordings.md
@@ -15,6 +15,7 @@ the dev server in recording mode and opens the dashboard:
 | F1 2025 | `bun run dev:dump:f1` | UDP — raw datagrams |
 | Assetto Corsa Competizione | `bun run dev:dump:acc` | Shared memory (Windows only) |
 | Assetto Corsa Evo | `bun run dev:dump:ac-evo` | Shared memory (Windows only) |
+| iRacing | `bun run dev:dump:iracing` | SDK source frames (Windows only) |
 
 Drive your session. The server appends packets live. When you're done,
 hit `Ctrl+C` — the signal handler flushes the recorder before exiting,
@@ -26,6 +27,7 @@ test/artifacts/sessions/fm-2023-2026-04-18T17-32-09-418Z.bin
 test/artifacts/sessions/f1-2025-2026-04-18T17-45-12-902Z.bin
 test/artifacts/sessions/acc-2026-04-18T17-51-03-776Z.bin
 test/artifacts/sessions/ac-evo-2026-04-18T17-59-44-112Z.bin
+test/artifacts/laps/iracing-2026-04-18T18-06-12-021Z.bin
 ```
 
 The filename prefix encodes the `gameId` — don't rename it, or the
@@ -88,7 +90,8 @@ gunzips it server-side before replaying.
   and flushes the buffer, so the file ends on a packet boundary. A
   hard kill (e.g. `kill -9`) can still truncate the in-flight record,
   but everything written prior remains importable.
-- Shared-memory games (ACC, AC Evo) use their own `.bin` triplet
-  format; UDP games (FM, F1) use the `UdpRecorder` `[uint32 len][N
-  bytes]` format. The importer picks the reader automatically from the
-  filename prefix.
+- UDP dump files (FM, F1) use `SessionRecorder` framing
+  (`[uint32 len][N bytes]`) with one raw datagram per record. Shared-memory
+  dumps (ACC, AC Evo) use `AcRecorder` typed frames. iRacing dump mode uses
+  its source-frame format and `IRacingRecorder`. Importer picks record decoder
+  automatically from file magic and filename prefix.

--- a/docs/session-bin-vs-motec.md
+++ b/docs/session-bin-vs-motec.md
@@ -54,14 +54,14 @@ uniform, which is a different property.
 
 ## `.bin` layout
 
-`server/udp-recorder.ts`. Append-only, length-prefixed:
+`server/session-recorder.ts`. Append-only, length-prefixed:
 
 ```
 [0xFFFFFFFF u32][4 u32][totalFrames u32]   // 12-byte meta frame at offset 0
 [len u32][len bytes]                        // repeated
 ```
 
-`META_FRAME_MAGIC = 0xffffffff` separates header from real packet length.
+`META_FRAME_MAGIC = 0xffffffff` separates header from first record length.
 `totalFrames` patched on `stop()`. Append-only: hard kill truncates at most last
 in-flight write. Reader detects truncation by reading declared length, checking
 that many bytes follow.
@@ -129,7 +129,7 @@ Not compression. Three multipliers:
 
 ## See also
 
-- `server/udp-recorder.ts` — writer, framing
+- `server/session-recorder.ts` — writer, framing
 - `server/games/shared/pack-triplet.ts` — shared-memory frame synthesis
 - `server/import-session-bin.ts` — re-import, re-parse
 - `server/session-compressor.ts` — background gzip

--- a/scripts/backfill-unknown-cars.ts
+++ b/scripts/backfill-unknown-cars.ts
@@ -19,7 +19,7 @@ import { db, initDb } from "../server/db/index";
 import { sessions } from "../server/db/schema";
 import { getServerGame } from "../server/games/registry";
 import { getOrCreateDiscoveredCar } from "../server/db/discovered-cars";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import type { TelemetryPacket } from "../shared/types";
 
 const GAME_ID = "ac-evo";
@@ -31,7 +31,7 @@ function decompressIfGz(bytes: Buffer): Buffer {
   return bytes;
 }
 
-/** Same framing as udp-recorder.ts / import-session-bin.ts: optional 12-byte
+/** Same framing as session-recorder.ts / import-session-bin.ts: optional 12-byte
  * meta frame, then repeated [uint32 LE len][frame bytes]. */
 function* iterateFrames(buf: Buffer): Generator<Buffer> {
   let offset = 0;

--- a/scripts/check-mid-session-lap.ts
+++ b/scripts/check-mid-session-lap.ts
@@ -7,7 +7,7 @@ import { gunzipSync } from "zlib";
 import { initGameAdapters } from "../shared/games/init";
 import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { CapturingDbAdapter } from "../server/pipeline-adapters";
 import { LapDetectorAcEvo } from "../server/lap-detector-ac-evo";
 import { stopMaintenanceTasks } from "../server/pipeline";

--- a/scripts/diag-ac-evo-status.ts
+++ b/scripts/diag-ac-evo-status.ts
@@ -14,7 +14,7 @@ import { gunzipSync } from "zlib";
 import { initGameAdapters } from "../shared/games/init";
 import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { ACEVO_STATUS, GRAPHICS_EVO } from "../server/games/ac-evo/structs";
 import { unpackTriplet } from "../server/games/shared/pack-triplet";
 import { LapDetectorAcEvo } from "../server/lap-detector-ac-evo";

--- a/scripts/scan-lap-offsets.ts
+++ b/scripts/scan-lap-offsets.ts
@@ -9,7 +9,7 @@ import { eq } from "drizzle-orm";
 import { initGameAdapters } from "../shared/games/init";
 import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 
 initGameAdapters();
 initServerGameAdapters();

--- a/scripts/verify-lap-alignment.ts
+++ b/scripts/verify-lap-alignment.ts
@@ -12,7 +12,7 @@ import { eq } from "drizzle-orm";
 import { initGameAdapters } from "../shared/games/init";
 import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 
 initGameAdapters();
 initServerGameAdapters();

--- a/server/import-session-bin.ts
+++ b/server/import-session-bin.ts
@@ -5,7 +5,7 @@ import { deleteSession } from "./db/queries";
 import { getAllServerGames, getServerGame } from "./games/registry";
 import { Pipeline } from "./pipeline";
 import { RealDbAdapter, type DbAdapter, type WsAdapter } from "./pipeline-adapters";
-import { META_FRAME_MAGIC } from "./udp-recorder";
+import { META_FRAME_MAGIC } from "./session-recorder";
 
 export class NoopWsAdapter implements WsAdapter {
   broadcast(): void {}

--- a/server/motec/to-ac-evo.ts
+++ b/server/motec/to-ac-evo.ts
@@ -56,7 +56,7 @@ import {
   STATIC_EVO,
 } from "../games/ac-evo/structs";
 import { ACEVO_PACKED_MAGIC, packTriplet } from "../games/shared/pack-triplet";
-import { META_FRAME_MAGIC } from "../udp-recorder";
+import { META_FRAME_MAGIC } from "../session-recorder";
 import { getAcEvoCarByModel, getAcEvoCarName } from "../../shared/ac-evo-car-data";
 import {
   getAcEvoTrackByName,

--- a/server/pipeline-adapters.ts
+++ b/server/pipeline-adapters.ts
@@ -6,7 +6,7 @@ import { notifyDriverProfileLap } from "./ai/driver-profile-runner";
 import type { ExclusionScopeLap } from "./experiment-auto-exclude";
 import { getTuneAssignment } from "./db/tune-queries";
 import { wsManager } from "./ws";
-import { UdpRecorder } from "./udp-recorder";
+import { SessionRecorder } from "./session-recorder";
 import { resolveDataDir } from "./data-dir";
 
 export interface CapturedSession {
@@ -84,7 +84,7 @@ export interface SessionRecorderAdapter {
   readonly epoch: number;
   start(gameId: GameId): void;
   writeMetaFrame(): void;
-  writePacket(buf: Buffer): void;
+  writeRecord(buf: Buffer): void;
   getCurrentByteOffset(): number;
   flush(): void;
   stop(): Promise<void>;
@@ -257,9 +257,9 @@ export class NullDbAdapter implements DbAdapter {
   }
 }
 
-/** Real session recorder — writes raw UDP packets to `<DATA_DIR>/sessions/<game>/<timestamp>.bin`. */
+/** Real session recorder — writes telemetry records to `<DATA_DIR>/sessions/<game>/<timestamp>.bin`. */
 export class RealSessionRecorderAdapter implements SessionRecorderAdapter {
-  private _inner: UdpRecorder | null = null;
+  private _inner: SessionRecorder | null = null;
   private _epoch = 0;
 
   get active(): boolean { return this._inner?.recording ?? false; }
@@ -272,13 +272,13 @@ export class RealSessionRecorderAdapter implements SessionRecorderAdapter {
     const sessionDir = resolve(dataDir, "sessions", gameId);
     mkdirSync(sessionDir, { recursive: true });
     const filePath = resolve(sessionDir, `${timestamp}.bin`);
-    this._inner = new UdpRecorder();
+    this._inner = new SessionRecorder();
     this._inner.start(filePath);
     this._epoch++;
   }
 
   writeMetaFrame(): void { this._inner?.writeMetaFrame(); }
-  writePacket(buf: Buffer): void { this._inner?.writePacket(buf); }
+  writeRecord(buf: Buffer): void { this._inner?.writeRecord(buf); }
   getCurrentByteOffset(): number { return this._inner?.getCurrentByteOffset() ?? 0; }
   flush(): void { this._inner?.flush(); }
   async stop(): Promise<void> {
@@ -295,7 +295,7 @@ export class NullSessionRecorderAdapter implements SessionRecorderAdapter {
   get epoch(): number { return 0; }
   start(_gameId: GameId): void {}
   writeMetaFrame(): void {}
-  writePacket(_buf: Buffer): void {}
+  writeRecord(_buf: Buffer): void {}
   getCurrentByteOffset(): number { return 0; }
   flush(): void {}
   async stop(): Promise<void> {}

--- a/server/pipeline.ts
+++ b/server/pipeline.ts
@@ -227,7 +227,7 @@ export class Pipeline {
     const epochBefore = this.recorder.epoch;
     if (rawBuf && this.recorder.active) {
       rawByteOffset = this.recorder.getCurrentByteOffset();
-      this.recorder.writePacket(rawBuf);
+      this.recorder.writeRecord(rawBuf);
     }
 
     // Normalize coordinates so all games use the same display convention.
@@ -252,7 +252,7 @@ export class Pipeline {
     // the detector's lap byte offset so the DB row points at the right place.
     if (rawBuf && this.recorder.active && this.recorder.epoch !== epochBefore) {
       const firstOffset = this.recorder.getCurrentByteOffset();
-      this.recorder.writePacket(rawBuf);
+      this.recorder.writeRecord(rawBuf);
       detector.setCurrentLapByteOffset?.(firstOffset);
     }
 

--- a/server/reprocess.ts
+++ b/server/reprocess.ts
@@ -4,7 +4,7 @@
  */
 import { getServerGame } from "./games/registry";
 import { CapturingDbAdapter } from "./pipeline-adapters";
-import { META_FRAME_MAGIC } from "./udp-recorder";
+import { META_FRAME_MAGIC } from "./session-recorder";
 import type { GameId } from "../shared/types";
 import { gunzip } from "zlib";
 import { promisify } from "util";

--- a/server/session-recorder.ts
+++ b/server/session-recorder.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, openSync, writeSync, closeSync } from "fs";
 import { dirname } from "path";
 
 /**
- * Appends raw UDP packets to a binary dump file.
+ * Appends raw telemetry records to a binary dump file.
  *
  * Format: repeated [uint32 LE byte-length][N raw bytes]
  *
@@ -10,17 +10,17 @@ import { dirname } from "path";
  * write — all prior records remain intact. A reader detects truncation by
  * reading the declared length and checking if enough bytes follow.
  *
- * File creation is deferred until the first real packet arrives. A session
- * that only calls start() + writeMetaFrame() and ends without any packets
+ * File creation is deferred until the first telemetry record arrives. A session
+ * that only calls start() + writeMetaFrame() and ends without any records
  * (e.g. sim in menu, car/track flap, app shutdown) leaves no .bin on disk.
  */
-/** Magic length value that marks a meta frame (not a real UDP packet). */
+/** Magic length value that marks a meta frame (not a telemetry record). */
 export const META_FRAME_MAGIC = 0xffffffff;
 
-export class UdpRecorder {
+export class SessionRecorder {
   private _file: Bun.FileSink | null = null;
   private _path: string | null = null;
-  private _packetCount = 0;
+  private _recordCount = 0;
   private _byteOffset = 0;
   private _metaPending = false;
   private _active = false;
@@ -29,8 +29,8 @@ export class UdpRecorder {
     return this._active;
   }
 
-  get packetCount(): number {
-    return this._packetCount;
+  get recordCount(): number {
+    return this._recordCount;
   }
 
   get path(): string | null {
@@ -44,12 +44,12 @@ export class UdpRecorder {
 
   /**
    * Reserve a file path for this session. No file is created on disk until
-   * the first writePacket() call — empty sessions leave nothing behind.
+   * the first writeRecord() call — empty sessions leave nothing behind.
    */
   start(filePath: string): string {
     if (this._active) this.stop();
     this._path = filePath;
-    this._packetCount = 0;
+    this._recordCount = 0;
     this._byteOffset = 0;
     this._metaPending = false;
     this._active = true;
@@ -58,8 +58,8 @@ export class UdpRecorder {
 
   /**
    * Reserve the 12-byte meta frame at offset 0. Actual bytes are written to
-   * disk on the first writePacket() call (lazy-open), so the lap byte-offset
-   * pipeline sees (12) matches what will be on disk once packets arrive.
+   * disk on the first writeRecord() call (lazy-open), so the lap byte-offset
+   * pipeline sees (12) matches what will be on disk once records arrive.
    *
    * Format: [0xFFFFFFFF uint32 LE][4 uint32 LE][totalFrames uint32 LE]
    * totalFrames is written as 0 initially and patched to the real count on stop().
@@ -70,8 +70,8 @@ export class UdpRecorder {
     this._byteOffset += 12;
   }
 
-  /** Append one raw UDP packet. Opens the file + writes meta header on first call. */
-  writePacket(buf: Buffer): void {
+  /** Append one telemetry record. Opens the file + writes meta header on first call. */
+  writeRecord(buf: Buffer): void {
     if (!this._active) return;
     if (!this._file) this._openAndWriteMeta();
     if (!this._file) return;
@@ -79,7 +79,7 @@ export class UdpRecorder {
     lenBuf.writeUInt32LE(buf.length, 0);
     this._file.write(lenBuf);
     this._file.write(buf);
-    this._packetCount++;
+    this._recordCount++;
     this._byteOffset += 4 + buf.length;
   }
 
@@ -88,7 +88,7 @@ export class UdpRecorder {
     const dir = dirname(this._path);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     this._file = Bun.file(this._path).writer();
-    console.log(`[UdpRecorder] Recording to ${this._path}`);
+    console.log(`[SessionRecorder] Recording to ${this._path}`);
     if (this._metaPending) {
       const header = Buffer.allocUnsafe(12);
       header.writeUInt32LE(META_FRAME_MAGIC, 0);
@@ -113,11 +113,11 @@ export class UdpRecorder {
     }
   }
 
-  /** Flush, patch total frame count into header, and close. No file is created if no packets were written. */
+  /** Flush, patch total frame count into header, and close. No file is created if no records were written. */
   async stop(): Promise<void> {
     const path = this._path;
     const file = this._file;
-    const count = this._packetCount;
+    const count = this._recordCount;
     const hadMeta = this._metaPending;
     this._file = null;
     this._metaPending = false;
@@ -132,9 +132,9 @@ export class UdpRecorder {
         writeSync(fd, countBuf, 0, 4, 8);
         closeSync(fd);
       } catch {
-        // Non-fatal: header patch failing doesn't corrupt the packet data
+        // Non-fatal: header patch failing doesn't corrupt the record data
       }
     }
-    console.log(`[UdpRecorder] Stopped. ${count} packets written to ${path}`);
+    console.log(`[SessionRecorder] Stopped. ${count} records written to ${path}`);
   }
 }

--- a/server/udp.ts
+++ b/server/udp.ts
@@ -16,7 +16,7 @@ import { wsManager } from "./ws";
 import { processPacket, flushSessionRecorderBuffer } from "./pipeline";
 import { getRunningGame } from "./games/registry";
 import { lapDetector } from "./pipeline";
-import { UdpRecorder } from "./udp-recorder";
+import { SessionRecorder } from "./session-recorder";
 import type { GameId } from "../shared/types";
 
 const MIN_PACKET_LENGTH = 29; // Minimum: F1 header size
@@ -33,7 +33,7 @@ class UdpListener {
   private _socket: { stop(): void } | null = null;
   private _port = 5301;
   private _hostname = "0.0.0.0";
-  private _recorder: UdpRecorder | null = null;
+  private _recorder: SessionRecorder | null = null;
   private _recordingGameId: GameId | null = null;
   private _lastDetectedGame: ReturnType<typeof getRunningGame> = null;
   private _lastRaceOn = false;
@@ -83,7 +83,7 @@ class UdpListener {
       const dir = resolve(process.cwd(), "test", "artifacts", "sessions");
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
       const filePath = resolve(dir, `${this._recordingGameId}-${timestamp}.bin`);
-      this._recorder = new UdpRecorder();
+      this._recorder = new SessionRecorder();
       this._recorder.start(filePath);
     }
 
@@ -188,7 +188,7 @@ class UdpListener {
 
     // Append raw datagrams to the dump BEFORE parsing so recordings preserve
     // the exact wire format (including any packets parsePacket would skip).
-    this._recorder?.writePacket(buf);
+    this._recorder?.writeRecord(buf);
 
     // Returns null when game is paused/in menus (IsRaceOn == 0)
     const packet = parsePacket(buf);

--- a/server/zip.ts
+++ b/server/zip.ts
@@ -25,7 +25,7 @@ import {
   importSessionBin,
   type ImportedLap,
 } from "./import-session-bin";
-import { META_FRAME_MAGIC } from "./udp-recorder";
+import { META_FRAME_MAGIC } from "./session-recorder";
 import { isIRacingSessionFrame } from "./games/iracing/source-frame";
 import type { GameId } from "../shared/types";
 

--- a/test/ac-evo-batch-decode.test.ts
+++ b/test/ac-evo-batch-decode.test.ts
@@ -12,7 +12,7 @@ import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
 import { CapturingDbAdapter } from "../server/pipeline-adapters";
 import { LapDetectorAcEvo } from "../server/lap-detector-ac-evo";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { stopMaintenanceTasks } from "../server/pipeline";
 import { parseRawLapFramesForTest, parseSessionLapsBatchedForTest } from "../server/db/queries";
 

--- a/test/ac-evo-mid-session.test.ts
+++ b/test/ac-evo-mid-session.test.ts
@@ -15,7 +15,7 @@ import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
 import { CapturingDbAdapter } from "../server/pipeline-adapters";
 import { LapDetectorAcEvo } from "../server/lap-detector-ac-evo";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { stopMaintenanceTasks } from "../server/pipeline";
 import { parseRawLapFramesForTest } from "../server/db/queries";
 import type { TelemetryPacket } from "../shared/types";

--- a/test/ac-evo-session-lifecycle.test.ts
+++ b/test/ac-evo-session-lifecycle.test.ts
@@ -18,7 +18,7 @@ import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
 import { CapturingDbAdapter } from "../server/pipeline-adapters";
 import { LapDetectorAcEvo } from "../server/lap-detector-ac-evo";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { stopMaintenanceTasks } from "../server/pipeline";
 import { parseAcEvoBuffers, createAcEvoParserCache } from "../server/games/ac-evo/parser";
 import { ACEVO_STATUS, GRAPHICS_EVO } from "../server/games/ac-evo/structs";

--- a/test/bin-fixture-detection.test.ts
+++ b/test/bin-fixture-detection.test.ts
@@ -21,7 +21,7 @@ import { initServerGameAdapters } from "../server/games/init";
 import { getServerGame } from "../server/games/registry";
 import { getGame } from "../shared/games/registry";
 import { stopMaintenanceTasks } from "../server/pipeline";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { detectGameIdFromBuffer } from "../server/import-session-bin";
 import { getAccTrackName } from "../shared/acc-track-data";
 import { getAccCarName } from "../shared/acc-car-data";

--- a/test/f1-2025-session-sectors.test.ts
+++ b/test/f1-2025-session-sectors.test.ts
@@ -19,7 +19,7 @@ import { getServerGame } from "../server/games/registry";
 import { CapturingDbAdapter, CapturingWsAdapter, NullSessionRecorderAdapter } from "../server/pipeline-adapters";
 import { Pipeline } from "../server/pipeline";
 import { computeLapSectors } from "../server/compute-lap-sectors";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { stopMaintenanceTasks } from "../server/pipeline";
 import type { TelemetryPacket } from "../shared/types";
 

--- a/test/helpers/parse-dump.ts
+++ b/test/helpers/parse-dump.ts
@@ -17,7 +17,7 @@ import { getAccCarByModel } from "../../shared/acc-car-data";
 import { getAccTrackByName } from "../../shared/acc-track-data";
 import { readFileSync } from "fs";
 import { gunzipSync } from "zlib";
-import { META_FRAME_MAGIC } from "../../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../../server/session-recorder";
 
 let _initialized = false;
 export function ensureInit(): void {

--- a/test/helpers/recording.ts
+++ b/test/helpers/recording.ts
@@ -7,7 +7,7 @@ function readMaybeGzipped(filePath: string): Buffer {
 }
 
 /**
- * Read a UDP dump file written by UdpRecorder.
+ * Read a UDP dump file written by SessionRecorder.
  *
  * Format: repeated [uint32 LE length][N raw bytes]
  * A truncated final record (declared length > remaining bytes) is silently skipped.

--- a/test/helpers/session-frames.ts
+++ b/test/helpers/session-frames.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { gunzipSync } from "zlib";
 import type { GameId, TelemetryPacket } from "../../shared/types";
 import { getServerGame } from "../../server/games/registry";
-import { META_FRAME_MAGIC } from "../../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../../server/session-recorder";
 import { ensureInit } from "./parse-dump";
 
 /**
@@ -10,7 +10,7 @@ import { ensureInit } from "./parse-dump";
  *
  * `test/helpers/parse-dump.ts` handles the older per-game dump formats; this
  * reads the length-prefixed session-bin container (with `META_FRAME_MAGIC`
- * sidecar frames interleaved) that `server/udp-recorder.ts` writes today.
+ * sidecar frames interleaved) that `server/session-recorder.ts` writes today.
  */
 export function readSessionPackets(filePath: string, gameId: GameId): TelemetryPacket[] {
   ensureInit();

--- a/test/lap-export-zip.test.ts
+++ b/test/lap-export-zip.test.ts
@@ -21,7 +21,7 @@ import { sessions, laps } from "../server/db/schema";
 import { eq } from "drizzle-orm";
 import { initGameAdapters } from "../shared/games/init";
 import { initServerGameAdapters } from "../server/games/init";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { buildLapsZip, LAPS_ZIP_VERSION, type LapsZipManifest } from "../server/zip";
 import {
   createIRacingSourceDecoderState,

--- a/test/motec-import.test.ts
+++ b/test/motec-import.test.ts
@@ -17,7 +17,7 @@ import { db } from "../server/db";
 import { laps as lapsTable, sessions, tunes } from "../server/db/schema";
 import { eq, isNull } from "drizzle-orm";
 import { getAcEvoTrackByName } from "../shared/ac-evo-track-data";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { buildLd, buildLdx, syntheticStint } from "./helpers/motec-ld";
 
 initGameAdapters();

--- a/test/motec-viz.test.ts
+++ b/test/motec-viz.test.ts
@@ -25,7 +25,7 @@ import { getServerGame } from "../server/games/registry";
 import { loadCenterline } from "../shared/track-segment-generate";
 import { parseLd } from "../server/motec/ld";
 import { synthesizeAcEvoCapture, SYNTH_HZ } from "../server/motec/to-ac-evo";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { buildLd } from "./helpers/motec-ld";
 import {
   alignToReference,

--- a/test/parse-bin-vs-gz.test.ts
+++ b/test/parse-bin-vs-gz.test.ts
@@ -10,7 +10,7 @@ import { gunzipSync } from "zlib";
 import { parseRawLapFramesForTest } from "../server/db/queries";
 import { initGameAdapters } from "../shared/games/init";
 import { initServerGameAdapters } from "../server/games/init";
-import { META_FRAME_MAGIC } from "../server/udp-recorder";
+import { META_FRAME_MAGIC } from "../server/session-recorder";
 import { stopMaintenanceTasks } from "../server/pipeline";
 
 initGameAdapters();

--- a/test/raw-binary-storage.test.ts
+++ b/test/raw-binary-storage.test.ts
@@ -1,12 +1,12 @@
 /**
- * Tests for raw binary lap storage: UdpRecorder meta frames, byte offset tracking,
+ * Tests for raw binary lap storage: SessionRecorder meta frames, byte offset tracking,
  * and reprocessSession strategy selection (in-place vs replace).
  */
 import { describe, test, expect, afterEach, beforeEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { UdpRecorder, META_FRAME_MAGIC } from "../server/udp-recorder";
+import { SessionRecorder, META_FRAME_MAGIC } from "../server/session-recorder";
 import { reprocessSession } from "../server/reprocess";
 import { db } from "../server/db/index";
 import { sessions, laps } from "../server/db/schema";
@@ -18,9 +18,9 @@ import { countStaleSessions } from "../server/db/queries";
 initGameAdapters();
 initServerGameAdapters();
 
-// ── UdpRecorder: meta frame + byte offset ─────────────────────────────────────
+// ── SessionRecorder: meta frame + byte offset ─────────────────────────────────────
 
-describe("UdpRecorder meta frame", () => {
+describe("SessionRecorder meta frame", () => {
   let tmpDir: string;
 
   afterEach(() => {
@@ -29,12 +29,12 @@ describe("UdpRecorder meta frame", () => {
 
   test("writeMetaFrame writes fixed 12-byte header with frame count", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "raceiq-test-"));
-    const recorder = new UdpRecorder();
+    const recorder = new SessionRecorder();
     recorder.start(join(tmpDir, "session.bin"));
 
     recorder.writeMetaFrame();
-    recorder.writePacket(Buffer.from([0x01, 0x02]));
-    recorder.writePacket(Buffer.from([0x03, 0x04]));
+    recorder.writeRecord(Buffer.from([0x01, 0x02]));
+    recorder.writeRecord(Buffer.from([0x03, 0x04]));
     await recorder.stop();
 
     const buf = Buffer.from(await Bun.file(recorder.path!).arrayBuffer());
@@ -45,7 +45,7 @@ describe("UdpRecorder meta frame", () => {
 
   test("getCurrentByteOffset starts at 0 before any writes", () => {
     tmpDir = mkdtempSync(join(tmpdir(), "raceiq-test-"));
-    const recorder = new UdpRecorder();
+    const recorder = new SessionRecorder();
     recorder.start(join(tmpDir, "session.bin"));
     expect(recorder.getCurrentByteOffset()).toBe(0);
     recorder.stop();
@@ -53,7 +53,7 @@ describe("UdpRecorder meta frame", () => {
 
   test("getCurrentByteOffset tracks written bytes", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "raceiq-test-"));
-    const recorder = new UdpRecorder();
+    const recorder = new SessionRecorder();
     recorder.start(join(tmpDir, "session.bin"));
 
     // meta frame: 4 (magic) + 4 (len) + 4 (count) = 12 bytes
@@ -61,7 +61,7 @@ describe("UdpRecorder meta frame", () => {
     expect(recorder.getCurrentByteOffset()).toBe(12);
 
     // packet: 4 (len prefix) + 3 (payload) = 7 bytes
-    recorder.writePacket(Buffer.from([0x01, 0x02, 0x03]));
+    recorder.writeRecord(Buffer.from([0x01, 0x02, 0x03]));
     expect(recorder.getCurrentByteOffset()).toBe(19);
 
     await recorder.stop();
@@ -69,14 +69,14 @@ describe("UdpRecorder meta frame", () => {
 
   test("byte offset after meta frame matches where first real packet is written", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "raceiq-test-"));
-    const recorder = new UdpRecorder();
+    const recorder = new SessionRecorder();
     recorder.start(join(tmpDir, "session.bin"));
 
     recorder.writeMetaFrame();
     const offsetAfterMeta = recorder.getCurrentByteOffset(); // always 12
 
     const pkt = Buffer.from([0xAA, 0xBB]);
-    recorder.writePacket(pkt);
+    recorder.writeRecord(pkt);
     await recorder.stop();
 
     // Verify the first packet's length prefix sits at offsetAfterMeta in the file

--- a/test/session-recorder.test.ts
+++ b/test/session-recorder.test.ts
@@ -2,10 +2,10 @@ import { describe, test, expect, afterEach } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { UdpRecorder } from "../server/udp-recorder";
+import { SessionRecorder } from "../server/session-recorder";
 import { readUdpDump } from "./helpers/recording";
 
-describe("UdpRecorder + readUdpDump", () => {
+describe("SessionRecorder + readUdpDump", () => {
   let tmpDir: string;
 
   afterEach(() => {
@@ -14,13 +14,13 @@ describe("UdpRecorder + readUdpDump", () => {
 
   test("round-trips packets through dump file", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "raceiq-test-"));
-    const recorder = new UdpRecorder();
+    const recorder = new SessionRecorder();
     recorder.start(join(tmpDir, "dump.bin"));
 
     const pkt1 = Buffer.from([0x01, 0x02, 0x03]);
     const pkt2 = Buffer.from([0xAA, 0xBB, 0xCC, 0xDD]);
-    recorder.writePacket(pkt1);
-    recorder.writePacket(pkt2);
+    recorder.writeRecord(pkt1);
+    recorder.writeRecord(pkt2);
     await recorder.stop();
 
     const packets = readUdpDump(recorder.path!);


### PR DESCRIPTION
## Summary

- rename `UdpRecorder` and `server/udp-recorder.ts` to `SessionRecorder` and `server/session-recorder.ts`
- rename packet-oriented recorder API and counters to record-oriented terminology
- update pipeline adapters, importers, scripts, tests, and documentation
- retain documentation for iRacing dump mode and its dedicated `IRacingRecorder`
- preserve existing session `.bin` framing and `META_FRAME_MAGIC`

## Why

Generic session recording handles UDP datagrams and non-UDP telemetry records. UDP-specific naming made shared-memory and source-frame paths look incorrect even though they use the same generic recording seam.

## Impact

Naming-only refactor. Existing recordings remain compatible; no migration or file-format change.

## Validation

- `bun test --timeout 60000 test/session-recorder.test.ts test/raw-binary-storage.test.ts test/changelog.test.ts` — 26 passed
- `git diff --cached --check` — passed
- `bun run build` — client TypeScript/Vite build passed; server binary compile remains blocked locally by missing cross-platform optional `@duckdb/node-bindings-*` packages

Closes #129