### PR TITLE
fix(ai): finish Codex follow-up fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Report missing AI model settings instead of silently selecting a provider default
+- Expose Codex subscription models and preserve comparison and setup analysis across AI features
 - Keep AI chat drafts editable and show submitted prompts with the loading state immediately across chat surfaces
 
 - Keep the Compare loading message hidden after comparison data is available

--- a/client/src/components/comparison/CompareAiPanel.tsx
+++ b/client/src/components/comparison/CompareAiPanel.tsx
@@ -1,5 +1,5 @@
 import type { UIMessage } from "ai";
-import { RefreshCw, Sparkles, Trash2, X } from "lucide-react";
+import { ChevronDown, ChevronUp, RefreshCw, Sparkles, X } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useState } from "react";
 import { useSettings } from "../../hooks/queries";
 import { isAiAnalysisConfigured, launchAiFeature } from "../../lib/is-ai-configured";
@@ -198,10 +198,7 @@ function useInputsAnalysis(lapAId: number, lapBId: number, panelOpen: boolean) {
 }
 
 function useAiRunAction(aiConfigured: boolean, run: (regenerate?: boolean) => Promise<void>, configureAi: () => void) {
-  return useCallback(
-    (regenerate = false) => launchAiFeature(aiConfigured, () => void run(regenerate), configureAi),
-    [aiConfigured, configureAi, run],
-  );
+  return useCallback((regenerate = false) => launchAiFeature(aiConfigured, () => void run(regenerate), configureAi), [aiConfigured, configureAi, run]);
 }
 
 function InputsSection({
@@ -228,7 +225,13 @@ function InputsSection({
         <span className="w-2 h-2 rounded-full bg-gradient-to-r from-(--comparison-lap-a) to-(--comparison-lap-b)" />
         <span className="text-app-compact font-semibold text-app-text truncate flex-1">{m.compare_inputs_comparison_ab()}</span>
         {analysis && (
-          <Button type="button" onClick={() => runAi(true)} disabled={loading} className="text-app-text-muted hover:text-app-text disabled:opacity-40" title={aiConfigured ? m.label_regenerate() : m.ai_configure_feature()}>
+          <Button
+            type="button"
+            onClick={() => runAi(true)}
+            disabled={loading}
+            className="text-app-text-muted hover:text-app-text disabled:opacity-40"
+            title={aiConfigured ? m.label_regenerate() : m.ai_configure_feature()}
+          >
             <RefreshCw className="size-3" />
           </Button>
         )}
@@ -294,7 +297,13 @@ function LapSection({
         <span className={`w-2 h-2 rounded-full ${dotClass}`} />
         <span className="text-app-compact font-semibold text-app-text truncate flex-1">{lap.label}</span>
         {summary && (
-          <Button type="button" onClick={() => runAi(true)} disabled={loading} className="text-app-text-muted hover:text-app-text disabled:opacity-40" title={aiConfigured ? m.label_regenerate() : m.ai_configure_feature()}>
+          <Button
+            type="button"
+            onClick={() => runAi(true)}
+            disabled={loading}
+            className="text-app-text-muted hover:text-app-text disabled:opacity-40"
+            title={aiConfigured ? m.label_regenerate() : m.ai_configure_feature()}
+          >
             <RefreshCw className="size-3" />
           </Button>
         )}
@@ -471,6 +480,7 @@ export const CompareAiPanel = forwardRef<CompareAiPanelHandle, CompareAiPanelPro
   const [viewing, setViewing] = useState<{ kind: "lap"; label: string; summary: AnalysisSummary } | { kind: "inputs"; analysis: InputsAnalysis } | null>(null);
 
   const [chatRemountKey, setChatRemountKey] = useState(0);
+  const [comparisonCollapsed, setComparisonCollapsed] = useState(false);
 
   const clearChat = useCallback(() => {
     fetch(`/api/laps/${lapA.id}/compare/${lapB.id}/chat`, { method: "DELETE" })
@@ -489,26 +499,57 @@ export const CompareAiPanel = forwardRef<CompareAiPanelHandle, CompareAiPanelPro
 
   const configureAi = useCallback(() => openSettings("ai"), [openSettings]);
 
-
   const bothReady = hasA && hasB;
 
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      <div className="flex-1 overflow-y-auto min-h-0 px-3 py-3 space-y-3">
-        <LapSection lap={lapA} dotClass="bg-(--comparison-lap-a)" panelOpen={panelOpen} aiConfigured={aiConfigured} configureAi={configureAi} onAnalysisChange={setHasA} onView={(label, s) => setViewing({ kind: "lap", label, summary: s })} />
-        <LapSection lap={lapB} dotClass="bg-(--comparison-lap-b)" panelOpen={panelOpen} aiConfigured={aiConfigured} configureAi={configureAi} onAnalysisChange={setHasB} onView={(label, s) => setViewing({ kind: "lap", label, summary: s })} />
-        <InputsSection lapAId={lapA.id} lapBId={lapB.id} panelOpen={panelOpen} aiConfigured={aiConfigured} configureAi={configureAi} onView={(a) => setViewing({ kind: "inputs", analysis: a })} />
+      <div className={`flex flex-col min-h-0 ${comparisonCollapsed ? "shrink-0" : "flex-1"}`}>
+        <div className="flex items-center justify-between border-b border-app-border px-3 py-1 cursor-pointer">
+          <span className="text-app-micro font-semibold uppercase tracking-wider text-app-text-muted">{m.compare_inputs_comparison_ab()}</span>
+          <Button
+            type="button"
+            variant="app-ghost"
+            size="app-sm"
+            onClick={(event) => {
+              event.stopPropagation();
+              setComparisonCollapsed((collapsed) => !collapsed);
+            }}
+            aria-label={comparisonCollapsed ? "Expand comparison" : "Collapse comparison"}
+            title={comparisonCollapsed ? "Expand comparison" : "Collapse comparison"}
+            className="text-app-text-muted hover:text-app-text"
+          >
+            {comparisonCollapsed ? <ChevronDown className="size-4" /> : <ChevronUp className="size-4" />}
+          </Button>
+        </div>
+        {!comparisonCollapsed && (
+          <div id="compare-ai-details" className="flex-1 overflow-y-auto min-h-0 px-3 py-3 space-y-3">
+            <LapSection
+              lap={lapA}
+              dotClass="bg-(--comparison-lap-a)"
+              panelOpen={panelOpen}
+              aiConfigured={aiConfigured}
+              configureAi={configureAi}
+              onAnalysisChange={setHasA}
+              onView={(label, s) => setViewing({ kind: "lap", label, summary: s })}
+            />
+            <LapSection
+              lap={lapB}
+              dotClass="bg-(--comparison-lap-b)"
+              panelOpen={panelOpen}
+              aiConfigured={aiConfigured}
+              configureAi={configureAi}
+              onAnalysisChange={setHasB}
+              onView={(label, s) => setViewing({ kind: "lap", label, summary: s })}
+            />
+            <InputsSection lapAId={lapA.id} lapBId={lapB.id} panelOpen={panelOpen} aiConfigured={aiConfigured} configureAi={configureAi} onView={(a) => setViewing({ kind: "inputs", analysis: a })} />
 
-        {!bothReady && <div className="text-app-caption text-app-text-muted text-center py-2 border border-dashed border-app-border-input/40 rounded">{m.compare_analyse_both_laps()}</div>}
+            {!bothReady && <div className="text-app-caption text-app-text-muted text-center py-2 border border-dashed border-app-border-input/40 rounded">{m.compare_analyse_both_laps()}</div>}
+          </div>
+        )}
       </div>
 
       {bothReady && (
         <div className="flex-1 min-h-0 flex flex-col border-t border-app-border">
-          <div className="flex justify-end px-2 pt-1">
-            <Button type="button" onClick={clearChat} className="text-app-micro text-app-text-muted hover:text-status-danger">
-              <Trash2 className="size-3" />
-            </Button>
-          </div>
           <ChatPanel
             key={chatRemountKey}
             api={`/api/laps/${lapA.id}/compare/${lapB.id}/chat`}

--- a/client/src/components/comparison/CompareTrackMap.tsx
+++ b/client/src/components/comparison/CompareTrackMap.tsx
@@ -31,6 +31,9 @@ interface CompareTrackMapProps {
   trackOrdinal?: number | null;
   gameId?: GameId | null;
 }
+export function compareSegmentKey(name: string, startFrac: number, endFrac: number): string {
+  return `${name}:${startFrac}:${endFrac}`;
+}
 
 /** Dual-panel track map: overview (left) + zoomed follow (right) */
 export function CompareTrackMap({ outline, telemetryA, telemetryB, segments, hoveredDistanceRef, redrawRef, trackOrdinal, gameId }: CompareTrackMapProps) {
@@ -403,7 +406,7 @@ export function CompareTrackMap({ outline, telemetryA, telemetryB, segments, hov
               <TH align="end">+/-</TH>
             </THead>
             <TBody ref={segmentTableRef}>
-              {segments.map((s) => {
+              {segments.map((s, index) => {
                 const fasterA = s.timeA > 0 && s.timeB > 0 && s.timeA < s.timeB;
                 const fasterB = s.timeA > 0 && s.timeB > 0 && s.timeB < s.timeA;
                 const delta = s.timeA - s.timeB;
@@ -411,7 +414,7 @@ export function CompareTrackMap({ outline, telemetryA, telemetryB, segments, hov
                 const segmentDeltaColor = isNeutral ? "var(--app-text-secondary)" : deltaColor(delta);
                 const sign = delta > 0 ? "+" : "";
                 return (
-                  <TRow key={s.name}>
+                  <TRow key={compareSegmentKey(s.name, s.startFrac, s.endFrac) || index}>
                     <TD nowrap numeric tone="primary">
                       {s.name}
                     </TD>

--- a/client/src/components/settings/AiSection.tsx
+++ b/client/src/components/settings/AiSection.tsx
@@ -184,9 +184,7 @@ export function AiSection() {
     driverProfileSettings.driverProfileThinkingBudget,
   ]);
 
-const selectedProviders = Array.from(
-  new Set([provider, chatProvider, autoTuneProvider, driverProfileProvider].filter((p) => p === "gemini" || p === "openai" || p === "codex" || p === "local")),
-);
+  const selectedProviders = Array.from(new Set([provider, chatProvider, autoTuneProvider, driverProfileProvider].filter((p) => p === "gemini" || p === "openai" || p === "codex" || p === "local")));
   const keyStatus: Record<string, boolean> = {
     gemini: !!displaySettings.geminiApiKeySet,
     openai: !!displaySettings.openaiApiKeySet,
@@ -218,8 +216,7 @@ const selectedProviders = Array.from(
     if (selectedProvider === "codex") return providerReadiness.codex?.ready === true;
     return !!keyStatus[selectedProvider];
   };
-  const providerReadinessError = (selectedProvider: string): string | null =>
-    selectedProvider === "codex" ? providerReadiness.codex?.error ?? null : null;
+  const providerReadinessError = (selectedProvider: string): string | null => (selectedProvider === "codex" ? (providerReadiness.codex?.error ?? null) : null);
   const selectedProvidersForFetch = selectedProviders.filter(isProviderConfigured);
   const selectedProvidersCsv = selectedProvidersForFetch.join(",");
   const {
@@ -261,34 +258,37 @@ const selectedProviders = Array.from(
     },
   });
   const modelsRefreshing = refreshModels.isPending;
-  const models = provider === "gemini" || provider === "openai" || provider === "local" ? (aiModels?.[provider] ?? []) : [];
+  const models = provider === "gemini" || provider === "openai" || provider === "codex" || provider === "local" ? (aiModels?.[provider] ?? []) : [];
   const hasProviderKey = isProviderConfigured(provider);
   const canShowModelPicker = provider !== "" && hasProviderKey && models.length > 0;
   const effectiveGeminiModel = model || "gemini-flash-latest";
   const modelSupportsThinking = provider === "gemini" && supportsGeminiThinkingBudget(effectiveGeminiModel);
   const effectiveThinkingBudget = modelSupportsThinking ? thinkingBudget : null;
-  const chatModels = chatProvider === "gemini" || chatProvider === "openai" || chatProvider === "local" ? (aiModels?.[chatProvider] ?? []) : [];
+  const chatModels = chatProvider === "gemini" || chatProvider === "openai" || chatProvider === "codex" || chatProvider === "local" ? (aiModels?.[chatProvider] ?? []) : [];
   const hasChatProviderKey = isProviderConfigured(chatProvider);
   const canShowChatModelPicker = chatProvider !== "" && hasChatProviderKey && chatModels.length > 0;
   const effectiveChatGeminiModel = chatModel || "gemini-flash-latest";
   const chatModelSupportsThinking = chatProvider === "gemini" && supportsGeminiThinkingBudget(effectiveChatGeminiModel);
   const effectiveChatThinkingBudget = chatModelSupportsThinking ? chatThinkingBudget : null;
   const modelErrors = aiModels?._errors ?? {};
-  const providerModelError = provider === "gemini" || provider === "openai" || provider === "local" ? (modelErrors[provider] ?? null) : null;
-  const chatProviderModelError = chatProvider === "gemini" || chatProvider === "openai" || chatProvider === "local" ? (modelErrors[chatProvider] ?? null) : null;
-  const autoTuneModels = autoTuneProvider === "gemini" || autoTuneProvider === "openai" || autoTuneProvider === "local" ? (aiModels?.[autoTuneProvider] ?? []) : [];
+  const providerModelError = provider === "gemini" || provider === "openai" || provider === "codex" || provider === "local" ? (modelErrors[provider] ?? null) : null;
+  const chatProviderModelError = chatProvider === "gemini" || chatProvider === "openai" || chatProvider === "codex" || chatProvider === "local" ? (modelErrors[chatProvider] ?? null) : null;
+  const autoTuneModels = autoTuneProvider === "gemini" || autoTuneProvider === "openai" || autoTuneProvider === "codex" || autoTuneProvider === "local" ? (aiModels?.[autoTuneProvider] ?? []) : [];
   const hasAutoTuneProviderKey = isProviderConfigured(autoTuneProvider);
   const canShowAutoTuneModelPicker = autoTuneProvider !== "" && hasAutoTuneProviderKey && autoTuneModels.length > 0;
-  const autoTuneProviderModelError = autoTuneProvider === "gemini" || autoTuneProvider === "openai" || autoTuneProvider === "local" ? (modelErrors[autoTuneProvider] ?? null) : null;
-const driverProfileModels =
-  driverProfileProvider === "gemini" || driverProfileProvider === "openai" || driverProfileProvider === "local" ? (aiModels?.[driverProfileProvider] ?? []) : [];
-const hasDriverProfileProviderKey = isProviderConfigured(driverProfileProvider);
+  const autoTuneProviderModelError =
+    autoTuneProvider === "gemini" || autoTuneProvider === "openai" || autoTuneProvider === "codex" || autoTuneProvider === "local" ? (modelErrors[autoTuneProvider] ?? null) : null;
+  const driverProfileModels =
+    driverProfileProvider === "gemini" || driverProfileProvider === "openai" || driverProfileProvider === "codex" || driverProfileProvider === "local" ? (aiModels?.[driverProfileProvider] ?? []) : [];
+  const hasDriverProfileProviderKey = isProviderConfigured(driverProfileProvider);
   const canShowDriverProfileModelPicker = driverProfileProvider !== "" && hasDriverProfileProviderKey && driverProfileModels.length > 0;
   const effectiveDriverProfileGeminiModel = driverProfileModel || "gemini-flash-latest";
   const driverProfileModelSupportsThinking = driverProfileProvider === "gemini" && supportsGeminiThinkingBudget(effectiveDriverProfileGeminiModel);
   const effectiveDriverProfileThinkingBudget = driverProfileModelSupportsThinking ? driverProfileThinkingBudget : null;
   const driverProfileProviderModelError =
-    driverProfileProvider === "gemini" || driverProfileProvider === "openai" || driverProfileProvider === "local" ? (modelErrors[driverProfileProvider] ?? null) : null;
+    driverProfileProvider === "gemini" || driverProfileProvider === "openai" || driverProfileProvider === "codex" || driverProfileProvider === "local"
+      ? (modelErrors[driverProfileProvider] ?? null)
+      : null;
 
   const initialProvider = analysisBaseline.provider;
   const initialModel = analysisBaseline.model;
@@ -526,7 +526,7 @@ const hasDriverProfileProviderKey = isProviderConfigured(driverProfileProvider);
               }}
               className="bg-app-surface border border-app-border-input rounded px-3 py-1.5 text-sm text-app-text w-full max-w-xs"
             >
-              <option value="">{m.ai_model_default()}</option>
+              <option value="">{provider === "codex" ? "Select a Codex model" : m.ai_model_default()}</option>
               {models.map((m: { id: string; name: string }) => (
                 <option key={m.id} value={m.id}>
                   {m.name}
@@ -656,7 +656,7 @@ const hasDriverProfileProviderKey = isProviderConfigured(driverProfileProvider);
               }}
               className="bg-app-surface border border-app-border-input rounded px-3 py-1.5 text-sm text-app-text w-full max-w-xs"
             >
-              <option value="">{m.ai_model_default()}</option>
+              <option value="">{chatProvider === "codex" ? "Select a Codex model" : m.ai_model_default()}</option>
               {chatModels.map((m: { id: string; name: string }) => (
                 <option key={m.id} value={m.id}>
                   {m.name}
@@ -807,7 +807,7 @@ const hasDriverProfileProviderKey = isProviderConfigured(driverProfileProvider);
               onChange={(e) => setAutoTuneModel(e.target.value)}
               className="bg-app-surface border border-app-border-input rounded px-3 py-1.5 text-sm text-app-text w-full max-w-xs"
             >
-              <option value="">{m.ai_model_default()}</option>
+              <option value="">{autoTuneProvider === "codex" ? "Select a Codex model" : m.ai_model_default()}</option>
               {autoTuneModels.map((mm: { id: string; name: string }) => (
                 <option key={mm.id} value={mm.id}>
                   {mm.name}
@@ -960,7 +960,7 @@ const hasDriverProfileProviderKey = isProviderConfigured(driverProfileProvider);
               }}
               className="bg-app-surface border border-app-border-input rounded px-3 py-1.5 text-sm text-app-text w-full max-w-xs"
             >
-              <option value="">{m.ai_model_default()}</option>
+              <option value="">{driverProfileProvider === "codex" ? "Select a Codex model" : m.ai_model_default()}</option>
               {driverProfileModels.map((mm: { id: string; name: string }) => (
                 <option key={mm.id} value={mm.id}>
                   {mm.name}

--- a/server/ai/format-tune.ts
+++ b/server/ai/format-tune.ts
@@ -7,7 +7,45 @@ interface TuneForPrompt {
 	settings: TuneSettings;
 }
 
+function summariseGameSpecificSettings(settings: unknown): string | null {
+	if (!settings || typeof settings !== "object") return null;
+	const lines: string[] = [];
+	const walk = (value: unknown, path: string) => {
+		if (lines.length >= 60 || value == null) return;
+		if (Array.isArray(value)) {
+			if (value.length > 0 && value.length <= 8 && value.every((item) => typeof item === "number" || typeof item === "string")) {
+				lines.push(`${path}: [${value.join(", ")}]`);
+			}
+			return;
+		}
+		if (typeof value === "object") {
+			for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+				walk(child, path ? `${path}.${key}` : key);
+			}
+			return;
+		}
+		if (typeof value === "number" || typeof value === "boolean" || typeof value === "string") {
+			lines.push(`${path}: ${value}`);
+		}
+	};
+	walk(settings, "");
+	return lines.length > 0 ? lines.join("\n") : null;
+}
+
+function isForzaTuneSettings(settings: TuneSettings): boolean {
+	const value = settings as unknown as Record<string, unknown>;
+	return Boolean(value.tires && value.gearing && value.alignment && value.antiRollBars && value.springs && value.damping && value.aero && value.differential && value.brakes);
+}
+
+
 export function formatTuneForPrompt(tune: TuneForPrompt): string {
+	if (!isForzaTuneSettings(tune.settings)) {
+		const summary = summariseGameSpecificSettings(tune.settings);
+		return [
+			`--- ACTIVE TUNE: "${tune.name}" by ${tune.author} (${tune.category}) ---`,
+			summary ? `Game-specific setup values:\n${summary}` : "Game-specific setup values unavailable.",
+		].join("\n");
+	}
 	const s = tune.settings;
 	const lines: string[] = [];
 

--- a/server/ai/model-provider.ts
+++ b/server/ai/model-provider.ts
@@ -112,9 +112,6 @@ export async function runAiChat(
   return runMastra(context);
 }
 
-export type AiStructuredOptions = {
-  operation?: "comparison";
-};
 
 function normalizeMastraResult(result: MastraResult, model: string): AiResult {
   if (
@@ -156,14 +153,7 @@ export async function runAiStructured(
   ai: ResolvedAi,
   input: StructuredRequest<unknown>,
   runMastra: (context: RequestContext) => Promise<unknown>,
-  options?: AiStructuredOptions,
 ): Promise<AiResult> {
-  if (options?.operation === "comparison" && ai.provider === "codex") {
-    throw new AiProviderError(
-      `Comparison analysis is not supported for ${ai.provider} provider on ${ai.feature} feature.`,
-      { code: "unsupported-operation", provider: ai.provider, modelId: ai.model },
-    );
-  }
 
   const internals = getResolvedAiInternals(ai);
   if (!internals?.model) return ai.generateStructured(input);

--- a/server/ai/providers.ts
+++ b/server/ai/providers.ts
@@ -5,6 +5,9 @@
 import { extractJson } from "./extract-json";
 import { AiProviderError } from "./provider-error";
 import { buildGoogleThinkingProviderOptions } from "./google-provider-options";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 export interface AiResult {
   analysis: string;
   usage: {
@@ -217,7 +220,8 @@ export async function runCodexCli(
   const startedAt = Date.now();
   const executable = codexExecutable(options);
   const args = [executable, "exec", "--json", "--ephemeral", "--skip-git-repo-check"];
-  if (model?.trim()) args.push("--model", model.trim());
+  const selectedModel = model?.trim();
+  if (selectedModel && selectedModel !== "codex-default") args.push("--model", selectedModel);
   args.push("-");
   let result: CodexProcessResult;
   try {
@@ -240,7 +244,7 @@ export async function runCodexCli(
       outputTokens: parsed.outputTokens,
       costUsd: 0,
       durationMs: Date.now() - startedAt,
-      model: model?.trim() || parsed.model,
+      model: selectedModel || parsed.model,
     },
   };
 }
@@ -639,6 +643,24 @@ export async function runOpenAi(
 ): Promise<AiResult> {
   return runOpenAiCompatible({ prompt, apiKey, model, schema, schemaName });
 }
+const CODEX_MODELS_CACHE_FILE = "models_cache.json";
+
+export function getCodexModels() {
+  try {
+    const codexHome = process.env.CODEX_HOME?.trim() || join(homedir(), ".codex");
+    const cache = JSON.parse(readFileSync(join(codexHome, CODEX_MODELS_CACHE_FILE), "utf8")) as {
+      models?: { slug?: unknown; display_name?: unknown; visibility?: unknown }[];
+    };
+    const models = (cache.models ?? [])
+      .filter((model) => model.visibility === "list" && typeof model.slug === "string" && typeof model.display_name === "string")
+      .map((model) => ({ id: model.slug as string, name: model.display_name as string }));
+    if (models.length > 0) return models;
+  } catch {
+    // Older Codex CLI versions may not have a model cache yet.
+  }
+  return [{ id: "codex-default", name: "Codex configured default" }];
+}
+
 
 const OPENAI_MODELS = [
   { id: "gpt-4o-mini", name: "GPT-4o Mini" },

--- a/server/routes/lap-routes.ts
+++ b/server/routes/lap-routes.ts
@@ -1222,7 +1222,7 @@ export const lapRoutes = new Hono()
         compareEngineerAgent.generate(prompt, {
           requestContext,
           modelSettings: { maxOutputTokens: 8192, temperature: 0 },
-        }), { operation: "comparison" });
+        }));
       const durationMs = Math.round(performance.now() - start);
       const object = InputsCompareSchema.parse(JSON.parse(extractJson(result.analysis)));
 

--- a/server/routes/settings-routes.ts
+++ b/server/routes/settings-routes.ts
@@ -16,7 +16,7 @@ import { getRunningGame } from "../games/registry";
 import { getTrackLengthMeters } from "../../shared/track-data";
 import { withOnboardingOverride } from "../runtime-options";
 
-import { getCodexStatus, getProviders, type CodexStatus } from "../ai/providers";
+import { getCodexModels, getCodexStatus, getGeminiModelsDetailed, getLocalModelsDetailed, getOpenAiModels, getProviders, type CodexStatus } from "../ai/providers";
 const MODELS_CACHE_TTL_MS = 5 * 60 * 1000;
 const MODELS_EMPTY_RETRY_MS = 10 * 1000;
 let cachedGeminiModels: { key: string; models: { id: string; name: string }[]; at: number } | null = null;
@@ -97,7 +97,6 @@ export const settingsRoutes = new Hono()
 
   // GET /api/ai-models — available models per provider
   .get("/api/ai-models", async (c) => {
-    const { getGeminiModelsDetailed, getOpenAiModels, getLocalModelsDetailed } = await import("../ai/providers");
     const forceRefresh = c.req.query("refresh") === "1";
     console.info(`[AI] ai-models request refresh=${forceRefresh ? "1" : "0"} providers=${c.req.query("providers") ?? "<settings>"}`);
 
@@ -186,7 +185,7 @@ export const settingsRoutes = new Hono()
     return c.json({
       "gemini": geminiModels,
       "openai": getOpenAiModels(),
-      "codex": [],
+      "codex": getCodexModels(),
       "local": localModels,
       "_errors": { gemini: geminiError, openai: null, codex: null, local: localError },
     });

--- a/test/ai-model-provider.test.ts
+++ b/test/ai-model-provider.test.ts
@@ -123,18 +123,33 @@ describe("settings-aware model provider", () => {
     expect(result).toMatchObject({ analysis: "ok", usage: { model: "gpt-4o-mini" } });
   });
 
-  test("rejects Codex comparison centrally before native execution", async () => {
-    const codex = await resolveAi("analysis", settings({ aiProvider: "codex", aiModel: "codex-model" }));
+  test("dispatches Codex comparison through native structured generation", async () => {
+    let called = false;
+    const codex = {
+      feature: "analysis" as const,
+      provider: "codex" as const,
+      model: "codex",
+      generateText: async () => {
+        throw new Error("comparison must use structured generation");
+      },
+      generateStructured: async () => {
+        called = true;
+        return {
+          analysis: "{\"ok\":true}",
+          usage: { inputTokens: 1, outputTokens: 2, costUsd: 0, durationMs: 3, model: "codex" },
+        };
+      },
+    };
 
-    await expect(runAiStructured(codex, {
+    const result = await runAiStructured(codex, {
       prompt: "compare",
       schema: {},
     }, async () => {
-      throw new Error("comparison Mastra must not run");
-    }, { operation: "comparison" })).rejects.toMatchObject({
-      code: "unsupported-operation",
-      provider: "codex",
+      throw new Error("Codex comparison must not run through Mastra");
     });
+
+    expect(called).toBe(true);
+    expect(result).toMatchObject({ analysis: "{\"ok\":true}", usage: { model: "codex" } });
   });
 
   test("dispatches Codex prose through native text generation", async () => {

--- a/test/codex-provider.test.ts
+++ b/test/codex-provider.test.ts
@@ -115,6 +115,27 @@ printf '%s\\n' '${jsonl(
       rmSync(keyFile, { force: true });
     }
   });
+  test("uses Codex CLI configured default for codex-default model", async () => {
+    const argsFile = join(tmpdir(), `raceiq-codex-default-args-${crypto.randomUUID()}`);
+    const { executable } = makeFakeExecutable(`
+printf '%s\\n' "$@" > "$CODEX_ARGS_FILE"
+printf '%s\\n' '${jsonl(
+  { type: "item.completed", item: { type: "agent_message", text: "ok" } },
+  { type: "turn.completed", usage: {} },
+)}'
+`);
+    try {
+      await expect(runCodexCli("prompt", "codex-default", {
+        executable,
+        env: { CODEX_ARGS_FILE: argsFile },
+      })).resolves.toMatchObject({ usage: { model: "codex-default" } });
+      expect(readFileSync(argsFile, "utf8").trim().split("\n")).toEqual([
+        "exec", "--json", "--ephemeral", "--skip-git-repo-check", "-",
+      ]);
+    } finally {
+      rmSync(argsFile, { force: true });
+    }
+  });
 
   test("reports non-zero exit with truncated stderr", async () => {
     const { executable } = makeFakeExecutable(`

--- a/test/compare-segment-key.test.ts
+++ b/test/compare-segment-key.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { compareSegmentKey } from "../client/src/components/comparison/CompareTrackMap";
+
+describe("compareSegmentKey", () => {
+  test("distinguishes repeated display names by segment position", () => {
+    const keys = [
+      compareSegmentKey("Start/Finish", 0, 0.1),
+      compareSegmentKey("Start/Finish", 0.9, 1),
+    ];
+
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/test/format-tune.test.ts
+++ b/test/format-tune.test.ts
@@ -79,4 +79,15 @@ describe("formatTuneForPrompt", () => {
 		expect(result).toContain("Minimal");
 		expect(result).not.toContain("undefined");
 	});
+	test("summarises game-specific setup blobs without throwing", () => {
+		const result = formatTuneForPrompt({
+			name: "AC Evo setup",
+			author: "RaceIQ",
+			category: "road",
+			settings: { frontARB: 2, rearARB: 3 } as TuneSettings,
+		});
+		expect(result).toContain("AC Evo setup");
+		expect(result).toContain("frontARB: 2");
+		expect(result).toContain("rearARB: 3");
+	});
 });

--- a/test/settings.test.ts
+++ b/test/settings.test.ts
@@ -125,10 +125,12 @@ describe("Codex provider discovery", () => {
     }
   });
 
-  test("keeps Codex model discovery empty", async () => {
+  test("returns visible Codex subscription models", async () => {
     const response = await settingsRoutes.request("/api/ai-models?providers=codex");
     expect(response.status).toBe(200);
-    const models = await response.json() as { codex: unknown[] };
-    expect(models.codex).toEqual([]);
+    const models = await response.json() as { codex: { id: string; name: string }[] };
+    expect(models.codex.length).toBeGreaterThan(0);
+    expect(models.codex.every((model) => model.id !== "codex-auto-review")).toBe(true);
+    expect(models.codex.every((model) => model.name.length > 0)).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- expose Codex subscription models and handle codex-default CLI selection
- support Codex comparison dispatch and tune prompt settings summaries
- add comparison collapse and stable segment keys with focused coverage

## Verification
- Focused tests: 37 pass, 0 fail, 76 assertions
- Client build: passed (Vite; 5,715 modules transformed)
- Note: repository lint has pre-existing diagnostics outside this change; changed-file accessibility findings were addressed where introduced.