### PR TITLE
fix(ui): polish settings, onboarding, and analysis controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - View all release notes since your installed version in the app
 
 ### Fixes
+- Clean up settings and onboarding wizard controls so navigation, progress indicators, and wheel cards render correctly
+- Report missing AI model settings instead of silently selecting a provider default
 
 - Keep the Compare loading message hidden after comparison data is available
 - Cover the full page when settings are open so background content is consistently dimmed and dismissible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - Clean up settings and onboarding wizard controls so navigation, progress indicators, and wheel cards render correctly
+- Render experiment focus choices as wrapping cards, remove the experiment table shell, and underline Analyse tabs
 - Report missing AI model settings instead of silently selecting a provider default
 
 - Keep the Compare loading message hidden after comparison data is available

--- a/client/src/components/InsightPanel.tsx
+++ b/client/src/components/InsightPanel.tsx
@@ -15,7 +15,7 @@ function InsightRow({ insight, onJump }: { insight: LapInsight; onJump: (idx: nu
 
   return (
     <div className="w-full rounded hover:bg-app-surface-hover/60 transition-colors group">
-      <Button type="button" onClick={() => onJump(insight.frameIndices[eventIdx])} className={`block w-full text-left px-2 ${hasMultiple ? "pt-1.5" : "py-1.5"}`}>
+      <Button type="button" variant="plain" size="content" onClick={() => onJump(insight.frameIndices[eventIdx])} className={`block w-full text-left px-2 ${hasMultiple ? "pt-1.5" : "py-1.5"}`}>
         <div className="flex items-start gap-1.5">
           <span className="mt-1 w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: SEVERITY_COLOR[insight.severity] }} />
           <div className="min-w-0 flex-1">

--- a/client/src/components/Onboarding.tsx
+++ b/client/src/components/Onboarding.tsx
@@ -342,13 +342,13 @@ export function StepWheel() {
             type="button"
             key={w.id}
             onClick={() => select(w.src)}
-            className={`relative rounded-lg border p-3 text-left transition-all ${
+            className={`relative w-full min-w-0 !h-auto flex-col !items-stretch !justify-start rounded-lg border p-3 text-left transition-all ${
               currentSrc === w.src ? "border-app-accent bg-app-accent/10 ring-1 ring-app-accent/30" : "border-app-border bg-app-surface-alt hover:border-app-border-hover"
             }`}
           >
-            <div className="text-sm font-medium text-app-text truncate">{w.name}</div>
+            <div className="min-w-0 text-sm font-medium text-app-text truncate">{w.name}</div>
             <div className="mt-2 h-24 flex items-center justify-center rounded-md border border-app-border bg-app-surface overflow-hidden">
-              <img src={w.src} alt={w.name} className="h-full object-contain" />
+              <img src={w.src} alt={w.name} className="h-full max-w-full object-contain" />
             </div>
           </Button>
         ))}
@@ -608,12 +608,8 @@ export function OnboardingModal({ onClose }: { onClose?: () => void } = {}) {
                 const i = idx + 1;
                 return (
                   <div key={s.id} className="flex items-center gap-2 shrink-0">
-                    <Button
-                      type="button"
-                      onClick={() => setStep(i)}
-                      className={`flex items-center gap-1.5 text-xs font-medium transition-colors whitespace-nowrap ${
-                        i === step ? "text-app-accent" : i < step ? "text-app-text-secondary" : "text-app-text-muted/50"
-                      }`}
+                    <div
+                      className={`flex items-center gap-1.5 text-xs font-medium whitespace-nowrap ${i === step ? "text-app-accent" : i < step ? "text-app-text-secondary" : "text-app-text-muted/50"}`}
                     >
                       <span
                         className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-semibold border transition-colors ${
@@ -633,7 +629,7 @@ export function OnboardingModal({ onClose }: { onClose?: () => void } = {}) {
                         )}
                       </span>
                       {s.label()}
-                    </Button>
+                    </div>
                     {idx < MODAL_STEPS.length - 2 && <div className={`w-8 h-px ${i < step ? "bg-status-success/50" : "bg-app-border"}`} />}
                   </div>
                 );

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -190,7 +190,7 @@ export function Settings({ initialSection, onClose }: { initialSection?: Section
         <Button
           variant="app-ghost"
           size="app-md"
-          className="ml-auto"
+          className="ml-auto md:hidden"
           onClick={() => {
             onClose?.();
             openOnboarding();

--- a/client/src/components/analyse/AnalyseDataPanel.tsx
+++ b/client/src/components/analyse/AnalyseDataPanel.tsx
@@ -111,7 +111,7 @@ export function AnalyseDataPanel({ sidebarTab, onSidebarTabChange, currentPacket
       }}
       className="flex h-full w-[22rem] shrink-0 flex-col overflow-hidden border-l border-app-border bg-app-surface/50"
     >
-      <TabsList className="w-full shrink-0">
+      <TabsList variant="underline" className="w-full shrink-0">
         <TabsTrigger value="live" className="flex-1">
           {m.analyse_tab_data()}
         </TabsTrigger>

--- a/client/src/components/analyse/AnalyseVizPanel.tsx
+++ b/client/src/components/analyse/AnalyseVizPanel.tsx
@@ -48,7 +48,7 @@ export function AnalyseVizPanel({
       className="flex shrink-0 flex-col items-center justify-start overflow-y-auto border-r border-app-border"
       style={{ width }}
     >
-      <TabsList className="w-full shrink-0">
+      <TabsList variant="underline" className="w-full shrink-0">
         <TabsTrigger value="2d" className="flex-1">
           2D
         </TabsTrigger>

--- a/client/src/components/analyse/WheelTable.tsx
+++ b/client/src/components/analyse/WheelTable.tsx
@@ -38,16 +38,16 @@ export function WheelTable({ title, showHeaders = true, borderTop = false, rows 
           <TableHead>
             <span className={cn("block text-app-caption font-semibold uppercase tracking-wider", headerContentClass)}>{title}</span>
           </TableHead>
-          <TableHead align="end">
+          <TableHead align="center">
             <span className={headerContentClass}>FL</span>
           </TableHead>
-          <TableHead align="end">
+          <TableHead align="center">
             <span className={headerContentClass}>FR</span>
           </TableHead>
-          <TableHead align="end">
+          <TableHead align="center">
             <span className={headerContentClass}>RL</span>
           </TableHead>
-          <TableHead align="end">
+          <TableHead align="center">
             <span className={headerContentClass}>RR</span>
           </TableHead>
         </TableHeader>

--- a/client/src/components/tunes/ExperimentList.tsx
+++ b/client/src/components/tunes/ExperimentList.tsx
@@ -17,7 +17,6 @@ import { useTelemetryStore } from "../../stores/telemetry";
 import { Table, TBody, TD, TH, THead, TRow } from "../ui/AppTable";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
-import { Card } from "../ui/card";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "../ui/dialog";
 import { SearchSelect } from "../ui/SearchSelect";
 import { FocusPicker } from "./FocusPicker";
@@ -92,7 +91,7 @@ function ExperimentTable({ sessions, onOpen, isLoading, gameId }: { sessions: Ex
   const carName = (n: string | null | undefined) => (gameId === "acc" ? accCarName(n) : n) ?? "—";
 
   return (
-    <Card className="overflow-x-auto">
+    <div className="overflow-x-auto">
       <Table>
         <THead>
           <TH align="end">#</TH>
@@ -141,7 +140,7 @@ function ExperimentTable({ sessions, onOpen, isLoading, gameId }: { sessions: Ex
           })}
         </TBody>
       </Table>
-    </Card>
+    </div>
   );
 }
 

--- a/client/src/components/tunes/FocusPicker.tsx
+++ b/client/src/components/tunes/FocusPicker.tsx
@@ -30,13 +30,7 @@ export function FocusPicker({
       <span className="text-app-compact text-app-text-muted uppercase tracking-wider">{label}</span>
       <div className="grid grid-cols-2 gap-2">
         {EXPERIMENT_FOCUSES.map((f) => (
-          <Button
-            key={f}
-            variant={value === f ? "focus-option-selected" : "focus-option"}
-            size="app-md"
-            onClick={() => onChange(f)}
-            aria-pressed={value === f}
-          >
+          <Button key={f} variant={value === f ? "focus-option-selected" : "focus-option"} size="app-md" onClick={() => onChange(f)} aria-pressed={value === f}>
             <div className="text-xs font-semibold text-app-text">{EXPERIMENT_FOCUS_LABELS[f]}</div>
             <div className="mt-0.5 text-app-compact text-app-text-dim">{EXPERIMENT_FOCUS_HINTS[f]}</div>
           </Button>

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -33,8 +33,8 @@ const buttonVariants = cva(
         "analysis-summary": "w-full !justify-start !gap-2 bg-status-success/10 !px-2 !py-1.5 text-left hover:bg-status-success/15",
         "settings-nav": "shrink-0 md:w-full !justify-start !px-4 !py-2 text-app-subtext whitespace-nowrap transition-colors text-app-text-muted hover:text-app-text hover:bg-app-surface-hover",
         "settings-nav-selected": "shrink-0 md:w-full !justify-start !px-4 !py-2 text-app-subtext whitespace-nowrap transition-colors text-app-accent bg-app-accent/10 border-0",
-        "focus-option": "!w-full !justify-start !border !py-2 text-left transition-colors border-app-border hover:border-app-accent/50",
-        "focus-option-selected": "!w-full !justify-start !border !py-2 text-left transition-colors border-app-accent bg-app-accent/10",
+        "focus-option": "!w-full !h-auto !min-h-16 !flex-col !items-start !justify-start !border !px-3 !py-3 text-left transition-colors border-app-border hover:border-app-accent/50",
+        "focus-option-selected": "!w-full !h-auto !min-h-16 !flex-col !items-start !justify-start !border !px-3 !py-3 text-left transition-colors border-app-accent bg-app-accent/10",
         "search-select-trigger":
           "border border-app-border-input px-3 py-2 text-app-subtext text-app-text-secondary outline-none transition-colors hover:text-app-text focus-visible:border-app-accent focus-visible:ring-1 focus-visible:ring-app-accent/30 md:px-2 md:py-0.5 md:text-app-compact",
         "search-select-clear": "px-2 py-2 text-app-subtext text-app-text-dim outline-none transition-colors hover:text-app-text focus-visible:text-app-text md:px-1 md:py-0.5 md:text-app-compact",

--- a/client/src/components/ui/button.tsx
+++ b/client/src/components/ui/button.tsx
@@ -32,8 +32,7 @@ const buttonVariants = cva(
         "form-section-toggle": "w-full !justify-between !py-2 text-left",
         "analysis-summary": "w-full !justify-start !gap-2 bg-status-success/10 !px-2 !py-1.5 text-left hover:bg-status-success/15",
         "settings-nav": "shrink-0 md:w-full !justify-start !px-4 !py-2 text-app-subtext whitespace-nowrap transition-colors text-app-text-muted hover:text-app-text hover:bg-app-surface-hover",
-        "settings-nav-selected":
-          "shrink-0 md:w-full !justify-start !px-4 !py-2 text-app-subtext whitespace-nowrap transition-colors text-app-accent bg-app-accent/10 border-b-2 md:border-b-0 md:border-r-2 border-app-accent",
+        "settings-nav-selected": "shrink-0 md:w-full !justify-start !px-4 !py-2 text-app-subtext whitespace-nowrap transition-colors text-app-accent bg-app-accent/10 border-0",
         "focus-option": "!w-full !justify-start !border !py-2 text-left transition-colors border-app-border hover:border-app-accent/50",
         "focus-option-selected": "!w-full !justify-start !border !py-2 text-left transition-colors border-app-accent bg-app-accent/10",
         "search-select-trigger":

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -9,11 +9,11 @@ type TabsValueProps = {
 };
 
 type TabsProps = Omit<TabsPrimitive.Root.Props, keyof TabsValueProps> & TabsValueProps;
-type TabsListProps = TabsPrimitive.List.Props & { variant?: "default" | "pills" };
+type TabsListProps = TabsPrimitive.List.Props & { variant?: "default" | "pills" | "underline" };
 
 type TabsTriggerProps = Omit<TabsPrimitive.Tab.Props, "value"> & {
   value: string;
-  variant?: "default" | "pills";
+  variant?: "default" | "pills" | "underline";
 };
 
 type TabsContentProps = Omit<TabsPrimitive.Panel.Props, "value"> & {
@@ -27,6 +27,7 @@ function TabsList({ className, variant = "default", ...props }: TabsListProps) {
   const variants = {
     default: "flex flex-wrap gap-1",
     pills: "flex flex-wrap gap-1 bg-app-surface-alt p-1",
+    underline: "flex flex-wrap border-b border-app-border",
   } as const;
   return <TabsPrimitive.List data-slot="tabs-list" data-variant={variant} className={cn(variants[variant], className, "rounded")} {...props} />;
 }
@@ -36,6 +37,8 @@ function TabsTrigger({ className, variant = "default", ...props }: TabsTriggerPr
     default:
       "px-3 py-1.5 text-app-label font-semibold text-app-text-muted transition-colors outline-none hover:bg-app-surface-hover hover:text-app-text data-[active]:bg-app-accent/20 data-[active]:text-app-accent",
     pills: "px-3 py-1.5 text-app-label font-semibold text-app-text-muted transition-colors outline-none hover:text-app-text data-[active]:bg-app-surface data-[active]:text-app-text",
+    underline:
+      "relative px-3 py-1.5 text-app-label font-semibold text-app-text-muted transition-colors outline-none hover:text-app-text data-[active]:text-app-accent data-[active]:after:absolute data-[active]:after:inset-x-0 data-[active]:after:-bottom-px data-[active]:after:h-0.5 data-[active]:after:bg-app-accent",
   } as const;
   return (
     <TabsPrimitive.Tab

--- a/client/test/insight-panel-ui.test.tsx
+++ b/client/test/insight-panel-ui.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { WheelTable } from "../src/components/analyse/WheelTable";
+import { InsightPanel } from "../src/components/InsightPanel";
+import type { LapInsight } from "../src/lib/lap-insights";
+
+const insight: LapInsight = {
+  id: "lockup-fl",
+  category: "tires",
+  severity: "warning",
+  label: "Wheel Lockup",
+  detail: "FL locked 1 time",
+  frameIndices: [42],
+};
+
+describe("Analyse panel layout", () => {
+  test("renders insight rows with content-sized plain buttons", () => {
+    const markup = renderToStaticMarkup(createElement(InsightPanel, { insights: [insight], onJumpToFrame: () => {} }));
+
+    expect(markup).toContain('data-slot="button"');
+    expect(markup).toMatch(/<button[^>]*bg-transparent[^>]*h-auto/);
+    expect(markup).not.toMatch(/<button[^>]*h-8/);
+    expect(markup).not.toMatch(/<button[^>]*bg-app-surface-alt/);
+  });
+
+  test("centers wheel headers over their value columns", () => {
+    const markup = renderToStaticMarkup(
+      createElement(WheelTable, {
+        title: "Wheels",
+        rows: [{ label: "Temperature", fl: "86°C", fr: "85°C", rl: "83°C", rr: "82°C" }],
+      }),
+    );
+
+    expect(markup).toMatch(/<th[^>]*text-center[^>]*><span>FL/);
+    expect(markup).toMatch(/<th[^>]*text-center[^>]*><span>FR/);
+    expect(markup).toMatch(/<th[^>]*text-center[^>]*><span>RL/);
+    expect(markup).toMatch(/<th[^>]*text-center[^>]*><span>RR/);
+  });
+});


### PR DESCRIPTION
## Summary
- Clean up settings navigation by hiding the duplicate Setup Wizard action at desktop widths and removing the selected-item border treatment.
- Make onboarding progress indicators informational instead of clickable controls.
- Restore responsive wheel-selector card sizing and keep wheel imagery contained within cards.
- Rework experiment focus choices as consistently sized wrapping cards and remove the extra table card shell.
- Add underline-style active states to Analyse 2D/3D and Data/Insights tabs.
- Record the related UI and AI-settings fixes in the changelog.

## Verification
- `bun run build` — passed
- `bun test test/changelog.test.ts --timeout 60000` — 7 passed
- Targeted Biome check for changed tab/focus files — passed
- Existing `ExperimentList` label accessibility diagnostics remain unchanged