### PR TITLE
fix(chat): stop render subscription loop

### DIFF
--- a/client/src/components/ai-chat/ChatPanel.tsx
+++ b/client/src/components/ai-chat/ChatPanel.tsx
@@ -3,7 +3,7 @@ import { AssistantChatTransport, createResumableSessionStorage, useChatRuntime, 
 import { contextWindowFor } from "@shared/ai/context-window";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { UIMessage } from "ai";
-import { useEffect, useMemo, useReducer, useState } from "react";
+import { useMemo, useState } from "react";
 import { Thread, type ThreadProps } from "@/components/assistant-ui/thread";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { client } from "@/lib/rpc";
@@ -358,12 +358,6 @@ function ChatPanelThread({
     transport,
     onFinish,
   });
-  // useChatRuntime's remote thread updates its resource directly, but the
-  // provider-level client subscription can miss those optimistic updates.
-  // Bridge active-thread notifications into this provider render so the user
-  // turn and running state appear as soon as send starts, not after finish.
-  const [, refreshThread] = useReducer((revision: number) => revision + 1, 0);
-  useEffect(() => runtime.thread.subscribe(refreshThread), [runtime]);
   const [compacting, setCompacting] = useState(false);
 
   return (


### PR DESCRIPTION
## Summary
- remove ChatPanel subscription that re-rendered recursively
- restore Setup Engineer response rendering

## Verification
- `cd client && bun run build`
- Full `bun test` did not complete: it timed out during existing suite execution without reporting a test failure.