### PR TITLE
Fix Compare alignment after crashes and shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - Highlight the active sector-blip setting with a cyan border
 - Keep analysis and comparison pages usable on wide, low-height displays
 - Resize the comparison track map with a persisted splitter and keep the AI Analysis control right-aligned
-- Keep the iRacing analysis car indicator aligned with track direction in fixed and follow map views
+- Keep Compare map markers, telemetry inputs, and deltas aligned by track position after crashes, spins, shortcuts, and off-track detours
 - Show corner and straight times on iRacing analysis laps without world-position telemetry
 - Keep table text, guide cards, and setup rows consistently scaled without overflowing, and align Tracks sorting with Track Detail tabs without extra divider spacing
 - Use one consistent table layout, spacing, alignment, and borderless sortable-header style throughout dashboards and analysis views

--- a/client/test/comparison-cursor-alignment.test.ts
+++ b/client/test/comparison-cursor-alignment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { resolveAlignedCursor } from "../src/lib/comparison-utils";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+
+const packet = (position: number): TelemetryPacket => ({ PositionX: position, PositionZ: 0 } as TelemetryPacket);
+
+describe("comparison aligned cursor", () => {
+  test("resolves each lap through its aligned source index", () => {
+    const telemetryA = [0, 50, 75, 100].map(packet);
+    const telemetryB = [0, 50, 55, 75, 100].map(packet);
+    const cursor = resolveAlignedCursor(telemetryA, telemetryB, [0, 50, 75, 100], [0, 1, 2, 3], [0, 1, 3, 4], 75);
+    expect(cursor).toEqual({ gridIndex: 2, packetA: telemetryA[2], packetB: telemetryB[3] });
+  });
+
+  test("returns null for empty cursor and does not substitute invalid indices", () => {
+    expect(resolveAlignedCursor([], [], [], [], [], null)).toBeNull();
+    const cursor = resolveAlignedCursor([packet(0)], [packet(0)], [0], [4], [0], 0);
+    expect(cursor?.packetA).toBeNull();
+    expect(cursor?.packetB).not.toBeNull();
+  });
+});

--- a/mastra/tools/setup-engineer.ts
+++ b/mastra/tools/setup-engineer.ts
@@ -52,6 +52,7 @@ import { consultLapAnalystForSession } from "../../server/ai/consult-lap-analyst
 import { loadCleanLapAggregate } from "../../server/experiments/lap-evidence/aggregate";
 import { setLapExperimentExcluded, getLapsForExperiment } from "../../server/db/experiment-lap-queries";
 import { getLapById } from "../../server/db/lap-read-queries";
+import { resolveTrack } from "../../server/tracks/info";
 import { recordAction } from "../../server/db/experiment-action-queries";
 import { undoLastAction } from "../../server/experiments/undo"
 import { detectCorners } from "../../server/lap-analysis/corners";
@@ -938,9 +939,13 @@ export function buildSetupEngineerTools() {
       if (lapA.telemetry.length === 0 || lapB.telemetry.length === 0) {
         return { ok: false, error: "One or both laps have no telemetry data." };
       }
-
       const corners = detectCorners(lapA.telemetry);
-      const result = compareLaps(lapA.telemetry, lapB.telemetry, corners);
+      const track = resolveTrack(lapA.gameId, lapA.trackOrdinal);
+      const result = compareLaps(lapA.telemetry, lapB.telemetry, corners, {
+        lapAIsValid: lapA.isValid,
+        lapBIsValid: lapB.isValid,
+        trackLengthMeters: track.lengthMeters,
+      });
       const timeDeltaSec = result.timeDelta.length > 0 ? result.timeDelta[result.timeDelta.length - 1]! : 0;
 
       return {

--- a/playwright/tests/seeded/compare/base-flow.spec.ts
+++ b/playwright/tests/seeded/compare/base-flow.spec.ts
@@ -30,6 +30,8 @@ test("Compare complete seeded flow (FM23) preserves identity/order, renders trac
   await page.goto(`/${fm23.prefix}/compare?${query}`, { waitUntil: "domcontentloaded" });
   expect(comparison.traces.distance.length, "trace length").toBeGreaterThan(1);
   expect(comparison.traces.distance).toHaveLength(comparison.timeDelta.length);
+  expect(comparison.traces.sourceIndicesA).toHaveLength(comparison.traces.distance.length);
+  expect(comparison.traces.sourceIndicesB).toHaveLength(comparison.traces.distance.length);
   expect(comparison.timeDelta).not.toHaveLength(0);
 
   const workspace = page.getByTestId("lap-compare-workspace");

--- a/server/lap-analysis/comparison.ts
+++ b/server/lap-analysis/comparison.ts
@@ -1,41 +1,44 @@
 import type { TelemetryPacket } from "../../shared/telemetry/types";
+import { hasWorldPositions, lapPath } from "../../shared/racing/tracks/path";
 import type { Corner } from "./corners";
 import { speedMphFromPacket } from "./metrics";
 
-/** A single aligned data point at a given distance. */
 export interface AlignedTrace {
-  speed: number[]; // mph
-  throttle: number[]; // 0-1
-  brake: number[]; // 0-1
-  steer: number[]; // raw u8 (127=center)
+  speed: number[];
+  throttle: number[];
+  brake: number[];
+  steer: number[];
   rpm: number[];
   gear: number[];
   posX: number[];
   posZ: number[];
-  elapsedTime: number[]; // seconds from lap start
-  tireWear: number[]; // average of all 4 tires (0-1)
-  fuel: number[]; // raw fuel value (game-dependent units; treated as a fraction for FM)
+  elapsedTime: number[];
+  tireWear: number[];
+  fuel: number[];
+  sourceIndices: number[];
 }
 
 export interface ComparisonResult {
-  distances: number[]; // 1-meter grid
+  distances: number[];
   lapA: AlignedTrace;
   lapB: AlignedTrace;
-  timeDelta: number[]; // cumulative time delta (positive = lapA slower, lapB gaining)
+  timeDelta: number[];
   cornerDeltas: CornerDelta[];
 }
 
 export interface CornerDelta {
   label: string;
-  deltaSeconds: number; // positive = lapA slower in this corner
-  timeA: number; // section time for lap A in seconds
-  timeB: number; // section time for lap B in seconds
+  deltaSeconds: number;
+  timeA: number;
+  timeB: number;
 }
 
+export interface ComparisonOptions {
+  lapAIsValid?: boolean;
+  lapBIsValid?: boolean;
+  trackLengthMeters?: number | null;
+}
 
-/**
- * Build per-packet arrays of values we want to interpolate.
- */
 interface LapData {
   distances: number[];
   speeds: number[];
@@ -51,201 +54,213 @@ interface LapData {
   fuels: number[];
 }
 
-function extractLapData(packets: TelemetryPacket[]): LapData {
-  const first = packets[0];
-  const distanceAtLapStart = first.DistanceTraveled;
-  const data: LapData = {
-    distances: new Array(packets.length),
-    speeds: new Array(packets.length),
-    throttles: new Array(packets.length),
-    brakes: new Array(packets.length),
-    steers: new Array(packets.length),
-    rpms: new Array(packets.length),
-    gears: new Array(packets.length),
-    posXs: new Array(packets.length),
-    posZs: new Array(packets.length),
-    times: new Array(packets.length),
-    tireWears: new Array(packets.length),
-    fuels: new Array(packets.length),
-  };
-
-  for (let index = 0; index < packets.length; index++) {
-    const packet = packets[index];
-    data.distances[index] = packet.DistanceTraveled - distanceAtLapStart;
-    data.speeds[index] = speedMphFromPacket(packet);
-    data.throttles[index] = packet.Accel / 255;
-    data.brakes[index] = packet.Brake / 255;
-    data.steers[index] = packet.Steer;
-    data.rpms[index] = packet.CurrentEngineRpm;
-    data.gears[index] = packet.Gear;
-    data.posXs[index] = packet.VelocityX;
-    data.posZs[index] = packet.VelocityZ;
-    data.times[index] = (packet.TimestampMS - first.TimestampMS) / 1000;
-    data.tireWears[index] =
-      (packet.TireWearFL + packet.TireWearFR + packet.TireWearRL + packet.TireWearRR) / 4;
-    data.fuels[index] = packet.Fuel;
-  }
-
-  return data;
+function positiveSpan(packets: TelemetryPacket[]): number {
+  const first = packets.find((packet) => Number.isFinite(packet.DistanceTraveled));
+  const last = [...packets].reverse().find((packet) => Number.isFinite(packet.DistanceTraveled));
+  return first && last ? Math.max(0, last.DistanceTraveled - first.DistanceTraveled) : 0;
 }
 
-function interpolateSample(
-  values: number[],
-  lower: number,
-  upper: number,
-  interpolation: number,
-): number {
+function rawDistances(packets: TelemetryPacket[]): number[] {
+  const first = packets.find((packet) => Number.isFinite(packet.DistanceTraveled))?.DistanceTraveled ?? 0;
+  let previous = 0;
+  return packets.map((packet) => {
+    const raw = packet.DistanceTraveled - first;
+    const next = Number.isFinite(raw) && raw >= previous ? raw : previous;
+    previous = next;
+    return next;
+  });
+}
+
+function fractionDistances(packets: TelemetryPacket[], span: number): number[] | null {
+  const values = packets.map((packet) => packet.iracing?.lapDistancePct);
+  if (values.filter((value) => Number.isFinite(value)).length < 2) return null;
+  let previous = 0;
+  let offset = 0;
+  const fractions = values.map((value) => {
+    if (!Number.isFinite(value)) return previous;
+    let next = value! + offset;
+    if (next < previous - 0.5) {
+      offset += 1;
+      next = value! + offset;
+    }
+    next = Math.max(previous, Math.min(1, next));
+    previous = next;
+    return next;
+  });
+  const start = fractions[0] ?? 0;
+  const end = fractions.at(-1) ?? start;
+  if (!(end > start)) return null;
+  return fractions.map((fraction) => ((fraction - start) / (end - start)) * span);
+}
+
+function projectPoint(px: number, pz: number, ax: number, az: number, bx: number, bz: number): { t: number; distance: number } {
+  const dx = bx - ax;
+  const dz = bz - az;
+  const lengthSquared = dx * dx + dz * dz;
+  const rawT = lengthSquared > 0 ? ((px - ax) * dx + (pz - az) * dz) / lengthSquared : 0;
+  const t = Math.max(0, Math.min(1, rawT));
+  return { t, distance: Math.hypot(px - (ax + dx * t), pz - (az + dz * t)) };
+}
+
+function projectedDistances(packets: TelemetryPacket[], referencePackets: TelemetryPacket[], nominalSpan: number): number[] | null {
+  const path = lapPath(referencePackets);
+  const points = path.x
+    .map((x, index) => ({ x, z: path.z[index] }))
+    .filter((point) => Number.isFinite(point.x) && Number.isFinite(point.z) && (point.x !== 0 || point.z !== 0));
+  if (points.length < 20) return null;
+  const cumulative = [0];
+  for (let index = 1; index < points.length; index++) {
+    cumulative.push(cumulative[index - 1] + Math.hypot(points[index].x - points[index - 1].x, points[index].z - points[index - 1].z));
+  }
+  const total = cumulative.at(-1) ?? 0;
+  if (!(total > 0)) return null;
+
+  const raw = rawDistances(packets);
+  const projected: number[] = [];
+  let previous = 0;
+  for (let index = 0; index < packets.length; index++) {
+    const packet = packets[index];
+    const { PositionX: x, PositionZ: z } = packet;
+    if (!Number.isFinite(x) || !Number.isFinite(z) || (x === 0 && z === 0)) {
+      projected.push(previous);
+      continue;
+    }
+    const increment = index > 0 ? Math.max(0, raw[index] - raw[index - 1]) : 50;
+    const low = index === 0 ? 0 : Math.max(0, previous - 25);
+    const high = index === 0 ? Math.min(total, 50) : Math.min(total, previous + Math.min(250, Math.max(50, increment * 3)));
+    let bestProgress = previous;
+    let bestDistance = Number.POSITIVE_INFINITY;
+    for (let segment = 0; segment < points.length - 1; segment++) {
+      if (cumulative[segment + 1] < low || cumulative[segment] > high) continue;
+      const candidate = projectPoint(x, z, points[segment].x, points[segment].z, points[segment + 1].x, points[segment + 1].z);
+      const progress = cumulative[segment] + candidate.t * (cumulative[segment + 1] - cumulative[segment]);
+      if (progress >= low && progress <= high && candidate.distance < bestDistance) {
+        bestDistance = candidate.distance;
+        bestProgress = progress;
+      }
+    }
+    previous = Math.max(previous, Math.min(high, bestProgress));
+    projected.push(previous);
+  }
+  const start = projected[0] ?? 0;
+  const end = projected.at(-1) ?? start;
+  if (!(end > start)) return null;
+  return projected.map((value) => ((value - start) / (end - start)) * nominalSpan);
+}
+
+function chooseReferenceIndex(packetsA: TelemetryPacket[], packetsB: TelemetryPacket[], options: ComparisonOptions): 0 | 1 {
+  if (options.lapAIsValid !== options.lapBIsValid) return options.lapAIsValid ? 0 : 1;
+  const spanA = positiveSpan(packetsA);
+  const spanB = positiveSpan(packetsB);
+  if (Number.isFinite(options.trackLengthMeters) && options.trackLengthMeters! > 0) {
+    const errorA = Math.abs(spanA - options.trackLengthMeters!);
+    const errorB = Math.abs(spanB - options.trackLengthMeters!);
+    if (errorA !== errorB) return errorA < errorB ? 0 : 1;
+  }
+  return spanA <= spanB ? 0 : 1;
+}
+
+function buildAlignmentDistances(packetsA: TelemetryPacket[], packetsB: TelemetryPacket[], options: ComparisonOptions): [number[], number[], number] {
+  const referencePackets = chooseReferenceIndex(packetsA, packetsB, options) === 0 ? packetsA : packetsB;
+  const nominalSpan = positiveSpan(referencePackets) || Math.max(positiveSpan(packetsA), positiveSpan(packetsB));
+  if (hasWorldPositions(packetsA) && hasWorldPositions(packetsB) && nominalSpan > 0) {
+    const distancesA = projectedDistances(packetsA, referencePackets, nominalSpan);
+    const distancesB = projectedDistances(packetsB, referencePackets, nominalSpan);
+    if (distancesA && distancesB) return [distancesA, distancesB, nominalSpan];
+  }
+  const fractionsA = fractionDistances(packetsA, nominalSpan);
+  const fractionsB = fractionDistances(packetsB, nominalSpan);
+  if (fractionsA && fractionsB) return [fractionsA, fractionsB, nominalSpan];
+  return [rawDistances(packetsA), rawDistances(packetsB), nominalSpan];
+}
+
+function extractLapData(packets: TelemetryPacket[], distances: number[]): LapData {
+  const first = packets[0];
+  return {
+    distances,
+    speeds: packets.map(speedMphFromPacket),
+    throttles: packets.map((packet) => packet.Accel / 255),
+    brakes: packets.map((packet) => packet.Brake / 255),
+    steers: packets.map((packet) => packet.Steer),
+    rpms: packets.map((packet) => packet.CurrentEngineRpm),
+    gears: packets.map((packet) => packet.Gear),
+    posXs: packets.map((packet) => packet.PositionX),
+    posZs: packets.map((packet) => packet.PositionZ),
+    times: packets.map((packet) => (packet.TimestampMS - first.TimestampMS) / 1000),
+    tireWears: packets.map((packet) => (packet.TireWearFL + packet.TireWearFR + packet.TireWearRL + packet.TireWearRR) / 4),
+    fuels: packets.map((packet) => packet.Fuel),
+  };
+}
+
+function interpolateSample(values: number[], lower: number, upper: number, interpolation: number): number {
   if (lower === upper) return values[lower];
   return values[lower] + interpolation * (values[upper] - values[lower]);
 }
 
-/**
- * Align all channels to the 1-metre distance grid in one pass.
- * Source distances must be monotonically non-decreasing.
- */
 function alignLap(data: LapData, grid: number[]): AlignedTrace {
   const trace: AlignedTrace = {
-    speed: new Array(grid.length),
-    throttle: new Array(grid.length),
-    brake: new Array(grid.length),
-    steer: new Array(grid.length),
-    rpm: new Array(grid.length),
-    gear: new Array(grid.length),
-    posX: new Array(grid.length),
-    posZ: new Array(grid.length),
-    elapsedTime: new Array(grid.length),
-    tireWear: new Array(grid.length),
-    fuel: new Array(grid.length),
+    speed: new Array(grid.length), throttle: new Array(grid.length), brake: new Array(grid.length), steer: new Array(grid.length),
+    rpm: new Array(grid.length), gear: new Array(grid.length), posX: new Array(grid.length), posZ: new Array(grid.length),
+    elapsedTime: new Array(grid.length), tireWear: new Array(grid.length), fuel: new Array(grid.length), sourceIndices: new Array(grid.length),
   };
-  const lastSourceIndex = data.distances.length - 1;
+  const last = Math.max(0, data.distances.length - 1);
   let sourceIndex = 0;
-
   for (let gridIndex = 0; gridIndex < grid.length; gridIndex++) {
     const distance = grid[gridIndex];
-    while (
-      sourceIndex < lastSourceIndex - 1 &&
-      data.distances[sourceIndex + 1] < distance
-    ) {
-      sourceIndex++;
-    }
-
+    while (sourceIndex < last && data.distances[sourceIndex + 1] <= distance) sourceIndex++;
     let lower = sourceIndex;
-    let upper = sourceIndex + 1;
-    if (distance <= data.distances[0]) {
-      lower = upper = 0;
-    } else if (distance >= data.distances[lastSourceIndex]) {
-      lower = upper = lastSourceIndex;
-    }
-
+    let upper = Math.min(last, sourceIndex + 1);
+    if (distance <= data.distances[0]) lower = upper = 0;
+    else if (distance >= data.distances[last]) lower = upper = last;
     const x0 = data.distances[lower];
     const x1 = data.distances[upper];
-    if (x1 === x0) upper = lower;
-    const interpolation = x1 === x0 ? 0 : (distance - x0) / (x1 - x0);
+    const interpolation = x1 === x0 ? 0 : Math.max(0, Math.min(1, (distance - x0) / (x1 - x0)));
+    trace.sourceIndices[gridIndex] = interpolation < 0.5 ? lower : upper;
     trace.speed[gridIndex] = interpolateSample(data.speeds, lower, upper, interpolation);
     trace.throttle[gridIndex] = interpolateSample(data.throttles, lower, upper, interpolation);
     trace.brake[gridIndex] = interpolateSample(data.brakes, lower, upper, interpolation);
     trace.steer[gridIndex] = interpolateSample(data.steers, lower, upper, interpolation);
     trace.rpm[gridIndex] = interpolateSample(data.rpms, lower, upper, interpolation);
-    trace.gear[gridIndex] = Math.round(
-      interpolateSample(data.gears, lower, upper, interpolation),
-    );
+    trace.gear[gridIndex] = Math.round(interpolateSample(data.gears, lower, upper, interpolation));
     trace.posX[gridIndex] = interpolateSample(data.posXs, lower, upper, interpolation);
     trace.posZ[gridIndex] = interpolateSample(data.posZs, lower, upper, interpolation);
     trace.elapsedTime[gridIndex] = interpolateSample(data.times, lower, upper, interpolation);
     trace.tireWear[gridIndex] = interpolateSample(data.tireWears, lower, upper, interpolation);
     trace.fuel[gridIndex] = interpolateSample(data.fuels, lower, upper, interpolation);
   }
-
   return trace;
 }
 
-/**
- * Compute cumulative time delta at each distance point.
- * Positive = lapA is slower (lapB is ahead / gaining time).
- */
-function computeTimeDelta(
-  lapATime: number[],
-  lapBTime: number[]
-): number[] {
-  return lapATime.map((tA, i) => tA - lapBTime[i]);
+function computeTimeDelta(lapATime: number[], lapBTime: number[]): number[] {
+  return lapATime.map((time, index) => time - lapBTime[index]);
 }
 
-/**
- * Compute per-corner time deltas.
- * For each corner, the delta is the change in cumulative time delta
- * from corner start to corner end.
- */
-function computeCornerDeltas(
-  corners: Corner[],
-  distances: number[],
-  timeDelta: number[],
-  lapATime: number[],
-  lapBTime: number[],
-): CornerDelta[] {
+function computeCornerDeltas(corners: Corner[], distances: number[], timeDelta: number[], lapATime: number[], lapBTime: number[]): CornerDelta[] {
   return corners.map((corner) => {
-    // Find grid indices closest to corner start/end
-    const startIdx = distances.findIndex((d) => d >= corner.distanceStart);
-    let endIdx = distances.findIndex((d) => d >= corner.distanceEnd);
+    const startIdx = distances.findIndex((distance) => distance >= corner.distanceStart);
+    let endIdx = distances.findIndex((distance) => distance >= corner.distanceEnd);
     if (endIdx === -1) endIdx = distances.length - 1;
-    if (startIdx === -1 || startIdx >= endIdx) {
-      return { label: corner.label, deltaSeconds: 0, timeA: 0, timeB: 0 };
-    }
-
-    const deltaSeconds = timeDelta[endIdx] - timeDelta[startIdx];
-    const timeA = lapATime[endIdx] - lapATime[startIdx];
-    const timeB = lapBTime[endIdx] - lapBTime[startIdx];
+    if (startIdx === -1 || startIdx >= endIdx) return { label: corner.label, deltaSeconds: 0, timeA: 0, timeB: 0 };
     return {
       label: corner.label,
-      deltaSeconds: Math.round(deltaSeconds * 1000) / 1000,
-      timeA: Math.round(timeA * 1000) / 1000,
-      timeB: Math.round(timeB * 1000) / 1000,
+      deltaSeconds: Math.round((timeDelta[endIdx] - timeDelta[startIdx]) * 1000) / 1000,
+      timeA: Math.round((lapATime[endIdx] - lapATime[startIdx]) * 1000) / 1000,
+      timeB: Math.round((lapBTime[endIdx] - lapBTime[startIdx]) * 1000) / 1000,
     };
   });
 }
 
-/**
- * Compare two laps by aligning their telemetry to a common 1-meter distance grid.
- *
- * @param packetsA - Telemetry packets for lap A
- * @param packetsB - Telemetry packets for lap B
- * @param corners - Optional corner definitions for per-corner breakdown
- * @returns Comparison result with aligned traces, time deltas, and corner deltas
- */
 export function compareLaps(
   packetsA: TelemetryPacket[],
   packetsB: TelemetryPacket[],
-  corners: Corner[] = []
+  corners: Corner[] = [],
+  options: ComparisonOptions = {},
 ): ComparisonResult {
-  const dataA = extractLapData(packetsA);
-  const dataB = extractLapData(packetsB);
-
-  // Determine common distance range (intersection of both laps)
-  const maxDistA = dataA.distances[dataA.distances.length - 1];
-  const maxDistB = dataB.distances[dataB.distances.length - 1];
-  const maxDist = Math.min(maxDistA, maxDistB);
-
-  // Build 1-meter grid
-  const gridLength = Math.floor(maxDist);
-  const distances: number[] = [];
-  for (let d = 0; d <= gridLength; d++) {
-    distances.push(d);
-  }
-
-  // Align both laps to the grid
-  const lapA = alignLap(dataA, distances);
-  const lapB = alignLap(dataB, distances);
-
-  // Compute cumulative time delta
+  const [distancesA, distancesB, nominalSpan] = buildAlignmentDistances(packetsA, packetsB, options);
+  const gridLength = Math.max(0, Math.floor(nominalSpan));
+  const distances = Array.from({ length: gridLength + 1 }, (_, index) => index);
+  const lapA = alignLap(extractLapData(packetsA, distancesA), distances);
+  const lapB = alignLap(extractLapData(packetsB, distancesB), distances);
   const timeDelta = computeTimeDelta(lapA.elapsedTime, lapB.elapsedTime);
-
-  // Compute per-corner deltas if corners provided
-  const cornerDeltas = computeCornerDeltas(corners, distances, timeDelta, lapA.elapsedTime, lapB.elapsedTime);
-
-  return {
-    distances,
-    lapA,
-    lapB,
-    timeDelta,
-    cornerDeltas,
-  };
+  return { distances, lapA, lapB, timeDelta, cornerDeltas: computeCornerDeltas(corners, distances, timeDelta, lapA.elapsedTime, lapB.elapsedTime) };
 }

--- a/shared/racing/comparison/types.ts
+++ b/shared/racing/comparison/types.ts
@@ -3,6 +3,8 @@ import type { LapMeta } from "../sessions/types";
 
 export interface AlignedTrace {
   distance: number[];
+  sourceIndicesA: number[];
+  sourceIndicesB: number[];
   speedA: number[];
   speedB: number[];
   throttleA: number[];

--- a/test/ai/prompts/inputs-compare-prompt.test.ts
+++ b/test/ai/prompts/inputs-compare-prompt.test.ts
@@ -18,6 +18,7 @@ const trace = {
   gear: [1, 2, 3],
   posX: [0, 0, 0],
   posZ: [0, 0, 0],
+  sourceIndices: [0, 1, 2],
 };
 
 const comparison = {

--- a/test/lap-analysis/comparison.test.ts
+++ b/test/lap-analysis/comparison.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { compareLaps } from "../../server/lap-analysis/comparison";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+
+function packet(overrides: Partial<TelemetryPacket> = {}): TelemetryPacket {
+  return {
+    gameId: "fm-2023",
+    IsRaceOn: 1,
+    TimestampMS: 0,
+    EngineMaxRpm: 9000,
+    EngineIdleRpm: 1000,
+    CurrentEngineRpm: 4000,
+    AccelerationX: 0,
+    AccelerationY: 0,
+    AccelerationZ: 0,
+    VelocityX: 10,
+    VelocityY: 0,
+    VelocityZ: 0,
+    AngularVelocityX: 0,
+    AngularVelocityY: 0,
+    AngularVelocityZ: 0,
+    Yaw: 0,
+    Pitch: 0,
+    Roll: 0,
+    Fuel: 1,
+    DistanceTraveled: 0,
+    BestLap: 0,
+    LastLap: 0,
+    CurrentLap: 0,
+    CurrentRaceTime: 0,
+    LapNumber: 1,
+    RacePosition: 1,
+    Accel: 128,
+    Brake: 0,
+    Clutch: 0,
+    HandBrake: 0,
+    Gear: 3,
+    Steer: 127,
+    NormDrivingLine: 0,
+    NormAIBrakeDiff: 0,
+    TireWearFL: 0,
+    TireWearFR: 0,
+    TireWearRL: 0,
+    TireWearRR: 0,
+    TireTempFL: 80,
+    TireTempFR: 80,
+    TireTempRL: 80,
+    TireTempRR: 80,
+    PositionX: 0,
+    PositionY: 0,
+    PositionZ: 0,
+    ...overrides,
+  } as TelemetryPacket;
+}
+
+function lineLap({ detour = false, shortcut = false, timeOffset = 0 } = {}): TelemetryPacket[] {
+  const points = shortcut
+    ? Array.from({ length: 15 }, (_, index) => index * 5)
+    : Array.from({ length: 21 }, (_, index) => index * 5);
+  const out: TelemetryPacket[] = [];
+  for (const x of points) {
+    out.push(packet({
+      TimestampMS: (x / 10) * 1000 + (x === 0 ? 0 : timeOffset),
+      DistanceTraveled: x,
+      PositionX: x,
+      PositionZ: 0,
+      Accel: x === 75 ? 200 : 128,
+    }));
+  }
+  if (detour) {
+    const insertAt = out.findIndex((p) => p.PositionX === 50) + 1;
+    out.splice(
+      insertAt,
+      0,
+      packet({ TimestampMS: 9000, DistanceTraveled: 70, PositionX: 55, PositionZ: 20, Accel: 255 }),
+      packet({ TimestampMS: 10000, DistanceTraveled: 80, PositionX: 50, PositionZ: 0, Accel: 255 }),
+      packet({ TimestampMS: 11000, DistanceTraveled: 90, PositionX: 60, PositionZ: 0, Accel: 255 }),
+    );
+    for (let i = insertAt + 3; i < out.length; i++) {
+      out[i].DistanceTraveled += 40;
+      out[i].TimestampMS += 4000;
+    }
+  }
+  return out;
+}
+
+describe("compare lap course alignment", () => {
+  test("keeps crash lap inputs aligned to same on-track position", () => {
+    const clean = lineLap();
+    const crash = lineLap({ detour: true });
+    const result = compareLaps(clean, crash, [], { lapAIsValid: true, lapBIsValid: true, trackLengthMeters: 100 });
+    expect(result.distances.at(-1)).toBe(100);
+    expect(result.lapA.sourceIndices).toHaveLength(result.distances.length);
+    expect(result.lapB.sourceIndices).toHaveLength(result.distances.length);
+    const idx = 75;
+    expect(crash[result.lapB.sourceIndices[idx]].PositionX).toBeGreaterThanOrEqual(70);
+    expect(crash[result.lapB.sourceIndices[idx]].PositionX).toBeLessThanOrEqual(80);
+    expect(result.timeDelta[idx]).toBeLessThan(-3);
+  });
+
+  test("chooses clean reference when another lap takes shortcut", () => {
+    const result = compareLaps(lineLap(), lineLap({ shortcut: true }), [], {
+      lapAIsValid: true,
+      lapBIsValid: true,
+      trackLengthMeters: 100,
+    });
+    expect(result.distances.at(-1)).toBe(100);
+  });
+
+  test("keeps projected position monotonic through noisy samples", () => {
+    const noisy = lineLap();
+    noisy.splice(4, 0, packet({ TimestampMS: 3500, DistanceTraveled: 35, PositionX: 0, PositionZ: 0 }));
+    noisy.splice(6, 0, packet({ TimestampMS: 5500, DistanceTraveled: 200, PositionX: 35, PositionZ: 0 }));
+    const result = compareLaps(lineLap(), noisy, [], { trackLengthMeters: 100 });
+    const positions = result.lapB.sourceIndices.map((i) => noisy[i].PositionX).filter((position) => position > 0);
+    for (let i = 1; i < positions.length; i++) expect(positions[i]).toBeGreaterThanOrEqual(positions[i - 1]);
+  });
+
+  test("uses iRacing lap fraction when world positions are unavailable", () => {
+    const a = lineLap().map((p, i) => packet({ ...p, gameId: "iracing", PositionX: 0, PositionZ: 0, DistanceTraveled: i * 5, iracing: { lapDistancePct: i / 20 } as never }));
+    const b = lineLap().map((p, i) => packet({ ...p, gameId: "iracing", PositionX: 0, PositionZ: 0, DistanceTraveled: i * 10, iracing: { lapDistancePct: i / 20 } as never }));
+    const result = compareLaps(a, b, []);
+    expect(result.distances.at(-1)).toBe(100);
+    expect(result.lapA.throttle).toEqual(result.lapB.throttle);
+  });
+
+  test("preserves clean lap grid and elapsed delta", () => {
+    const result = compareLaps(lineLap(), lineLap({ timeOffset: 500 }), []);
+    expect(result.distances).toHaveLength(101);
+    expect(result.timeDelta.at(-1)).toBeCloseTo(-0.5, 3);
+  });
+});


### PR DESCRIPTION
## Summary
- Align Compare telemetry and map markers by monotonic track position instead of raw traveled distance.
- Propagate aligned source indices through the API and client cursor/map/HUD paths.
- Preserve native iRacing and sanitized raw-distance fallbacks.
- Add crash, shortcut, noise, native-fraction, cursor, API, and seeded browser coverage.

## Verification
- `bun test --timeout 30000` — 2856 passed, 3 skipped, 0 failed.
- `bun test ./test/tooling/changelog.test.ts --timeout 60000` — 9 passed.
- `bun run typecheck` — passed.
- Seeded Compare Playwright smoke — 1 passed.

Closes #216