### PR TITLE
fix(ci): compare screenshots with PR base branch

### DIFF
--- a/.github/workflows/pr-screenshots-comment.yml
+++ b/.github/workflows/pr-screenshots-comment.yml
@@ -3,7 +3,7 @@ name: Comment app screenshot diffs
 # Runs after the dashboard screenshot or snapshot workflow completes. Downloads
 # the rendered before/after/diff PNGs, hosts them on the throwaway
 # `pr-previews` branch, and posts (or updates) a sticky PR comment showing
-# every change from main. Also labels the PR "ui change".
+# every change from the pull request's base branch. Also labels the PR "ui change".
 
 #
 # Security: this triggers on workflow_run, so it runs in the BASE repo context
@@ -43,7 +43,9 @@ jobs:
         id: meta
         run: |
           pr=$(cat pr-preview/pr-number.txt)
+          base_ref=$(cat pr-preview/base-ref.txt)
           echo "pr=$pr" >> "$GITHUB_OUTPUT"
+          echo "base-ref=$base_ref" >> "$GITHUB_OUTPUT"
           if ls pr-preview/*-after.png >/dev/null 2>&1; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           else
@@ -81,6 +83,7 @@ jobs:
         env:
           PR: ${{ steps.meta.outputs.pr }}
           SUBDIR: ${{ steps.publish.outputs.subdir }}
+          BASE_REF: ${{ steps.meta.outputs.base-ref }}
         run: |
           marker='<!-- app-screenshot-diff -->'
           base="https://raw.githubusercontent.com/${REPO}/${PREVIEW_BRANCH}/${SUBDIR}"
@@ -88,7 +91,7 @@ jobs:
             echo "$marker"
             echo "## 🖼️ App UI changes"
             echo
-            echo "Current PR screenshots compared with main. Storybook render-vs-committed-baseline failures are listed separately from committed PR-baseline-vs-main changes."
+            printf 'Current PR screenshots compared with `%s`. Storybook render-vs-committed-baseline failures are listed separately from committed PR-baseline-vs-base changes.\n' "$BASE_REF"
             echo
             for after in pr-preview/*-after.png; do
               name=$(basename "$after" -after.png)
@@ -108,7 +111,7 @@ jobs:
               echo "| ![before](${base}/${name}-before.png) | ![after](${base}/${name}-after.png) | ![diff](${base}/${name}-diff.png) |"
               echo
             done
-            echo "<sub>Rendered from Storybook and responsive app screenshot tests against current main.</sub>"
+            printf '<sub>Rendered from Storybook and responsive app screenshot tests against `%s`.</sub>\n' "$BASE_REF"
           } > body.md
 
           # Replace previous UI-diff reports so each PR has one current comment.

--- a/.github/workflows/pr-screenshots.yml
+++ b/.github/workflows/pr-screenshots.yml
@@ -1,7 +1,7 @@
 name: Render dashboard screenshots
 
 # Renders responsive app screenshots on pull requests that change the client
-# and compares them against the current main branch. Any differences produce
+# and compares them against each pull request's base branch. Any differences produce
 # before/after/diff PNGs for the companion comment workflow.
 #
 # This workflow runs the PR's code, so it deliberately uses the read-only
@@ -11,7 +11,6 @@ name: Render dashboard screenshots
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "client/**"
       - "playwright/**"
@@ -23,7 +22,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: "PR number to render (renders that PR's merge ref and comments on it)"
+        description: "PR number to render (merges its base into the PR head and comments on it)"
         required: true
         type: number
 
@@ -42,13 +41,28 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.62.0-jammy
     permissions:
       contents: read
+      pull-requests: read
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
-      # Check out the PR HEAD (not refs/pull/N/merge): GitHub recomputes the
-      # merge ref lazily, so on workflow_dispatch it can be stale and render
-      # old code against old baselines. We merge current main ourselves below
-      # so the render is always "PR code + latest main (baselines + fixes)".
+      # Resolve through the API for both event types. This keeps manual runs
+      # aligned with the PR's current base revision too.
+      - name: Resolve pull request revisions
+        id: pull-request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            core.setOutput("base-ref", pull.base.ref);
+            core.setOutput("base-sha", pull.base.sha);
+
+      # Check out the PR HEAD rather than GitHub's lazily updated merge ref,
+      # then merge the resolved base revision ourselves.
       - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number || inputs.pr }}/head
@@ -57,15 +71,19 @@ jobs:
       - name: Mark workspace safe for git (container runs as root)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Merge current main into the PR head
+      - name: Merge pull request base into the PR head
+        env:
+          BASE_SHA: ${{ steps.pull-request.outputs.base-sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git merge --no-edit origin/main
+          git fetch --no-tags origin "$BASE_SHA"
+          git merge --no-edit "$BASE_SHA"
 
-      - name: Prepare main comparison worktree
-        run: git worktree add --detach "$RUNNER_TEMP/raceiq-main" origin/main
+      - name: Prepare base comparison worktree
+        env:
+          BASE_SHA: ${{ steps.pull-request.outputs.base-sha }}
+        run: git worktree add --detach "$RUNNER_TEMP/raceiq-base" "$BASE_SHA"
 
       - name: Install unzip (required by setup-bun in the container)
         run: apt-get update && apt-get install -y --no-install-recommends unzip
@@ -103,10 +121,10 @@ jobs:
           fi
           exit "$status"
 
-      - name: Capture main responsive screenshots with current tests
-        id: main-responsive
+      - name: Capture base responsive screenshots with current tests
+        id: base-responsive
         continue-on-error: true
-        working-directory: ${{ runner.temp }}/raceiq-main
+        working-directory: ${{ runner.temp }}/raceiq-base
         env:
           E2E_SERVER_MODE: compiled
           PW_SCREENSHOT_ONLY: "1"
@@ -122,7 +140,7 @@ jobs:
           status=$?
           set -e
           if [ -d screenshots/mobile ]; then
-            mv screenshots/mobile "$RUNNER_TEMP/main-responsive"
+            mv screenshots/mobile "$RUNNER_TEMP/base-responsive"
           fi
           exit "$status"
 
@@ -137,16 +155,17 @@ jobs:
           # Always record the PR number so the comment job can find the PR even
           # for fork PRs (workflow_run.pull_requests is empty for forks).
           echo "${{ github.event.pull_request.number || inputs.pr }}" > "$out/pr-number.txt"
+          echo "${{ steps.pull-request.outputs.base-ref }}" > "$out/base-ref.txt"
 
           # Responsive tests write ordinary PNGs rather than Playwright
           # snapshots. Render both revisions and compare the union of paths,
           # which covers added, changed, and removed test screenshots.
           bun "$GITHUB_WORKSPACE/scripts/ui/collect-screenshot-diffs.ts" \
-            --base "$RUNNER_TEMP/main-responsive" \
+            --base "$RUNNER_TEMP/base-responsive" \
             --current "$RUNNER_TEMP/current-responsive" \
             --out "$out" \
             --prefix responsive
-          if [[ "${{ steps.current-responsive.outcome }}" == "failure" || "${{ steps.main-responsive.outcome }}" == "failure" ]]; then
+          if [[ "${{ steps.current-responsive.outcome }}" == "failure" || "${{ steps.base-responsive.outcome }}" == "failure" ]]; then
             echo "::warning::Responsive screenshot comparison is partial because one render failed."
           fi
 

--- a/.github/workflows/pr-snapshots.yml
+++ b/.github/workflows/pr-snapshots.yml
@@ -1,9 +1,10 @@
 name: Render dashboard snapshots
 
 # Renders Storybook dashboard snapshots on pull requests that change the client
-# and compares them against the committed baselines. Any differences produce
+# and compares them against the committed baselines, then compares those
+# baselines with each pull request's base branch. Any differences produce
 # before/after/diff PNGs for the companion comment workflow.
-#
+
 # This workflow runs the PR's code, so it deliberately uses the read-only
 # `pull_request` token — it never gets write access. All writes (comment,
 # label, preview hosting) happen in the separate workflow_run job, which does
@@ -11,7 +12,6 @@ name: Render dashboard snapshots
 
 on:
   pull_request:
-    branches: [main]
     paths:
       - "client/**"
     types: [opened, synchronize, reopened, ready_for_review]
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       pr:
-        description: "PR number to render (renders that PR's merge ref and comments on it)"
+        description: "PR number to render (merges its base into the PR head and comments on it)"
         required: true
         type: number
 
@@ -35,9 +35,24 @@ jobs:
       image: mcr.microsoft.com/playwright:v1.62.0-jammy
     permissions:
       contents: read
+      pull-requests: read
     env:
       PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr }}
     steps:
+      - name: Resolve pull request revisions
+        id: pull-request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            core.setOutput("base-ref", pull.base.ref);
+            core.setOutput("base-sha", pull.base.sha);
+
       - uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ github.event.pull_request.number || inputs.pr }}/head
@@ -46,15 +61,19 @@ jobs:
       - name: Mark workspace safe for git (container runs as root)
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Merge current main into the PR head
+      - name: Merge pull request base into the PR head
+        env:
+          BASE_SHA: ${{ steps.pull-request.outputs.base-sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch origin main
-          git merge --no-edit origin/main
+          git fetch --no-tags origin "$BASE_SHA"
+          git merge --no-edit "$BASE_SHA"
 
-      - name: Prepare main comparison worktree
-        run: git worktree add --detach "$RUNNER_TEMP/raceiq-main" origin/main
+      - name: Prepare base comparison worktree
+        env:
+          BASE_SHA: ${{ steps.pull-request.outputs.base-sha }}
+        run: git worktree add --detach "$RUNNER_TEMP/raceiq-base" "$BASE_SHA"
 
       - name: Install unzip (required by setup-bun in the container)
         run: apt-get update && apt-get install -y --no-install-recommends unzip
@@ -88,6 +107,7 @@ jobs:
           out="$GITHUB_WORKSPACE/pr-preview"
           mkdir -p "$out"
           echo "${{ github.event.pull_request.number || inputs.pr }}" > "$out/pr-number.txt"
+          echo "${{ steps.pull-request.outputs.base-ref }}" > "$out/base-ref.txt"
 
           results="src/stories/__snapshots__/results"
           if [ -d "$results" ]; then
@@ -103,10 +123,10 @@ jobs:
           fi
 
           bun "$GITHUB_WORKSPACE/scripts/ui/collect-screenshot-diffs.ts" \
-            --base "$RUNNER_TEMP/raceiq-main/client/src/stories/__snapshots__" \
+            --base "$RUNNER_TEMP/raceiq-base/client/src/stories/__snapshots__" \
             --current "$GITHUB_WORKSPACE/client/src/stories/__snapshots__" \
             --out "$out" \
-            --prefix committed-pr-baseline-vs-main
+            --prefix committed-pr-baseline-vs-base
 
           if compgen -G "$out/*-after.png" >/dev/null; then
             echo "changed=1" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Restored live-dashboard Storybook runtime context and added same-renderer local visual comparison before canonical Linux baseline generation
 - Expanded visual regression coverage to 97 fixture-seeded responsive app states plus 17 Storybook states, covering every game, high-risk screens, track and experiment details, reusable primitives, navigation, dialogs, and viewport-positioned menus
 - Added a local main-versus-worktree UI comparison report using the same responsive and Storybook screenshot inventory as pull-request previews
+- Compare screenshot previews against each pull request's base branch and revision instead of current main
 - Deterministic iRacing recording and replay coverage through the production parser pipeline
 - Preserve complete iRacing SessionInfo YAML in recordings while keeping historical captures replayable and telemetry deltas compact
 - Add fixture-seeded cross-game route and lap playback end-to-end coverage


### PR DESCRIPTION
## Summary
- resolve each PR's current base ref and SHA through GitHub API
- render screenshot comparisons from exact base revision instead of main
- report compared base branch in sticky screenshot comments

## Verification
- bun test test/tooling/local-ui-diff.test.ts (5 pass, 0 fail)
- @action-validator/cli on all three changed workflows
- PyYAML parse on all three changed workflows
- base-branch workflow contract checks