### PR TITLE
docs: recommend DeepWiki for codebase discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,14 @@ This file provides guidance to coding agents working in this repository.
 
 RaceIQ is a full-stack racing telemetry analysis app for Forza Motorsport 2023, F1 25, Assetto Corsa Competizione, Assetto Corsa Evo, and iRacing. UDP and native Windows telemetry sources feed a Bun server, SQLite storage, and a React dashboard. See [architecture overview](docs/architecture/overview.md).
 
+## Codebase Discovery
+
+When available, try the DeepWiki MCP first (`read_wiki_structure`,
+`read_wiki_contents`, or `ask_question`) to learn the app's architecture and
+feature flows before broad code searches. Use DeepWiki for orientation, then
+verify implementation details against the current checkout because its content
+may be stale or unavailable. Fall back to repository search when needed.
+
 ## Commands
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@
 
 ### Internal
 - Replace Biome with Oxc for repository linting and formatting
-- Consolidate coding-agent guidance in `AGENTS.md` and remove duplicate guidance file
+- Document DeepWiki MCP as the preferred first pass for codebase discovery
 - Catch repository-wide staged lint violations before commit and generate localization modules before root type-checking
 - Preserve complete exports when startup-job tests mock background schedulers
 - Keep tune prompt formatting compatible with game-specific setup blobs


### PR DESCRIPTION
## Summary
- document DeepWiki MCP as first-pass app discovery
- require verification against current checkout and repository-search fallback

## Verification
- pre-commit lint and typecheck passed
- `bun test test/tooling/changelog.test.ts --timeout 60000` passed (11 tests)
- full `bun run test` currently has 3 unrelated failures; see test output for existing `@/paraglide/messages` resolution failure and other suite failures