### PR TITLE
fix: restore Analyse attitude telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - Group rear setup controls with their populated mechanical-balance section
 - Close searchable dropdowns, including Analyse lap selection, after choosing an option
 - Show vehicle roll in the correct direction on the Analyse attitude indicator
+- Keep Analyse attitude indicator and roll/pitch readouts moving while replaying saved laps
 - Restore Analyse Data panel rows, section grouping, source-native tyre temperatures, copied values, F1 ERS/DRS details, and green throttle traces on both 2D and 3D views
 
 ### Internal

--- a/server/routes/laps/resource-routes.ts
+++ b/server/routes/laps/resource-routes.ts
@@ -34,6 +34,8 @@ export function semanticReplayIds(): readonly string[] {
     "motion.speed",
     "motion.acceleration-x",
     "motion.angular-velocity-y",
+    "motion.pitch",
+    "motion.roll",
     "motion.position-x",
     "motion.position-z",
     "motion.yaw",

--- a/test/routes/lap-analysis-route.test.ts
+++ b/test/routes/lap-analysis-route.test.ts
@@ -10,7 +10,7 @@ initGameAdapters();
 test("semantic replay requests lap-relative timing", () => {
   expect(semanticReplayIds()).toContain("timing.current-lap");
 });
-test("semantic replay requests every Analyse Data panel dependency", () => {
+test("semantic replay requests every Analyse display dependency", () => {
   const ids = semanticReplayIds();
   for (const id of [
     "brakes.brake-bias",
@@ -18,6 +18,8 @@ test("semantic replay requests every Analyse Data panel dependency", () => {
     "fuel.ers-harvested",
     "fuel.fuel-capacity",
     "identity.car-ordinal",
+    "motion.pitch",
+    "motion.roll",
     "identity.player-track-surface",
     "tires.wheel-in-puddle-depth",
     "suspension.norm-suspension-travel",


### PR DESCRIPTION
## Summary
- include roll and pitch in saved-lap semantic replay
- restore moving Analyse attitude indicator and live roll/pitch readouts
- cover Analyse display telemetry dependencies

## Verification
- bun test test/routes/lap-analysis-route.test.ts --timeout 60000
- bun test test/tooling/changelog.test.ts --timeout 60000
- bun run typecheck
- browser smoke: attitude label, horizon rotation, and pitch position changed during playback