### PR TITLE
fix: stabilize iRacing live telemetry display and cadence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 
 - Detect imported file contents before accepting ZIP/BIN session data and reject unrelated archives
 ### Fixes
-- Keep live dashboards from flickering back to Waiting for telemetry, show measured source telemetry frequency, and maintain the configured browser refresh cadence
+- Keep live dashboards from flickering back to Waiting for telemetry, clearly label measured source telemetry frequency, and maintain the configured browser refresh cadence
 - Raise Windows timer resolution during ACC, AC Evo, and iRacing capture so native polling no longer collapses onto the default timer tick
 - Make stale-session reprocessing recoverable with retry and dismissal actions, accessible progress states, and clear failure feedback
 - Skip unavailable raw captures during stale-session reprocessing instead of failing the entire maintenance run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 - Detect imported file contents before accepting ZIP/BIN session data and reject unrelated archives
 ### Fixes
-- Raise Windows timer resolution during ACC and AC Evo capture so shared-memory polling no longer collapses to the default ~64 Hz tick
+- Keep live dashboards from flickering back to Waiting for telemetry, show measured source telemetry frequency, and maintain the configured browser refresh cadence
+- Raise Windows timer resolution during ACC, AC Evo, and iRacing capture so native polling no longer collapses onto the default timer tick
 - Make stale-session reprocessing recoverable with retry and dismissal actions, accessible progress states, and clear failure feedback
 - Skip unavailable raw captures during stale-session reprocessing instead of failing the entire maintenance run
 - Keep newly started session captures from being removed by concurrent storage cleanup

--- a/client/src/components/ConnectionStatus.tsx
+++ b/client/src/components/ConnectionStatus.tsx
@@ -40,7 +40,7 @@ export function ConnectionStatus({ connected, packetsPerSec, forzaReceiving, col
       break;
   }
 
-  const packetText = forzaReceiving ? `Telemetry: ${packetsPerSec} Hz` : null;
+  const packetText = forzaReceiving ? `${m.browser_source()}: ${packetsPerSec} Hz` : null;
   const accessibleLabel = packetText ? `${statusText}. ${packetText}` : statusText;
 
   if (collapsed) {

--- a/client/src/components/ConnectionStatus.tsx
+++ b/client/src/components/ConnectionStatus.tsx
@@ -1,6 +1,5 @@
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { m } from "@/paraglide/messages";
-import { useSettings } from "../hooks/settings";
 import { useTelemetryStore } from "../stores/telemetry";
 import { deriveConnectionStatusView } from "./connection-status-logic";
 
@@ -21,7 +20,6 @@ const DOT_CLASS: Record<"green" | "red" | "cyan" | "amber" | "dim", string> = {
 
 export function ConnectionStatus({ connected, packetsPerSec, forzaReceiving, collapsed = false }: Props) {
   const detectedGame = useTelemetryStore((s) => s.serverStatus?.detectedGame);
-  const { displaySettings } = useSettings();
   const view = deriveConnectionStatusView({ connected, forzaReceiving, detectedGame });
 
   // Localize the display text here (connection-status-logic stays pure/testable).
@@ -42,7 +40,7 @@ export function ConnectionStatus({ connected, packetsPerSec, forzaReceiving, col
       break;
   }
 
-  const packetText = forzaReceiving ? `${packetsPerSec} pkt/s · ${displaySettings.wsRefreshRate ?? 60}Hz` : null;
+  const packetText = forzaReceiving ? `Telemetry: ${packetsPerSec} Hz` : null;
   const accessibleLabel = packetText ? `${statusText}. ${packetText}` : statusText;
 
   if (collapsed) {

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -50,7 +50,7 @@ function AppShell() {
   }, [settingsLoaded, settingsLanguage]);
 
   const connected = useTelemetryStore((s) => s.connected);
-  const packetsPerSec = useTelemetryStore((s) => s.packetsPerSec);
+  const packetsPerSec = useTelemetryStore((s) => s.serverStatus?.telemetryPps ?? 0);
   const isRaceOn = useTelemetryStore((s) => s.isRaceOn);
   const updateState = useUpdateCheck();
   const updateAvailable = useTelemetryStore((s) => s.updateAvailable);

--- a/client/src/stores/telemetry.ts
+++ b/client/src/stores/telemetry.ts
@@ -83,6 +83,8 @@ export interface VersionInfo {
 
 export interface ServerStatus {
   udpPps: number;
+  /** Telemetry packets/sec accepted by the common live pipeline. */
+  telemetryPps: number;
   isRaceOn: boolean;
   droppedPackets: number;
   udpPort: number;
@@ -220,7 +222,12 @@ export const useTelemetryStore = create<TelemetryState>((set, get) => ({
       // Most-recent-first, capped so a long practice session doesn't grow unbounded.
       lapIssuesFeed: [entry, ...prev.lapIssuesFeed.filter((e) => e.lapId !== entry.lapId)].slice(0, 20),
     })),
-  setTelemetrySchema: (telemetrySchema) => set({ telemetrySchema, telemetryFrame: null, telemetryView: null }),
+  setTelemetrySchema: (telemetrySchema) =>
+    set((prev) =>
+      prev.telemetrySchema?.schemaId === telemetrySchema.schemaId
+        ? { telemetrySchema }
+        : { telemetrySchema, telemetryFrame: null, telemetryView: null },
+    ),
   setTelemetryFrame: (telemetryFrame) =>
     set((prev) => ({ telemetryFrame, telemetryView: prev.telemetrySchema ? buildLiveTelemetryView(prev.telemetrySchema, telemetryFrame) ?? prev.telemetryView : prev.telemetryView })),
   clearTelemetry: () => set({ telemetryFrame: null, telemetryView: null, telemetrySchema: null }),

--- a/client/src/stories/AccLiveDashboard.stories.tsx
+++ b/client/src/stories/AccLiveDashboard.stories.tsx
@@ -28,6 +28,7 @@ function StoryDecorator({ story }: { story: React.ComponentType }) {
     packetsPerSec: 60,
     serverStatus: {
       udpPps: 60,
+      telemetryPps: 60,
       isRaceOn: true,
       droppedPackets: 0,
       udpPort: 5300,

--- a/client/src/stories/F1LiveDashboard.stories.tsx
+++ b/client/src/stories/F1LiveDashboard.stories.tsx
@@ -30,6 +30,7 @@ function StoryDecorator({ story }: { story: React.ComponentType }) {
     packetsPerSec: 60,
     serverStatus: {
       udpPps: 60,
+      telemetryPps: 60,
       isRaceOn: true,
       droppedPackets: 0,
       udpPort: 5300,

--- a/client/src/stories/ForzaLiveDashboard.stories.tsx
+++ b/client/src/stories/ForzaLiveDashboard.stories.tsx
@@ -28,6 +28,7 @@ function StoryDecorator({ story }: { story: React.ComponentType }) {
     packetsPerSec: 60,
     serverStatus: {
       udpPps: 60,
+      telemetryPps: 60,
       isRaceOn: true,
       droppedPackets: 0,
       udpPort: 5300,

--- a/client/test/websocket-messages.test.ts
+++ b/client/test/websocket-messages.test.ts
@@ -14,6 +14,16 @@ describe("websocket message router", () => {
     expect(handleWebSocketMessage({ type: "telemetry-frame", protocolVersion: 1, schemaId: "s", streamId: "x", sessionId: null, sequence: 1, observedAt: { domain: "session", milliseconds: 1 }, receivedAtMs: 1, values: [] })).toBe(true);
     expect(useTelemetryStore.getState().telemetryFrame?.sequence).toBe(1);
   });
+  it("keeps current live view when server repeats its schema", () => {
+    useTelemetryStore.getState().clearTelemetry();
+    handleWebSocketMessage(schema);
+    handleWebSocketMessage({ type: "telemetry-frame", protocolVersion: 1, schemaId: "s", streamId: "x", sessionId: null, sequence: 1, observedAt: { domain: "session", milliseconds: 1 }, receivedAtMs: 1, values: [] });
+    const frame = useTelemetryStore.getState().telemetryFrame;
+    const view = useTelemetryStore.getState().telemetryView;
+    handleWebSocketMessage(schema);
+    expect(useTelemetryStore.getState().telemetryFrame).toBe(frame);
+    expect(useTelemetryStore.getState().telemetryView).toBe(view);
+  });
   it("routes dev packets only to isolated dev store and ignores legacy packets", () => {
     useDevTelemetryStore.getState().clear();
     useTelemetryStore.getState().clearTelemetry();

--- a/docs/reference/adapters/iracing.md
+++ b/docs/reference/adapters/iracing.md
@@ -10,7 +10,7 @@ RaceIQ reads iRacing directly through the local Windows SDK memory map. It does 
 4. The source combines telemetry values with the current SessionInfo snapshot and encodes a versioned RaceIQ source frame.
 5. The iRacing adapter parses and normalizes that frame to `TelemetryPacket` before the common pipeline performs recording, lap/sector processing, persistence, analysis, and WebSocket broadcast.
 
-The source polls at 60 Hz by default. Actual change frequency remains variable-specific; do not present the poll cadence as source resolution.
+iRacing publishes SDK ticks at 60 Hz. RaceIQ polls the memory map above that rate so timer phase, scheduling jitter, and brief processing overlap do not miss ticks, deduplicates unchanged tick counters, and displays measured accepted-tick frequency. Actual change frequency remains variable-specific.
 
 ## Source-frame contract
 

--- a/docs/reference/adapters/iracing.md
+++ b/docs/reference/adapters/iracing.md
@@ -10,7 +10,7 @@ RaceIQ reads iRacing directly through the local Windows SDK memory map. It does 
 4. The source combines telemetry values with the current SessionInfo snapshot and encodes a versioned RaceIQ source frame.
 5. The iRacing adapter parses and normalizes that frame to `TelemetryPacket` before the common pipeline performs recording, lap/sector processing, persistence, analysis, and WebSocket broadcast.
 
-iRacing publishes SDK ticks at 60 Hz. RaceIQ polls the memory map above that rate so timer phase, scheduling jitter, and brief processing overlap do not miss ticks, deduplicates unchanged tick counters, and displays measured accepted-tick frequency. Actual change frequency remains variable-specific.
+iRacing normally publishes live SDK variables at 60 Hz. RaceIQ checks the shared-memory map independently from the user-configured WebSocket refresh cap and accepts each new SDK tick once using its tick counter. The WebSocket broadcaster separately sends the latest accepted frame at the configured refresh rate. Actual change frequency remains variable-specific.
 
 ## Source-frame contract
 

--- a/server/games/iracing/source.ts
+++ b/server/games/iracing/source.ts
@@ -14,6 +14,7 @@ import {
   IRacingFramePipeline,
   ParsingProcessor,
 } from "./frame-pipeline";
+import { acquireHighResolutionTimer, releaseHighResolutionTimer } from "../shared/win-timer-resolution";
 
 export interface IRacingFrameReader {
   start(): void;
@@ -63,6 +64,7 @@ export class IRacingTelemetrySource {
   private running = false;
   private polling = false;
   private lastErrorLogAt = 0;
+  private holdsTimerResolution = false;
   private cachedSessionInfoUpdate: number | null = null;
   private cachedSessionInfo: string | null = null;
   private cachedSessionNum: number | null = null;
@@ -72,7 +74,9 @@ export class IRacingTelemetrySource {
     this.reader = options.reader ?? new IRacingSdkReader();
     this.dispatchRawFrame = options.dispatchRawFrame ?? dispatchThroughParser;
     this.registerIdentity = options.registerIdentity;
-    this.pollIntervalMs = options.pollIntervalMs ?? 1000 / 60;
+    // Poll above the SDK's 60Hz rate so timer phase and brief processing overlap cannot miss ticks.
+    // IRacingSdkReader deduplicates unchanged tick counts.
+    this.pollIntervalMs = options.pollIntervalMs ?? 1000 / 240;
     this.recordingEnabled = options.recordingEnabled ?? false;
     this.recordingDir = options.recordingDir;
     this.recorder = options.recorder ?? iracingRecorder;
@@ -89,6 +93,8 @@ export class IRacingTelemetrySource {
       console.log(`[iRacing] Recording mode: bin file created at ${recordPath}`);
     }
     this.reader.start();
+    acquireHighResolutionTimer();
+    this.holdsTimerResolution = true;
     this.running = true;
     this.timer = setInterval(() => void this.pollOnce(), this.pollIntervalMs);
     console.log("[iRacing] Telemetry source started");
@@ -99,6 +105,10 @@ export class IRacingTelemetrySource {
     if (this.timer) {
       clearInterval(this.timer);
       this.timer = null;
+    }
+    if (this.holdsTimerResolution) {
+      this.holdsTimerResolution = false;
+      releaseHighResolutionTimer();
     }
     try {
       await this.reader.stop();

--- a/server/routes/dev/replay-routes.ts
+++ b/server/routes/dev/replay-routes.ts
@@ -181,6 +181,7 @@ export const replayRoutes = new Hono()
 
     wsManager.broadcastStatus({
       udpPps: 0,
+      telemetryPps: intervalMs > 0 ? Math.round(1000 / intervalMs) : 0,
       isRaceOn: true,
       droppedPackets: 0,
       udpPort: 0,

--- a/server/runtime/udp-listener.ts
+++ b/server/runtime/udp-listener.ts
@@ -35,6 +35,7 @@ class UdpListener {
   private _lastDetectedGame: ReturnType<typeof getRunningGame> = null;
   private _lastRaceOn = false;
   private _lastWsPacketCount = 0;
+  private _lastStatusAt = performance.now();
   private _statusTimer: ReturnType<typeof setInterval> | null = null;
 
   get droppedPackets(): number {
@@ -101,8 +102,13 @@ class UdpListener {
     // Update packets/sec every second. Own the handle so restart replaces,
     // rather than stacks, status/flush loops.
     clearInterval(this._statusTimer ?? undefined);
+    this._lastStatusAt = performance.now();
+    this._lastWsPacketCount = wsManager.packetCount;
     this._statusTimer = setInterval(() => {
-      this._packetsPerSec = this._packetsInWindow;
+      const statusAt = performance.now();
+      const elapsedMs = Math.max(1, statusAt - this._lastStatusAt);
+      this._lastStatusAt = statusAt;
+      this._packetsPerSec = Math.round((this._packetsInWindow * 1000) / elapsedMs);
       this._packetsInWindow = 0;
 
       // Flush the session recorder's in-memory write buffer so rawByteOffset
@@ -120,9 +126,9 @@ class UdpListener {
       // source (UDP, ACC SHM, AC Evo SHM). isRaceOn must reflect all sources,
       // not just UDP — otherwise shared-memory games show "Waiting" forever.
       const wsCount = wsManager.packetCount;
-      const streamPps = wsCount - this._lastWsPacketCount;
+      const telemetryPps = Math.round(((wsCount - this._lastWsPacketCount) * 1000) / elapsedMs);
       this._lastWsPacketCount = wsCount;
-      const raceOn = this._receiving || streamPps > 0;
+      const raceOn = this._receiving || telemetryPps > 0;
 
       // Broadcast full server status to clients (replaces REST polling)
       const runningGame = getRunningGame();
@@ -152,6 +158,7 @@ class UdpListener {
 
       wsManager.broadcastStatus({
         udpPps: this._packetsPerSec,
+        telemetryPps,
         isRaceOn: raceOn,
         droppedPackets: this._droppedPackets,
         udpPort: this._port,

--- a/server/runtime/websocket-manager.ts
+++ b/server/runtime/websocket-manager.ts
@@ -72,11 +72,13 @@ function pushFourWheelSample(
 export class WebSocketManager {
   private clients = new Set<ServerWebSocket<WSData>>();
   private _packetCount = 0;
-  private broadcastIntervalMs = 16; // default 60Hz
+  private broadcastPeriodMs = 1000 / 60;
   private gripSampleCounter = 0; // Counts to 6 for 10Hz history sampling
   private gripHistory: GripHistoryData = { fl: [], fr: [], rl: [], rr: [] };
   /** Last broadcast JSON — sent to new clients so they don't start blank */
   private lastSchemaJson: string | null = null;
+  /** Schema waiting for delivery to clients already connected when it changed. */
+  private pendingSchemaJson: string | null = null;
   private lastFrameJson: string | null = null;
   private lastDevPacketJson: string | null = null;
   private readonly allowDevTelemetry = IS_DEV || IS_E2E;
@@ -125,8 +127,8 @@ export class WebSocketManager {
 
   setRefreshRate(hz: string): void {
     const rate = parseInt(hz, 10) || 60;
-    this.broadcastIntervalMs = rate > 0 ? Math.round(1000 / rate) : 16;
-    if (this._broadcastTimer) this.startBroadcastTimer(); // restart with new interval
+    this.broadcastPeriodMs = 1000 / (rate > 0 ? rate : 60);
+    if (this._broadcastTimer) this.startBroadcastTimer();
   }
 
   addClient(ws: ServerWebSocket<WSData>): void {
@@ -179,6 +181,7 @@ export class WebSocketManager {
    * Fired every 1s from the UDP listener's interval timer.
    */
   broadcastStatus(status: {
+    telemetryPps: number;
     udpPps: number;
     isRaceOn: boolean;
     droppedPackets: number;
@@ -212,7 +215,10 @@ export class WebSocketManager {
   }
 
   publishTelemetry(projection: LiveProjection): void {
-    if (projection.schema) this.lastSchemaJson = JSON.stringify(projection.schema);
+    if (projection.schema) {
+      this.lastSchemaJson = JSON.stringify(projection.schema);
+      if (this.clients.size > 0) this.pendingSchemaJson = this.lastSchemaJson;
+    }
     if (projection.frame) this.lastFrameJson = JSON.stringify(projection.frame);
   }
 
@@ -277,29 +283,40 @@ export class WebSocketManager {
     }
   }
 
-  /** Start the broadcast timer at the configured Hz. */
+  /** Start a deadline-based broadcast loop that preserves fractional periods. */
   private startBroadcastTimer(): void {
     this.stopBroadcastTimer();
-    this._broadcastTimer = setInterval(() => this._pushToClients(), this.broadcastIntervalMs);
+    const periodMs = this.broadcastPeriodMs;
+    let nextBroadcastAt = performance.now() + periodMs;
+    const tick = () => {
+      this._pushToClients();
+      nextBroadcastAt += periodMs;
+      const now = performance.now();
+      if (nextBroadcastAt <= now) nextBroadcastAt += (Math.floor((now - nextBroadcastAt) / periodMs) + 1) * periodMs;
+      this._broadcastTimer = setTimeout(tick, Math.max(0, nextBroadcastAt - now));
+    };
+    this._broadcastTimer = setTimeout(tick, periodMs);
   }
 
   /** Stop the broadcast timer. */
   private stopBroadcastTimer(): void {
     if (this._broadcastTimer) {
-      clearInterval(this._broadcastTimer);
+      clearTimeout(this._broadcastTimer);
       this._broadcastTimer = null;
     }
   }
 
   private _pushToClients(): void {
+    const schemaJson = this.pendingSchemaJson;
     const deadClients: ServerWebSocket<WSData>[] = [];
     for (const client of this.clients) {
       try {
-        if (this.lastSchemaJson) client.send(this.lastSchemaJson);
+        if (schemaJson) client.send(schemaJson);
         if (this.lastFrameJson) client.send(this.lastFrameJson);
         if (this.lastDevPacketJson && client.data.devTelemetrySubscribed) client.send(this.lastDevPacketJson);
       } catch { deadClients.push(client); }
     }
+    this.pendingSchemaJson = null;
     for (const dead of deadClients) this.clients.delete(dead);
   }
 }

--- a/test/games/iracing/iracing-sdk-source-integration.test.ts
+++ b/test/games/iracing/iracing-sdk-source-integration.test.ts
@@ -14,6 +14,7 @@ import {
   type IRacingSourceFrameV3,
 } from "../../../server/games/iracing/source-frame";
 import { parsePacket } from "../../../server/games/packet-dispatch";
+import { timerResolutionRefCount } from "../../../server/games/shared/win-timer-resolution";
 import { initGameAdapters } from "../../../shared/games/init";
 import {
   iracingAdapter,
@@ -24,6 +25,18 @@ initGameAdapters();
 initServerGameAdapters();
 import { sampleFrame, } from "../../support/games/iracing-sdk";
 describe("iRacing source ownership integration", () => {
+  test.skipIf(process.platform !== "win32")("holds high-resolution timer while polling iRacing", async () => {
+    const initialRefCount = timerResolutionRefCount();
+    const reader: IRacingFrameReader = { start() {}, async stop() {}, readLatest: () => null };
+    const source = new IRacingTelemetrySource({ reader, pollIntervalMs: 1000 });
+    source.start();
+    try {
+      expect(timerResolutionRefCount()).toBe(initialRefCount + 1);
+    } finally {
+      await source.stop();
+    }
+    expect(timerResolutionRefCount()).toBe(initialRefCount);
+  });
 
   test("parsing a historical frame cannot overwrite live identity", () => {
     const carOrdinal = 901_042;

--- a/test/runtime/websocket-manager.test.ts
+++ b/test/runtime/websocket-manager.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { ServerWebSocket } from "bun";
 import { WebSocketManager, type WSData } from "../../server/runtime/websocket-manager";
+import type { LiveProjection } from "../../server/telemetry/live-projector";
 
 function socket() {
   const sent: string[] = [];
   return { data: { createdAt: Date.now(), devTelemetrySubscribed: false } satisfies WSData, sent, send: (value: string) => { sent.push(value); }, close() {} } as unknown as ServerWebSocket<WSData> & { sent: string[] };
 }
+
+const schema = { type: "telemetry-schema", protocolVersion: 1, schemaId: "schema-1", simulator: "iracing", catalogVersion: "catalog", catalogHash: "hash", catalogSchemaVersion: "1", parserVersion: "parser", resolverVersion: "resolver", derivationVersion: "derivation", definitions: [] } as const satisfies NonNullable<LiveProjection["schema"]>;
+const frame = { type: "telemetry-frame", protocolVersion: 1, schemaId: schema.schemaId, streamId: "stream-1", sessionId: 1, sequence: 1, observedAt: { domain: "session", milliseconds: 1 }, receivedAtMs: 1, values: [], context: {} } as const satisfies NonNullable<LiveProjection["frame"]>;
 
 describe("WebSocketManager controls", () => {
   test("malformed control is rejected without subscription", () => {
@@ -14,5 +18,21 @@ describe("WebSocketManager controls", () => {
     expect(ws.data.devTelemetrySubscribed).toBe(false);
     expect(ws.sent).toHaveLength(1);
     expect(JSON.parse(ws.sent[0]).error).toBe("invalid-message");
+  });
+
+  test("broadcasts source rate and sends schemas only when they change", () => {
+    const manager = new WebSocketManager(); const ws = socket();
+    manager.publishTelemetry({ schema, frame });
+    manager.addClient(ws);
+    expect(ws.sent.map((value) => JSON.parse(value).type)).toEqual(["telemetry-schema", "telemetry-frame"]);
+
+    ws.sent.length = 0;
+    manager.flushLatest();
+    expect(ws.sent.map((value) => JSON.parse(value).type)).toEqual(["telemetry-frame"]);
+
+    ws.sent.length = 0;
+    manager.broadcastStatus({ udpPps: 0, telemetryPps: 60, isRaceOn: true, droppedPackets: 0, udpPort: 5301, detectedGame: { id: "iracing", name: "iRacing" }, currentSession: null });
+    expect(JSON.parse(ws.sent.at(-1)!)).toMatchObject({ type: "status", telemetryPps: 60 });
+    manager.removeClient(ws);
   });
 });


### PR DESCRIPTION
## Summary

- Stop the live dashboard from flickering back to **Waiting for telemetry** by sending telemetry schemas only on connection or schema change and treating repeated schema IDs as idempotent on the client.
- Report measured source telemetry frequency instead of conflating browser delivery rate with the configured refresh cap, and keep iRacing ingestion and browser delivery near 60 Hz with high-resolution polling and a deadline-based broadcast scheduler.

## Why these fixes are combined

Both issues appeared during the same live iRacing test: the dashboard alternated between live data and the waiting view while the sidebar showed roughly **40 pkt/s · 60 Hz**. They looked like one dropped-data problem, but investigation found two independent causes:

1. **Dashboard flicker:** the server resent the cached telemetry schema on every broadcast tick, and the client cleared its current view whenever it received a schema.
2. **Rate mismatch:** the sidebar displayed browser-received frames beside a configured cap, while 60 Hz source polling could miss SDK ticks and the rounded/drifting WebSocket interval reduced actual delivery cadence.

They share this PR because they were found from one reproduction, touch the same live telemetry transport/status path, and require the same end-to-end iRacing validation. Neither issue causes the other.

## Verification

- Live iRacing SDK/source rate: 59 Hz during final sample
- Browser WebSocket transport: 59.2 Hz during final sample
- Dashboard remained visible with no Waiting for telemetry transition
- `bun test ./test/runtime/websocket-manager.test.ts ./test/games/iracing/iracing-sdk-source-integration.test.ts ./client/test/websocket-messages.test.ts ./test/tooling/changelog.test.ts --timeout 60000`: 22 passed
- Client TypeScript build: passed
- Server TypeScript check: passed