### PR TITLE
fix: restore iRacing live fuel bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Detect imported file contents before accepting ZIP/BIN session data and reject unrelated archives
 ### Fixes
 - Keep live dashboards from flickering back to Waiting for telemetry, show measured source telemetry frequency, and maintain the configured browser refresh cadence
+- Show iRacing live fuel bars using tank capacity reported by simulator session data
 - Raise Windows timer resolution during ACC, AC Evo, and iRacing capture so native polling no longer collapses onto the default timer tick
 - Make stale-session reprocessing recoverable with retry and dismissal actions, accessible progress states, and clear failure feedback
 - Skip unavailable raw captures during stale-session reprocessing instead of failing the entire maintenance run

--- a/server/games/iracing/normalizer.ts
+++ b/server/games/iracing/normalizer.ts
@@ -5,6 +5,7 @@ import {
   type IRacingSourceFrame,
   type IRacingValue,
 } from "./source-frame";
+import { parseIRacingFuelCapacity } from "./session-info";
 import {
   startsAtIRacingSectorOrigin,
   warnInvalidIRacingSectorLayout,
@@ -17,6 +18,8 @@ export interface IRacingParserState {
   sessionKey: string | null;
   rawLap: number | null;
   lapStartSessionTime: number;
+  fuelCapacitySessionInfo: string | null;
+  fuelCapacityL: number | undefined;
 }
 
 export function createIRacingParserState(): IRacingParserState {
@@ -25,6 +28,8 @@ export function createIRacingParserState(): IRacingParserState {
     sessionKey: null,
     rawLap: null,
     lapStartSessionTime: 0,
+    fuelCapacitySessionInfo: null,
+    fuelCapacityL: undefined,
   };
 }
 
@@ -156,6 +161,18 @@ export function normalizeIRacingFrame(
   );
   const sdkLastLapTime = Math.max(0, scalar(values, "LapLastLapTime", 0));
   const sessionKey = `${session.subSessionId}:${session.sessionId}:${session.sessionNum}`;
+  let fuelCapacityL: number | undefined;
+  if ("sessionInfo" in frame) {
+    if (!state) {
+      fuelCapacityL = parseIRacingFuelCapacity(frame.sessionInfo);
+    } else {
+      if (state.fuelCapacitySessionInfo !== frame.sessionInfo) {
+        state.fuelCapacitySessionInfo = frame.sessionInfo;
+        state.fuelCapacityL = parseIRacingFuelCapacity(frame.sessionInfo);
+      }
+      fuelCapacityL = state.fuelCapacityL;
+    }
+  }
   let currentLapTime = sdkCurrentLapTime;
   if (state) {
     if (state.sessionKey !== sessionKey || state.rawLap === null) {
@@ -299,6 +316,7 @@ export function normalizeIRacingFrame(
 
     Boost: 0,
     Fuel: Math.max(0, scalar(values, "FuelLevel", 0)),
+    ...(fuelCapacityL !== undefined ? { FuelCapacity: fuelCapacityL } : {}),
     DistanceTraveled: distanceTraveled,
     BestLap: Math.max(0, scalar(values, "LapBestLapTime", 0)),
     LastLap: sdkLastLapTime,

--- a/server/games/iracing/session-info.ts
+++ b/server/games/iracing/session-info.ts
@@ -27,6 +27,17 @@ function toNumber(value: string | undefined, fallback = 0): number {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+export function parseIRacingFuelCapacity(
+  yaml: string,
+): number | undefined {
+  const lines = yaml.replace(/\r\n/g, "\n").split("\n");
+  const capacity = toNumber(
+    findScalar(lines, "DriverCarFuelMaxLtr"),
+    Number.NaN,
+  );
+  return Number.isFinite(capacity) && capacity > 0 ? capacity : undefined;
+}
+
 function parseTrackLengthM(value: string | undefined): number {
   if (!value) return 0;
   const match = value.match(/(-?\d+(?:\.\d+)?)\s*(km|m|mi|ft)?/i);

--- a/test/games/iracing/iracing-sdk-source-integration.test.ts
+++ b/test/games/iracing/iracing-sdk-source-integration.test.ts
@@ -116,6 +116,7 @@ DriverInfo:
   DriverCarIdleRPM: 900
   DriverCarRedLine: 8500
   DriverCarEngCylinderCount: 8
+  DriverCarFuelMaxLtr: 105.0
   Drivers:
   - CarIdx: 7
     CarID: 42
@@ -155,6 +156,7 @@ DriverInfo:
     );
     expect(parsePacket(delivered!)).toMatchObject({
       gameId: "iracing",
+      FuelCapacity: 105,
       iracing: { sectorStarts: [0, 0.34, 0.67] },
     });
   });


### PR DESCRIPTION
## Summary
- propagate iRacing DriverCarFuelMaxLtr session metadata into semantic live telemetry
- restore live fuel bar fill while preserving historical source-frame compatibility
- document user-visible fix

## Tests
- bun test test/games/iracing/iracing-sdk-source-integration.test.ts --timeout 60000
- bun test ./test/tooling/changelog.test.ts --timeout 60000