### PR TITLE
feat(db): persist versioned lap quality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Breaking
 - Store primary database as `app.db` and automatically move older `forza-telemetry.db` files; resolve dual-file directories before startup because RaceIQ refuses to overwrite either
+- Persist versioned lap-quality evidence in primary database; databases upgraded by this release require builds that understand quality schema
 
 ### Features
 - Classify imported laps as Mine or Others, filter sessions and owned statistics by ownership, preserve cross-tab selections, and label Compare/Analyse laps with ownership

--- a/scripts/data/seed-db-demo.ts
+++ b/scripts/data/seed-db-demo.ts
@@ -2,6 +2,7 @@ import { db } from "../../server/db/index";
 import { sessions, laps, tunes, tuneAssignments, experiments, experimentVersions, experimentFocusEvents, lapAnalyses, compareAnalyses } from "../../server/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { chatThreadId, compareChatThreadId, saveChatMessages } from "../../server/ai/chat-agent";
+import { getCompareQualityIdentity } from "../../server/db/analysis-queries";
 import { loadSettings, saveSettings } from "../../server/runtime/config/settings";
 import { SEED_MARKER } from "./seed-db-options";
 
@@ -10,30 +11,70 @@ export function markOnboardingComplete(): void {
 }
 
 export async function insertDemoRows(profileId: number, importedLapIds: number[]): Promise<void> {
-  const importedLaps = await db.select({ id: laps.id, gameId: sessions.gameId, carOrdinal: sessions.carOrdinal, trackOrdinal: sessions.trackOrdinal })
-    .from(laps).innerJoin(sessions, eq(laps.sessionId, sessions.id)).where(inArray(laps.id, importedLapIds)).all();
+  const importedLaps = await db
+    .select({ id: laps.id, gameId: sessions.gameId, carOrdinal: sessions.carOrdinal, trackOrdinal: sessions.trackOrdinal })
+    .from(laps)
+    .innerJoin(sessions, eq(laps.sessionId, sessions.id))
+    .where(inArray(laps.id, importedLapIds))
+    .all();
   await db.update(laps).set({ profileId }).where(inArray(laps.id, importedLapIds)).run();
 
   const fmLaps = importedLaps.filter((lap) => lap.gameId === "fm-2023");
   const fm = fmLaps.find((lap) => lap.carOrdinal === 3631) ?? fmLaps[0];
   if (fm) {
     const secondCar = 3632;
-    const tuneA = await db.insert(tunes).values({
-      gameId: "fm-2023", name: "Demo Sprint Baseline", author: "RaceIQ Demo", carOrdinal: fm.carOrdinal,
-      category: "road", trackOrdinal: fm.trackOrdinal, description: `Seeded demo tune (${SEED_MARKER})`,
-      strengths: JSON.stringify(["Stable braking"]), weaknesses: JSON.stringify(["Corner exit traction"]),
-      bestTracks: JSON.stringify(["Silverstone"]), strategies: JSON.stringify(["Brake earlier for consistency"]),
-      settings: JSON.stringify({ frontArb: 32, rearArb: 28 }), unitSystem: "metric", source: SEED_MARKER,
-    }).returning({ id: tunes.id }).get();
-    const tuneB = await db.insert(tunes).values({
-      gameId: "fm-2023", name: "Demo Qualifying Variant", author: "RaceIQ Demo", carOrdinal: secondCar,
-      category: "road", trackOrdinal: fm.trackOrdinal, description: `Second-car tune (${SEED_MARKER})`,
-      strengths: JSON.stringify(["Rotation"]), weaknesses: JSON.stringify(["Tyre wear"]), bestTracks: "[]", strategies: "[]",
-      settings: JSON.stringify({ frontArb: 28, rearArb: 34 }), unitSystem: "metric", source: SEED_MARKER,
-    }).returning({ id: tunes.id }).get();
+    const tuneA = await db
+      .insert(tunes)
+      .values({
+        gameId: "fm-2023",
+        name: "Demo Sprint Baseline",
+        author: "RaceIQ Demo",
+        carOrdinal: fm.carOrdinal,
+        category: "road",
+        trackOrdinal: fm.trackOrdinal,
+        description: `Seeded demo tune (${SEED_MARKER})`,
+        strengths: JSON.stringify(["Stable braking"]),
+        weaknesses: JSON.stringify(["Corner exit traction"]),
+        bestTracks: JSON.stringify(["Silverstone"]),
+        strategies: JSON.stringify(["Brake earlier for consistency"]),
+        settings: JSON.stringify({ frontArb: 32, rearArb: 28 }),
+        unitSystem: "metric",
+        source: SEED_MARKER,
+      })
+      .returning({ id: tunes.id })
+      .get();
+    const tuneB = await db
+      .insert(tunes)
+      .values({
+        gameId: "fm-2023",
+        name: "Demo Qualifying Variant",
+        author: "RaceIQ Demo",
+        carOrdinal: secondCar,
+        category: "road",
+        trackOrdinal: fm.trackOrdinal,
+        description: `Second-car tune (${SEED_MARKER})`,
+        strengths: JSON.stringify(["Rotation"]),
+        weaknesses: JSON.stringify(["Tyre wear"]),
+        bestTracks: "[]",
+        strategies: "[]",
+        settings: JSON.stringify({ frontArb: 28, rearArb: 34 }),
+        unitSystem: "metric",
+        source: SEED_MARKER,
+      })
+      .returning({ id: tunes.id })
+      .get();
     await db.insert(tuneAssignments).values({ gameId: "fm-2023", carOrdinal: fm.carOrdinal, trackOrdinal: fm.trackOrdinal, tuneId: tuneA.id }).run();
     await db.insert(tuneAssignments).values({ gameId: "fm-2023", carOrdinal: secondCar, trackOrdinal: fm.trackOrdinal, tuneId: tuneB.id }).run();
-    await db.update(laps).set({ tuneId: tuneA.id }).where(inArray(laps.id, fmLaps.map((lap) => lap.id))).run();
+    await db
+      .update(laps)
+      .set({ tuneId: tuneA.id })
+      .where(
+        inArray(
+          laps.id,
+          fmLaps.map((lap) => lap.id),
+        ),
+      )
+      .run();
     await saveChatMessages(chatThreadId(fm.id), [
       {
         role: "user",
@@ -45,38 +86,107 @@ export async function insertDemoRows(profileId: number, importedLapIds: number[]
   const f1Laps = importedLaps.filter((lap) => lap.gameId === "f1-2025");
   const f1 = f1Laps[0];
   if (f1) {
-    const experiment = await db.insert(experiments).values({
-      seq: 1, gameId: "f1-2025", name: "Demo setup experiment", carOrdinal: f1.carOrdinal,
-      trackOrdinal: f1.trackOrdinal, focus: "car", notes: SEED_MARKER,
-    }).returning({ id: experiments.id }).get();
-    const base = await db.insert(experimentVersions).values({
-      experimentId: experiment.id, version: 1, label: "Base setup", kind: "setup", setupPath: "seed/demo-base.json",
-      appliedChanges: "[]", hypothesis: "Baseline reference", prediction: "Reference pace", status: "active",
-    }).returning({ id: experimentVersions.id }).get();
-    const drill = await db.insert(experimentVersions).values({
-      experimentId: experiment.id, version: 2, label: "Brake later drill", parentVersionId: base.id, kind: "drill",
-      appliedChanges: JSON.stringify([{ kind: "drill", description: "Brake later and release smoothly" }]),
-      hypothesis: "Later release preserves entry speed", prediction: "Faster sector one", status: "active",
-    }).returning({ id: experimentVersions.id }).get();
+    const experiment = await db
+      .insert(experiments)
+      .values({
+        seq: 1,
+        gameId: "f1-2025",
+        name: "Demo setup experiment",
+        carOrdinal: f1.carOrdinal,
+        trackOrdinal: f1.trackOrdinal,
+        focus: "car",
+        notes: SEED_MARKER,
+      })
+      .returning({ id: experiments.id })
+      .get();
+    const base = await db
+      .insert(experimentVersions)
+      .values({
+        experimentId: experiment.id,
+        version: 1,
+        label: "Base setup",
+        kind: "setup",
+        setupPath: "seed/demo-base.json",
+        appliedChanges: "[]",
+        hypothesis: "Baseline reference",
+        prediction: "Reference pace",
+        status: "active",
+      })
+      .returning({ id: experimentVersions.id })
+      .get();
+    const drill = await db
+      .insert(experimentVersions)
+      .values({
+        experimentId: experiment.id,
+        version: 2,
+        label: "Brake later drill",
+        parentVersionId: base.id,
+        kind: "drill",
+        appliedChanges: JSON.stringify([{ kind: "drill", description: "Brake later and release smoothly" }]),
+        hypothesis: "Later release preserves entry speed",
+        prediction: "Faster sector one",
+        status: "active",
+      })
+      .returning({ id: experimentVersions.id })
+      .get();
     await db.update(experiments).set({ headVersionId: drill.id, focus: "driver" }).where(eq(experiments.id, experiment.id)).run();
-    await db.insert(experimentFocusEvents).values([
-      { experimentId: experiment.id, focus: "car", fromVersionId: null, note: "Initial setup focus" },
-      { experimentId: experiment.id, focus: "driver", fromVersionId: drill.id, note: "Switch to technique" },
-    ]).run();
-    await db.update(laps).set({ experimentVersionId: drill.id }).where(inArray(laps.id, f1Laps.map((lap) => lap.id))).run();
+    await db
+      .insert(experimentFocusEvents)
+      .values([
+        { experimentId: experiment.id, focus: "car", fromVersionId: null, note: "Initial setup focus" },
+        { experimentId: experiment.id, focus: "driver", fromVersionId: drill.id, note: "Switch to technique" },
+      ])
+      .run();
+    await db
+      .update(laps)
+      .set({ experimentVersionId: drill.id })
+      .where(
+        inArray(
+          laps.id,
+          f1Laps.map((lap) => lap.id),
+        ),
+      )
+      .run();
   }
 
   if (fmLaps.length >= 2) {
     const faster = [...fmLaps].sort((a, b) => a.id - b.id).at(-1)?.id ?? fmLaps[0].id;
     const slower = fmLaps.find((lap) => lap.id !== faster)?.id ?? fmLaps[0].id;
     const marker = `<!-- ${SEED_MARKER} -->`;
-    await db.insert(lapAnalyses).values({ lapId: faster, analysis: `${marker}\n## Demo lap analysis\nThis seeded lap is available for local UI development.`, model: "seed", inputTokens: 0, outputTokens: 0, costUsd: 0, durationMs: 0 }).run();
-    await db.insert(compareAnalyses).values({ lapAId: Math.min(faster, slower), lapBId: Math.max(faster, slower), kind: "inputs", analysis: `${marker}\n## Demo comparison\nThe seeded laps provide a faster/slower comparison for local development.`, model: "seed", inputTokens: 0, outputTokens: 0, costUsd: 0, durationMs: 0 }).run();
-    await saveChatMessages(compareChatThreadId(faster, slower), [
-      {
-        role: "user",
-        markdown: "What changed between these laps?",
-      },
-    ]);
+    await db
+      .insert(lapAnalyses)
+      .values({
+        lapId: faster,
+        analysis: `${marker}\n## Demo lap analysis\nThis seeded lap is available for local UI development.`,
+        model: "seed",
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+        durationMs: 0,
+      })
+      .run();
+    await db
+      .insert(compareAnalyses)
+      .values({
+        lapAId: Math.min(faster, slower),
+        lapBId: Math.max(faster, slower),
+        kind: "inputs",
+        analysis: `${marker}\n## Demo comparison\nThe seeded laps provide a faster/slower comparison for local development.`,
+        model: "seed",
+        inputTokens: 0,
+        outputTokens: 0,
+        costUsd: 0,
+        durationMs: 0,
+      })
+      .run();
+    const identity = await getCompareQualityIdentity(faster, slower);
+    if (identity) {
+      await saveChatMessages(compareChatThreadId(faster, slower, `${identity.policyVersion}:${identity.generation}`), [
+        {
+          role: "user",
+          markdown: "What changed between these laps?",
+        },
+      ]);
+    }
   }
 }

--- a/scripts/data/seed-db-reset.ts
+++ b/scripts/data/seed-db-reset.ts
@@ -2,22 +2,35 @@ import { existsSync, unlinkSync } from "node:fs";
 import { eq, inArray, like } from "drizzle-orm";
 import { db } from "../../server/db/index";
 import { chatThreadId, compareChatThreadId, getChatMemory, listThreadGenerations } from "../../server/ai/chat-agent";
+import { getCompareQualityIdentity } from "../../server/db/analysis-queries";
 import { sessions, laps, profiles, tunes, tuneAssignments, experiments, experimentVersions, experimentFocusEvents, lapAnalyses, compareAnalyses } from "../../server/db/schema";
 import { deleteSession } from "../../server/db/session-queries";
 import { PROFILE_NAME, SEED_MARKER } from "./seed-db-options";
 
 export async function removeSeedData(): Promise<void> {
-  const sessionRows = await db.select({ id: sessions.id, rawFile: sessions.rawFile })
-    .from(sessions).where(like(sessions.notes, `%${SEED_MARKER}%`)).all();
+  const sessionRows = await db
+    .select({ id: sessions.id, rawFile: sessions.rawFile })
+    .from(sessions)
+    .where(like(sessions.notes, `%${SEED_MARKER}%`))
+    .all();
   const seededLaps = sessionRows.length
     ? await db
         .select({ id: laps.id, gameId: sessions.gameId })
         .from(laps)
         .innerJoin(sessions, eq(laps.sessionId, sessions.id))
-        .where(inArray(sessions.id, sessionRows.map((row) => row.id)))
+        .where(
+          inArray(
+            sessions.id,
+            sessionRows.map((row) => row.id),
+          ),
+        )
         .all()
     : [];
-  const experimentRows = await db.select({ id: experiments.id }).from(experiments).where(like(experiments.notes, `%${SEED_MARKER}%`)).all();
+  const experimentRows = await db
+    .select({ id: experiments.id })
+    .from(experiments)
+    .where(like(experiments.notes, `%${SEED_MARKER}%`))
+    .all();
   const tuneRows = await db.select({ id: tunes.id }).from(tunes).where(eq(tunes.source, SEED_MARKER)).all();
   const chatBases = seededLaps.map((lap) => chatThreadId(lap.id));
   const fmLapIds = seededLaps
@@ -26,7 +39,10 @@ export async function removeSeedData(): Promise<void> {
     .sort((a, b) => a - b);
   if (fmLapIds.length >= 2) {
     const latestFmLapId = fmLapIds[fmLapIds.length - 1];
-    if (latestFmLapId !== undefined) chatBases.push(compareChatThreadId(latestFmLapId, fmLapIds[0]));
+    if (latestFmLapId !== undefined) {
+      const identity = await getCompareQualityIdentity(latestFmLapId, fmLapIds[0]);
+      if (identity) chatBases.push(compareChatThreadId(latestFmLapId, fmLapIds[0], `${identity.policyVersion}:${identity.generation}`));
+    }
   }
   if (chatBases.length > 0) {
     const memory = getChatMemory();
@@ -38,20 +54,75 @@ export async function removeSeedData(): Promise<void> {
   }
 
   if (experimentRows.length) {
-    await db.delete(experimentFocusEvents).where(inArray(experimentFocusEvents.experimentId, experimentRows.map((row) => row.id))).run();
-    await db.delete(experimentVersions).where(inArray(experimentVersions.experimentId, experimentRows.map((row) => row.id))).run();
-    await db.delete(experiments).where(inArray(experiments.id, experimentRows.map((row) => row.id))).run();
+    await db
+      .delete(experimentFocusEvents)
+      .where(
+        inArray(
+          experimentFocusEvents.experimentId,
+          experimentRows.map((row) => row.id),
+        ),
+      )
+      .run();
+    await db
+      .delete(experimentVersions)
+      .where(
+        inArray(
+          experimentVersions.experimentId,
+          experimentRows.map((row) => row.id),
+        ),
+      )
+      .run();
+    await db
+      .delete(experiments)
+      .where(
+        inArray(
+          experiments.id,
+          experimentRows.map((row) => row.id),
+        ),
+      )
+      .run();
   }
   if (tuneRows.length) {
-    await db.delete(tuneAssignments).where(inArray(tuneAssignments.tuneId, tuneRows.map((row) => row.id))).run();
-    await db.delete(tunes).where(inArray(tunes.id, tuneRows.map((row) => row.id))).run();
+    await db
+      .delete(tuneAssignments)
+      .where(
+        inArray(
+          tuneAssignments.tuneId,
+          tuneRows.map((row) => row.id),
+        ),
+      )
+      .run();
+    await db
+      .delete(tunes)
+      .where(
+        inArray(
+          tunes.id,
+          tuneRows.map((row) => row.id),
+        ),
+      )
+      .run();
   }
   for (const row of sessionRows) {
     await deleteSession(row.id);
     if (row.rawFile && existsSync(row.rawFile)) unlinkSync(row.rawFile);
   }
   const seedProfile = await db.select({ id: profiles.id }).from(profiles).where(eq(profiles.name, PROFILE_NAME)).all();
-  if (seedProfile.length) await db.delete(profiles).where(inArray(profiles.id, seedProfile.map((row) => row.id))).run();
-  await db.delete(lapAnalyses).where(like(lapAnalyses.analysis, `%${SEED_MARKER}%`)).run();
-  await db.delete(compareAnalyses).where(like(compareAnalyses.analysis, `%${SEED_MARKER}%`)).run();
+  if (seedProfile.length)
+    await db
+      .delete(profiles)
+      .where(
+        inArray(
+          profiles.id,
+          seedProfile.map((row) => row.id),
+        ),
+      )
+      .run();
+  await db
+    .delete(lapAnalyses)
+    .where(like(lapAnalyses.analysis, `%${SEED_MARKER}%`))
+    .run();
+  await db
+    .delete(compareAnalyses)
+    .where(like(compareAnalyses.analysis, `%${SEED_MARKER}%`))
+    .run();
 }

--- a/server/ai/chat-agent.ts
+++ b/server/ai/chat-agent.ts
@@ -7,6 +7,7 @@
  */
 import { Memory } from "@mastra/memory";
 import { LibSQLStore } from "@mastra/libsql";
+import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import { cancelChatRun } from "./chat-run-registry";
 import type { ChatTurnMessage } from "./chat-message-context";
@@ -40,10 +41,7 @@ export function getChatMemory() {
  * Map app settings (aiProvider + aiModel) to a Mastra model ID string.
  * Mastra uses the format "provider/model-name".
  */
-export function getMastraModelId(
-  aiProvider: string,
-  aiModel: string,
-): string {
+export function getMastraModelId(aiProvider: string, aiModel: string): string {
   switch (aiProvider) {
     case "gemini":
       return `google/${aiModel || "gemini-flash-latest"}`;
@@ -76,13 +74,24 @@ export function tuneSessionThreadId(sessionId: number): string {
 }
 
 /**
- * Build the threadId for a compare chat between two laps.
- * Uses canonical ordering (min,max) so order of selection doesn't matter.
+ * Build the threadId for a compare chat between two laps and one quality
+ * identity. Canonical lap ordering keeps A/B selection order irrelevant.
  */
-export function compareChatThreadId(idA: number, idB: number): string {
+export function compareChatThreadId(idA: number, idB: number, qualityIdentity: string): string {
   const lo = Math.min(idA, idB);
   const hi = Math.max(idA, idB);
-  return `compare-${lo}-${hi}`;
+  const qualityHash = createHash("sha256").update(qualityIdentity).digest("hex");
+  return `compare-${lo}-${hi}~q${qualityHash}`;
+}
+
+export function parseCompareChatThreadId(threadId: string): readonly [number, number] | null {
+  const base = parseThreadGeneration(threadId).base;
+  if (!base.startsWith("compare-")) return null;
+  const pair = base.slice("compare-".length).split("~q", 1)[0];
+  const parts = pair.split("-");
+  if (parts.length !== 2) return null;
+  const ids = parts.map(Number);
+  return ids.every(Number.isFinite) ? [ids[0], ids[1]] : null;
 }
 
 /** The resource ID used for all chat threads. */
@@ -105,11 +114,7 @@ export type ChatExportMemory = {
 type ChatThreadRecord = { id: string; title?: string; metadata?: Record<string, unknown> };
 
 /** Persist initial prompt in thread metadata, once per generation. */
-export async function ensureSystemPrompt(
-  threadId: string,
-  systemPrompt: string,
-  mem: ChatExportMemory = memory as unknown as ChatExportMemory,
-): Promise<void> {
+export async function ensureSystemPrompt(threadId: string, systemPrompt: string, mem: ChatExportMemory = memory as unknown as ChatExportMemory): Promise<void> {
   if (!systemPrompt.trim() || !mem.getThreadById) return;
   const thread = (await mem.getThreadById({ threadId })) as ChatThreadRecord | null;
   if (!thread) {
@@ -147,11 +152,15 @@ export function chatMemoryMessagesToUiMessages(messages: unknown[]): ChatTurnMes
         parts: parts.map((part) => {
           const candidate = part as { type?: unknown; text?: unknown; reasoning?: unknown; details?: unknown[] };
           if (candidate.type !== "reasoning" || typeof candidate.text === "string") return part;
-          const text = typeof candidate.reasoning === "string"
-            ? candidate.reasoning
-            : Array.isArray(candidate.details)
-              ? candidate.details.filter((detail) => (detail as { type?: unknown })?.type === "text").map((detail) => (detail as { text?: unknown }).text ?? "").join("")
-              : "";
+          const text =
+            typeof candidate.reasoning === "string"
+              ? candidate.reasoning
+              : Array.isArray(candidate.details)
+                ? candidate.details
+                    .filter((detail) => (detail as { type?: unknown })?.type === "text")
+                    .map((detail) => (detail as { text?: unknown }).text ?? "")
+                    .join("")
+                : "";
           return text ? { ...(part as object), text } : part;
         }),
       };
@@ -162,16 +171,25 @@ export function buildChatExport(messages: unknown[]): { messages: unknown[] };
 export function buildChatExport(systemPromptOrMessages: string | undefined | unknown[], maybeMessages?: unknown[]) {
   const systemPrompt = typeof systemPromptOrMessages === "string" || systemPromptOrMessages === undefined ? systemPromptOrMessages : undefined;
   const messages = Array.isArray(systemPromptOrMessages) ? systemPromptOrMessages : (maybeMessages ?? []);
-  const system = systemPrompt === undefined ? [] : [{
-    role: "system",
-    content: { format: 2, parts: [{ type: "text", text: systemPrompt }], content: systemPrompt },
-  }];
-  return { messages: [...system, ...messages.filter((message) => {
-    const role = (message as { role?: unknown })?.role;
-    return role === "user" || role === "assistant";
-  })] };
+  const system =
+    systemPrompt === undefined
+      ? []
+      : [
+          {
+            role: "system",
+            content: { format: 2, parts: [{ type: "text", text: systemPrompt }], content: systemPrompt },
+          },
+        ];
+  return {
+    messages: [
+      ...system,
+      ...messages.filter((message) => {
+        const role = (message as { role?: unknown })?.role;
+        return role === "user" || role === "assistant";
+      }),
+    ],
+  };
 }
-
 
 // ─── Chat generations ──────────────────────────────────────────────────────
 //
@@ -222,10 +240,7 @@ export type ThreadProbeMemory = {
  * `mem` defaults to the shared `getChatMemory()` singleton; pass a fake to
  * probe an alternate store (tests).
  */
-export async function listThreadGenerations(
-  base: string,
-  mem: ThreadProbeMemory = getChatMemory(),
-): Promise<Array<{ threadId: string; generation: number }>> {
+export async function listThreadGenerations(base: string, mem: ThreadProbeMemory = getChatMemory()): Promise<Array<{ threadId: string; generation: number }>> {
   const out: Array<{ threadId: string; generation: number }> = [];
   for (let gen = 1; ; gen++) {
     const threadId = generationThreadId(base, gen);
@@ -252,10 +267,7 @@ export async function deleteChatLineage(baseThreadId: string, mem: ChatExportMem
  * (gen 1) when nothing exists yet, so a first POST auto-creates gen 1 exactly
  * as before.
  */
-export async function resolveActiveThread(
-  base: string,
-  mem: ThreadProbeMemory = getChatMemory(),
-): Promise<string> {
+export async function resolveActiveThread(base: string, mem: ThreadProbeMemory = getChatMemory()): Promise<string> {
   const gens = await listThreadGenerations(base, mem);
   return gens.length ? gens[gens.length - 1].threadId : base;
 }
@@ -279,10 +291,7 @@ export async function saveAssistantChatMessage(threadId: string, markdown: strin
  * MessageList reader collapsing consecutive same-role messages into one entry,
  * so a user+assistant pair renders as two separate turns.
  */
-export async function saveChatMessages(
-  threadId: string,
-  entries: Array<{ role: "user" | "assistant"; markdown: string }>,
-): Promise<string[]> {
+export async function saveChatMessages(threadId: string, entries: Array<{ role: "user" | "assistant"; markdown: string }>): Promise<string[]> {
   const mem = getChatMemory();
   const existing = await mem.getThreadById({ threadId });
   if (!existing) {
@@ -327,16 +336,15 @@ function messageText(message: any): string {
   if (typeof message?.content === "string") return message.content;
   if (typeof message?.content?.content === "string") return message.content.content;
   return Array.isArray(message?.content?.parts)
-    ? message.content.parts.filter((part: any) => part?.type === "text").map((part: any) => part.text ?? "").join("")
+    ? message.content.parts
+        .filter((part: any) => part?.type === "text")
+        .map((part: any) => part.text ?? "")
+        .join("")
     : "";
 }
 
 /** Retain history through one user prompt and remove its response and all later messages. */
-export async function truncateChatAfterUserMessage(
-  threadId: string,
-  messageId: string,
-  mem: ChatMutationMemory = getChatMemory(),
-): Promise<{ messages: unknown[]; prompt: string }> {
+export async function truncateChatAfterUserMessage(threadId: string, messageId: string, mem: ChatMutationMemory = getChatMemory()): Promise<{ messages: unknown[]; prompt: string }> {
   const messages = (await mem.recall({ threadId, perPage: false })).messages ?? [];
   const selectedIndex = messages.findIndex((message: any) => message?.id === messageId && message?.role === "user");
   if (selectedIndex < 0) throw new Error("User message not found");

--- a/server/ai/compare-chat-prompt.ts
+++ b/server/ai/compare-chat-prompt.ts
@@ -9,6 +9,8 @@ import type { UnitSystem, TemperatureUnit } from "../lap-analysis/report";
 import { getPromptCarName, getPromptTrackName, compareEngineerPersona, compareLapHeader } from "./compare-engineer";
 import { buildSegmentTimingTable, type PromptSegment } from "./inputs-compare-prompt";
 import { TRACK_GUIDE_PROMPT } from "../../shared/integrations/ai/prompt-snippets";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import { buildQualityPromptContext } from "./quality-context";
 
 interface LapInfo {
   id: number;
@@ -18,6 +20,9 @@ interface LapInfo {
   carOrdinal?: number;
   trackOrdinal?: number;
   gameId?: GameId;
+  quality?: LapQualitySummary | null;
+  eligibility?: EligibilityDecisionSet | null;
+  qualityGeneration?: string | null;
 }
 
 function summarizeComparison(comp: ComparisonResult): string {
@@ -41,9 +46,7 @@ function summarizeComparison(comp: ComparisonResult): string {
   const distAtAhead = comp.distances[maxAheadIdx];
   const distAtBehind = comp.distances[maxBehindIdx];
 
-  const corners = [...comp.cornerDeltas]
-    .sort((a, b) => Math.abs(b.deltaSeconds) - Math.abs(a.deltaSeconds))
-    .slice(0, 8);
+  const corners = [...comp.cornerDeltas].sort((a, b) => Math.abs(b.deltaSeconds) - Math.abs(a.deltaSeconds)).slice(0, 8);
 
   let out = `--- COMPARISON SUMMARY ---\n`;
   out += `Final time delta (A − B): ${final >= 0 ? "+" : ""}${final.toFixed(3)}s `;
@@ -60,18 +63,11 @@ function summarizeComparison(comp: ComparisonResult): string {
   return `${out}\n`;
 }
 
-export function buildCompareChatContext(
-  lapA: LapInfo,
-  lapB: LapInfo,
-  comparison: ComparisonResult,
-  segments: PromptSegment[] | null = null,
-): string {
+export function buildCompareChatContext(lapA: LapInfo, lapB: LapInfo, comparison: ComparisonResult, segments: PromptSegment[] | null = null): string {
   const carA = getPromptCarName(lapA.carOrdinal ?? 0, lapA.gameId);
   const carB = getPromptCarName(lapB.carOrdinal ?? 0, lapB.gameId);
   const trackName = getPromptTrackName(lapA.trackOrdinal ?? 0, lapA.gameId);
-  const finalDelta =
-    comparison.timeDelta[comparison.timeDelta.length - 1] ??
-    lapA.lapTime - lapB.lapTime;
+  const finalDelta = comparison.timeDelta[comparison.timeDelta.length - 1] ?? lapA.lapTime - lapB.lapTime;
   return `${compareLapHeader(trackName, carA, carB, lapA, lapB, finalDelta)}
 ${summarizeComparison(comparison)}
 
@@ -82,14 +78,7 @@ Use these computed deltas as authoritative. Explain why they differ using teleme
 Use the retrieved analyses and the corner-by-corner deltas to explain where time is gained or lost and what the slower lap should change.`;
 }
 
-export function buildCompareChatSystemPrompt(
-  lapA: LapInfo,
-  lapB: LapInfo,
-  comparison: ComparisonResult,
-  unit?: UnitSystem,
-  temperatureUnit?: TemperatureUnit,
-  language?: string,
-): string;
+export function buildCompareChatSystemPrompt(lapA: LapInfo, lapB: LapInfo, comparison: ComparisonResult, unit?: UnitSystem, temperatureUnit?: TemperatureUnit, language?: string): string;
 export function buildCompareChatSystemPrompt(
   lapA: LapInfo,
   lapB: LapInfo,
@@ -110,29 +99,18 @@ export function buildCompareChatSystemPrompt(
   languageOrUnit: string | UnitSystem = "en",
   legacyTemperature?: TemperatureUnit,
   legacyLanguage = "en",
+  legacyPrecomputedInsights = "",
 ): string {
   const isCurrent = unitOrAnalysisA === "metric" || unitOrAnalysisA === "imperial";
-  const unit: UnitSystem = isCurrent
-    ? unitOrAnalysisA
-    : languageOrUnit === "imperial"
-      ? "imperial"
-      : "metric";
-  const temperatureUnit: TemperatureUnit = isCurrent
-    ? temperatureOrAnalysisB === "F"
-      ? "F"
-      : "C"
-    : legacyTemperature ?? (unit === "metric" ? "C" : "F");
-  const language = isCurrent
-    ? typeof languageOrUnit === "string" && languageOrUnit !== "metric" && languageOrUnit !== "imperial"
-      ? languageOrUnit
-      : "en"
-    : legacyLanguage;
+  const unit: UnitSystem = isCurrent ? unitOrAnalysisA : languageOrUnit === "imperial" ? "imperial" : "metric";
+  const temperatureUnit: TemperatureUnit = isCurrent ? (temperatureOrAnalysisB === "F" ? "F" : "C") : (legacyTemperature ?? (unit === "metric" ? "C" : "F"));
+  const language = isCurrent ? (typeof languageOrUnit === "string" && languageOrUnit !== "metric" && languageOrUnit !== "imperial" ? languageOrUnit : "en") : legacyLanguage;
   const carA = getPromptCarName(lapA.carOrdinal ?? 0, lapA.gameId);
   const carB = getPromptCarName(lapB.carOrdinal ?? 0, lapB.gameId);
   const trackName = getPromptTrackName(lapA.trackOrdinal ?? 0, lapA.gameId);
-  const finalDelta =
-    comparison.timeDelta[comparison.timeDelta.length - 1] ??
-    lapA.lapTime - lapB.lapTime;
+  const finalDelta = comparison.timeDelta[comparison.timeDelta.length - 1] ?? lapA.lapTime - lapB.lapTime;
+  const qualityContextA = buildQualityPromptContext(lapA, ["lap-comparison", "corner-trace", "transient-event"]);
+  const qualityContextB = buildQualityPromptContext(lapB, ["lap-comparison", "corner-trace", "transient-event"]);
   return `${compareEngineerPersona(unit, temperatureUnit, language)}${TRACK_GUIDE_PROMPT}
 
 INITIALIZATION PROTOCOL — MUST COMPLETE BEFORE ANY TEXT
@@ -150,6 +128,11 @@ The required call order is: get_lap_analysis(${lapA.id}), get_lap_analysis(${lap
 This task: free-form chat. The driver will ask you questions about how the two laps compare. Be brief and use bullet points where helpful. NO JSON output — write conversational answers.
 
 ${compareLapHeader(trackName, carA, carB, lapA, lapB, finalDelta)}
+Lap A:
+${qualityContextA}
+Lap B:
+${qualityContextB}
+${legacyPrecomputedInsights}
 
 ${summarizeComparison(comparison)}
 Use the retrieved analyses and the corner-by-corner deltas to explain where time is gained or lost and what the slower lap should change.`;

--- a/server/ai/generate-lap-analysis.ts
+++ b/server/ai/generate-lap-analysis.ts
@@ -1,8 +1,11 @@
 import type { Tune } from "../../shared/racing/tuning/types";
 import type { GameId } from "../../shared/games/ids";
+import type { EligibilityDecision } from "../../shared/racing/quality/contracts";
+import { eligibilityDecisionText } from "../../shared/racing/quality/display";
+import { isEligibilityUsable, resolveEligibilityDecision } from "../../shared/racing/quality/policies";
 import { getLapById } from "../db/lap-read-queries";
 import { getCorners } from "../db/track-queries";
-import { getAnalysis, saveAnalysis } from "../db/analysis-queries";
+import { getAnalysis, qualityCacheIdentityForLap, saveAnalysis } from "../db/analysis-queries";
 import { getTuneById as getDbTune } from "../db/tune-queries";
 import { detectCorners, type Corner } from "../lap-analysis/corners";
 import { loadSettings } from "../runtime/config/settings";
@@ -38,12 +41,10 @@ export interface LapAnalysisResult {
   cornerFracs: CornerFraction[];
   hasTune: boolean;
   error?: string;
+  decision?: EligibilityDecision;
 }
 
-type AgentGenerate = (
-  prompt: string,
-  options: Record<string, unknown>,
-) => Promise<unknown>;
+type AgentGenerate = (prompt: string, options: Record<string, unknown>) => Promise<unknown>;
 export interface GenerateLapAnalysisDeps {
   getLapById?: typeof getLapById;
   getCorners?: typeof getCorners;
@@ -62,16 +63,13 @@ export interface GenerateLapAnalysisDeps {
   generate?: AgentGenerate;
 }
 
-const invalidAnalysisError =
-  "Model produced invalid analysis structure. Not cached. Try again or switch model.";
+const invalidAnalysisError = "Model produced invalid analysis structure. Not cached. Try again or switch model.";
 
 function parseAndValidateAnalysis(raw: unknown): string | null {
   if (typeof raw !== "string") return null;
   try {
     const text = extractJson(raw);
-    return AnalystOutputSchema.safeParse(JSON.parse(text)).success
-      ? text
-      : null;
+    return AnalystOutputSchema.safeParse(JSON.parse(text)).success ? text : null;
   } catch {
     return null;
   }
@@ -99,6 +97,18 @@ export async function generateLapAnalysis(
       hasTune: false,
       error: "Lap not found",
     };
+  const qualityIdentity = qualityCacheIdentityForLap(lap);
+  const decision = resolveEligibilityDecision(lap, "corner-trace");
+  if (!isEligibilityUsable(decision)) {
+    return {
+      analysis: null,
+      cached: false,
+      cornerFracs: [],
+      hasTune: false,
+      decision,
+      error: eligibilityDecisionText(decision),
+    };
+  }
   if (lap.telemetry.length === 0)
     return {
       analysis: null,
@@ -106,20 +116,22 @@ export async function generateLapAnalysis(
       cornerFracs: [],
       hasTune: false,
       error: "No telemetry data",
+      decision,
+    };
+  if (!qualityIdentity)
+    return {
+      analysis: null,
+      cached: false,
+      cornerFracs: [],
+      hasTune: false,
+      error: "Lap has no current quality generation",
+      decision,
     };
 
   const trackOrdinal = lap.trackOrdinal ?? 0;
-  let corners: Corner[] =
-    trackOrdinal > 0 && lap.gameId
-      ? await findCorners(trackOrdinal, lap.gameId)
-      : [];
-  if (corners.length === 0)
-    corners = (deps.detectCorners ?? detectCorners)(lap.telemetry);
-  const totalDist =
-    lap.telemetry.length > 1
-      ? lap.telemetry[lap.telemetry.length - 1].DistanceTraveled -
-        lap.telemetry[0].DistanceTraveled
-      : 1;
+  let corners: Corner[] = trackOrdinal > 0 && lap.gameId ? await findCorners(trackOrdinal, lap.gameId) : [];
+  if (corners.length === 0) corners = (deps.detectCorners ?? detectCorners)(lap.telemetry);
+  const totalDist = lap.telemetry.length > 1 ? lap.telemetry[lap.telemetry.length - 1].DistanceTraveled - lap.telemetry[0].DistanceTraveled : 1;
   const firstDist = lap.telemetry[0]?.DistanceTraveled ?? 0;
   const cornerFracs = corners.map((corner) => ({
     label: corner.label,
@@ -144,10 +156,10 @@ export async function generateLapAnalysis(
         },
         cornerFracs,
         hasTune,
+        decision,
       };
     }
-    if (options.cacheOnly && !options.preflight)
-      return { analysis: null, cached: false, cornerFracs, hasTune };
+    if (options.cacheOnly && !options.preflight) return { analysis: null, cached: false, cornerFracs, hasTune, decision };
   }
 
   const settings = (deps.loadSettings ?? loadSettings)();
@@ -165,35 +177,20 @@ export async function generateLapAnalysis(
       } as Tune;
     }
   }
-  const track = (deps.resolveTrack ?? resolveTrack)(
-    lap.gameId,
-    lap.trackOrdinal,
-  );
+  const track = (deps.resolveTrack ?? resolveTrack)(lap.gameId, lap.trackOrdinal);
   let sectors: PromptSectors | undefined;
   try {
     const game = lap.gameId ? (deps.getGame ?? getGame)(lap.gameId) : undefined;
     if (game?.nativeSectors && game.getNativeSectorLayout) {
-      const timeline = (
-        deps.computeNativeSectorTimeline ?? computeNativeSectorTimeline
-      )(lap.telemetry, lap.lapTime, game.getNativeSectorLayout);
+      const timeline = (deps.computeNativeSectorTimeline ?? computeNativeSectorTimeline)(lap.telemetry, lap.lapTime, game.getNativeSectorLayout);
       if (timeline && timeline.times.length >= 2) {
         sectors = {
           times: timeline.times,
           sectorStarts: timeline.sectorStarts,
         };
       }
-    } else if (
-      track.sectors.s1End &&
-      track.sectors.s2End &&
-      lap.gameId &&
-      lap.trackOrdinal != null
-    ) {
-      const times = await (deps.computeLapSectors ?? computeLapSectors)(
-        lap.trackOrdinal,
-        lap.gameId as GameId,
-        lap.telemetry,
-        lap.lapTime,
-      );
+    } else if (track.sectors.s1End && track.sectors.s2End && lap.gameId && lap.trackOrdinal != null) {
+      const times = await (deps.computeLapSectors ?? computeLapSectors)(lap.trackOrdinal, lap.gameId as GameId, lap.telemetry, lap.lapTime);
       if (times && times.length >= 3) {
         sectors = {
           times,
@@ -227,12 +224,13 @@ export async function generateLapAnalysis(
       cached: false,
       cornerFracs,
       hasTune,
+      decision,
       error: toClientAiError(err).message,
     };
   }
 
   if (options.preflight) {
-    return { analysis: null, cached: false, cornerFracs, hasTune };
+    return { analysis: null, cached: false, cornerFracs, hasTune, decision };
   }
   const model = ai.model;
   const startedAt = Date.now();
@@ -256,21 +254,12 @@ export async function generateLapAnalysis(
             jsonSchema: { name: "analyst_output", strict: true, schema },
           },
         },
-        google: buildGoogleProviderOptions(
-          model,
-          schema,
-          settings.aiThinkingBudget,
-        ),
+        google: buildGoogleProviderOptions(model, schema, settings.aiThinkingBudget),
       },
     };
-    const generate =
-      deps.generate ??
-      ((requestPrompt, requestOptions) =>
-        lapAnalystAgent.generate(requestPrompt, requestOptions as never));
+    const generate = deps.generate ?? ((requestPrompt, requestOptions) => lapAnalystAgent.generate(requestPrompt, requestOptions as never));
     const runStructured = deps.runAiStructured ?? runAiStructured;
-    const result = await runStructured(ai, input, (requestContext) =>
-      generate(prompt, { ...generationOptions, requestContext }),
-    );
+    const result = await runStructured(ai, input, (requestContext) => generate(prompt, { ...generationOptions, requestContext }));
     const text = parseAndValidateAnalysis(result.analysis);
     if (!text)
       return {
@@ -278,14 +267,12 @@ export async function generateLapAnalysis(
         cached: false,
         cornerFracs,
         hasTune,
+        decision,
         error: invalidAnalysisError,
       };
 
     const rawUsage = (result.usage ?? {}) as Record<string, unknown>;
-    const numberFor = (...keys: string[]) =>
-      keys
-        .map((key) => rawUsage[key])
-        .find((value): value is number => typeof value === "number") ?? 0;
+    const numberFor = (...keys: string[]) => keys.map((key) => rawUsage[key]).find((value): value is number => typeof value === "number") ?? 0;
     const usage: AnalysisUsage = {
       inputTokens: numberFor("inputTokens", "promptTokens"),
       outputTokens: numberFor("outputTokens", "completionTokens"),
@@ -293,14 +280,25 @@ export async function generateLapAnalysis(
       durationMs: numberFor("durationMs") || Date.now() - startedAt,
       model,
     };
-    await writeAnalysis(lapId, text, usage);
-    return { analysis: text, cached: false, usage, cornerFracs, hasTune };
+    const saved = await writeAnalysis(lapId, text, usage, qualityIdentity);
+    if (!saved) {
+      return {
+        analysis: null,
+        cached: false,
+        cornerFracs,
+        hasTune,
+        decision,
+        error: "Lap quality changed during analysis generation. Analysis not cached.",
+      };
+    }
+    return { analysis: text, cached: false, usage, cornerFracs, hasTune, decision };
   } catch (err) {
     return {
       analysis: null,
       cached: false,
       cornerFracs,
       hasTune,
+      decision,
       error: toClientAiError(err).message,
     };
   }

--- a/server/ai/inputs-compare-prompt.ts
+++ b/server/ai/inputs-compare-prompt.ts
@@ -11,6 +11,8 @@ import { buildTrackGuideContext } from "./track-guides";
 import { resolveTrack } from "../tracks/info";
 import { segmentPromptNames } from "../../shared/racing/tracks/segment-label";
 import { computeStatsRange, steerScaleFor, type InputStats } from "../lap-analysis/metrics";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import { buildQualityPromptContext } from "./quality-context";
 
 /**
  * Zod schema for the per-segment inputs comparison output.
@@ -57,6 +59,9 @@ interface LapInfo {
   carOrdinal?: number;
   trackOrdinal?: number;
   gameId?: GameId;
+  quality?: LapQualitySummary | null;
+  eligibility?: EligibilityDecisionSet | null;
+  qualityGeneration?: string | null;
 }
 
 export interface PromptSegment {
@@ -112,10 +117,7 @@ function formatSegmentTable(
 }
 
 /** Build server-authoritative per-segment timing rows for any compare flow. */
-export function buildSegmentTimingTable(
-  comparison: ComparisonResult,
-  segments: PromptSegment[] | null,
-): string {
+export function buildSegmentTimingTable(comparison: ComparisonResult, segments: PromptSegment[] | null): string {
   const useSegs = segments && segments.length > 0 ? segments : fallbackSegments(8);
   const distances = comparison.distances;
   const totalDist = distances[distances.length - 1] - distances[0] || 1;
@@ -258,6 +260,8 @@ export function buildInputsComparePrompt(
   // Build the explicit list of expected segment names so the model can't forget them
   const segNames = segLabels.map((l) => `"${l}"`).join(", ");
   const expectedCount = useSegs.length;
+  const qualityContextA = buildQualityPromptContext(lapA, ["lap-comparison", "corner-trace", "transient-event"]);
+  const qualityContextB = buildQualityPromptContext(lapB, ["lap-comparison", "corner-trace", "transient-event"]);
 
   // No persona prefix here: this string is sent as the USER message, and
   // compareEngineerAgent already carries the persona (built from the same
@@ -297,6 +301,10 @@ Rules:
 - Top-level "coaching" is for the overall lap, max 5 tips, target the slower lap unless a meaningful issue exists on the faster lap.
 
 ${compareLapHeader(trackName, carA, carB, lapA, lapB, finalDelta)}
+Lap A:
+${qualityContextA}
+Lap B:
+${qualityContextB}
 ${trackGuide}
 Per-segment timings (positive Δ = Lap A is slower):
 ${formatSegmentTable(tableRows)}

--- a/server/ai/insight-format.ts
+++ b/server/ai/insight-format.ts
@@ -1,15 +1,16 @@
 import type { GameId } from "../../shared/games/ids";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import { analyzeLap } from "../../shared/racing/analysis/laps/insights/analyze";
+import type { LapQualitySummary } from "../../shared/racing/quality/contracts";
 
 /**
  * Format one lap's precomputed insights as a prompt block for the compare
  * flows. Mirrors the analyst prompt's insight section: severity, category,
  * label, approximate lap distance, and detail per line.
  */
-export function buildCompareInsightsBlock(label: string, packets: TelemetryPacket[], gameId: GameId | undefined): string {
+export function buildCompareInsightsBlock(label: string, packets: TelemetryPacket[], gameId: GameId | undefined, quality: LapQualitySummary | null | undefined): string {
   if (!gameId || packets.length === 0) return "";
-  const insights = analyzeLap(packets, gameId);
+  const insights = analyzeLap(packets, gameId, quality);
   if (insights.length === 0) return "";
   let out = `\n--- ${label} Precomputed Insights (unverified — automated detections, may contain false positives; use as hints) ---\n`;
   for (const insight of insights) {

--- a/server/ai/quality-context.ts
+++ b/server/ai/quality-context.ts
@@ -1,0 +1,23 @@
+import type { EligibilityDecisionSet, EligibilityPolicyId, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import { eligibilityDecisionText, qualityReasonText } from "../../shared/racing/quality/display";
+import { resolveEligibilityDecision } from "../../shared/racing/quality/policies";
+
+export interface QualityPromptEvidence {
+  quality?: LapQualitySummary | null;
+  eligibility?: Partial<EligibilityDecisionSet> | null;
+  qualityGeneration?: string | null;
+}
+
+export function buildQualityPromptContext(evidence: QualityPromptEvidence, policyIds: readonly EligibilityPolicyId[]): string {
+  const lines = ["--- TELEMETRY QUALITY AND ANALYSIS LIMITS ---"];
+  for (const policyId of policyIds) {
+    const decision = resolveEligibilityDecision(evidence, policyId);
+    lines.push(`${policyId}: ${decision.status}; confidence=${decision.confidence.level}; ${eligibilityDecisionText(decision)}`);
+    for (const reason of decision.reasons) {
+      lines.push(`- ${reason.code}: ${qualityReasonText(reason.code, reason.timeRange, reason.distanceRange)}`);
+    }
+  }
+  lines.push(`quality-generation: ${evidence.qualityGeneration ?? evidence.quality?.provenance.outputGeneration ?? "unknown"}`);
+  lines.push("Do not make conclusions from ineligible or unknown evidence. For warning decisions, state limits and avoid claims inside affected ranges.");
+  return lines.join("\n");
+}

--- a/server/db/README.md
+++ b/server/db/README.md
@@ -9,6 +9,8 @@ Owns RaceIQ's SQLite persistence boundary: connection startup, schema evolution,
 - `index.ts` creates the libSQL/Drizzle client and exposes idempotent `initDb()` startup.
 - `schema.ts` describes current tables; `migrations.ts` preserves ordered upgrades for existing databases.
 - `*-queries.ts` modules group reads and mutations by stored aggregate. Lap operations are split between read, mutation, reprocessing, and experiment-link concerns.
+- `lap-eligibility.ts` reads persisted policy decisions in SQL without defining policy rules.
+- `quality-event-queries.ts` links localized quality facts to durable session events and invalidates generation-tied analysis caches.
 - `telemetry-codec.ts` serializes compressed CSV telemetry fixtures; `telemetry-replay-storage.ts` replays indexed frames from session capture files and owns replay caches.
 - `discovered-*.ts` persists game-provided identities that are not yet in static catalogs.
 
@@ -18,6 +20,7 @@ Owns RaceIQ's SQLite persistence boundary: connection startup, schema evolution,
 - Entrypoints must await `initDb()` before querying. Foreign keys, WAL mode, backfills, and migration ordering are established there.
 - Raw session files are the authoritative telemetry replay source; frame offsets and counts retain their persisted meaning.
 - Query modules normalize SQLite nulls and booleans at the boundary. Game IDs, ordinal pairs, experiment links, and exclusion provenance must remain scoped together.
+- Session and lap quality, eligibility decision snapshots, version identities, event links, and source/output generations are persisted compatibility data. SQL may select by stored status only when schema, policy, configuration, JSON provenance, and stored generation identities are current. Policy evaluation remains in `shared/racing/quality/`.
 - Database code may use game adapters to interpret persisted telemetry, but game policy and parsing semantics stay in their owning domains.
 
 ## Testing

--- a/server/db/analysis-queries.ts
+++ b/server/db/analysis-queries.ts
@@ -1,6 +1,9 @@
-import { eq, and, sql } from "drizzle-orm";
+import { eq, and, inArray, sql } from "drizzle-orm";
+import { ELIGIBILITY_POLICY_VERSION, type LapQualitySummary } from "../../shared/racing/quality/contracts";
+import { isQualitySnapshotCurrent } from "../../shared/racing/quality/policies";
+import { combineQualityGenerations } from "../lap-analysis/quality-generation";
 import { db } from "./index";
-import { lapAnalyses, compareAnalyses } from "./schema";
+import { lapAnalyses, compareAnalyses, laps } from "./schema";
 
 interface AnalysisRow {
   analysis: string;
@@ -9,6 +12,98 @@ interface AnalysisRow {
   costUsd: number;
   durationMs: number;
   model: string;
+}
+export interface QualityCacheIdentity {
+  generation: string;
+  policyVersion: string;
+}
+export interface LapQualityCacheEvidence {
+  qualityGeneration?: string | null;
+  qualityStale?: boolean;
+  qualitySchemaVersion?: string | null;
+  qualityPolicyVersion?: string | null;
+  qualityConfigVersion?: string | null;
+  quality?: LapQualitySummary | null;
+}
+
+export function qualityCacheIdentityForLap(evidence: LapQualityCacheEvidence): QualityCacheIdentity | null {
+  if (!isQualitySnapshotCurrent(evidence)) return null;
+  return {
+    generation: evidence.qualityGeneration!,
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+  };
+}
+
+export function qualityCacheIdentityForComparison(evidence: readonly [LapQualityCacheEvidence, LapQualityCacheEvidence]): QualityCacheIdentity | null {
+  return combineCompareIdentityRows(
+    evidence.map((lap) => (isQualitySnapshotCurrent(lap) ? { generation: lap.qualityGeneration ?? null, policyVersion: ELIGIBILITY_POLICY_VERSION } : { generation: null, policyVersion: null })),
+  );
+}
+
+interface PersistedQualityIdentityRow {
+  generation: string | null;
+  policyVersion: string | null;
+  schemaVersion: string | null;
+  configurationVersion: string | null;
+  quality: LapQualitySummary | null;
+}
+
+function currentQualityCacheIdentity(row: PersistedQualityIdentityRow | null | undefined): QualityCacheIdentity | null {
+  if (
+    !row?.quality ||
+    !row.generation ||
+    !isQualitySnapshotCurrent({
+      quality: row.quality,
+      qualityGeneration: row.generation,
+      qualitySchemaVersion: row.schemaVersion,
+      qualityPolicyVersion: row.policyVersion,
+      qualityConfigVersion: row.configurationVersion,
+    })
+  ) {
+    return null;
+  }
+  return { generation: row.generation, policyVersion: ELIGIBILITY_POLICY_VERSION };
+}
+
+function combineCompareIdentityRows(rows: Array<{ generation: string | null; policyVersion: string | null }>): QualityCacheIdentity | null {
+  if (rows.length !== 2) return null;
+  if (rows.some(({ policyVersion }) => policyVersion !== ELIGIBILITY_POLICY_VERSION)) return null;
+  if (rows.some(({ generation }) => !generation)) return null;
+  return {
+    generation: combineQualityGenerations(rows.map(({ generation }) => generation!)),
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+  };
+}
+
+async function getLapQualityIdentity(lapId: number): Promise<QualityCacheIdentity | null> {
+  const row = await db
+    .select({
+      generation: laps.qualityGeneration,
+      policyVersion: laps.qualityPolicyVersion,
+      schemaVersion: laps.qualitySchemaVersion,
+      configurationVersion: laps.qualityConfigVersion,
+      quality: laps.quality,
+    })
+    .from(laps)
+    .where(eq(laps.id, lapId))
+    .get();
+  return currentQualityCacheIdentity(row);
+}
+
+export async function getCompareQualityIdentity(idA: number, idB: number): Promise<QualityCacheIdentity | null> {
+  const rows = await db
+    .select({
+      id: laps.id,
+      generation: laps.qualityGeneration,
+      policyVersion: laps.qualityPolicyVersion,
+      schemaVersion: laps.qualitySchemaVersion,
+      configurationVersion: laps.qualityConfigVersion,
+      quality: laps.quality,
+    })
+    .from(laps)
+    .where(inArray(laps.id, [idA, idB]))
+    .all();
+  return combineCompareIdentityRows(rows.map((row) => currentQualityCacheIdentity(row) ?? { generation: null, policyVersion: null }));
 }
 
 /**
@@ -28,6 +123,8 @@ export interface AnalysisUsage {
  */
 
 export async function getAnalysis(lapId: number): Promise<AnalysisRow | null> {
+  const identity = await getLapQualityIdentity(lapId);
+  if (!identity || identity.policyVersion !== ELIGIBILITY_POLICY_VERSION) return null;
   const row = await db
     .select({
       analysis: lapAnalyses.analysis,
@@ -38,19 +135,17 @@ export async function getAnalysis(lapId: number): Promise<AnalysisRow | null> {
       model: lapAnalyses.model,
     })
     .from(lapAnalyses)
-    .where(eq(lapAnalyses.lapId, lapId))
+    .where(and(eq(lapAnalyses.lapId, lapId), eq(lapAnalyses.qualityGeneration, identity.generation), eq(lapAnalyses.qualityPolicyVersion, identity.policyVersion)))
     .get();
   return row ?? null;
 }
 
-
-export async function saveAnalysis(lapId: number, analysis: string, usage: AnalysisUsage): Promise<void> {
-  const existing = await db
-    .select({ id: lapAnalyses.id })
-    .from(lapAnalyses)
-    .where(eq(lapAnalyses.lapId, lapId))
-    .get();
-
+export async function saveAnalysis(lapId: number, analysis: string, usage: AnalysisUsage, expectedIdentity: QualityCacheIdentity): Promise<boolean> {
+  const currentIdentity = await getLapQualityIdentity(lapId);
+  if (!currentIdentity || expectedIdentity.generation !== currentIdentity.generation || expectedIdentity.policyVersion !== currentIdentity.policyVersion) {
+    return false;
+  }
+  const existing = await db.select({ id: lapAnalyses.id }).from(lapAnalyses).where(eq(lapAnalyses.lapId, lapId)).get();
   const values = {
     analysis,
     inputTokens: usage.inputTokens,
@@ -59,18 +154,19 @@ export async function saveAnalysis(lapId: number, analysis: string, usage: Analy
     durationMs: usage.durationMs,
     model: usage.model,
     createdAt: sql`(datetime('now'))`,
+    qualityGeneration: expectedIdentity.generation,
+    qualityPolicyVersion: expectedIdentity.policyVersion,
   };
 
   if (existing) {
-    await db.update(lapAnalyses)
-      .set(values)
-      .where(eq(lapAnalyses.lapId, lapId))
-      .run();
+    await db.update(lapAnalyses).set(values).where(eq(lapAnalyses.lapId, lapId)).run();
   } else {
-    await db.insert(lapAnalyses)
+    await db
+      .insert(lapAnalyses)
       .values({ lapId, ...values })
       .run();
   }
+  return true;
 }
 
 /**
@@ -86,13 +182,11 @@ export async function deleteAnalysis(lapId: number): Promise<void> {
  * The pair key is canonical (min, max) so the order of arguments doesn't matter.
  */
 
-export async function getCompareAnalysis(
-  idA: number,
-  idB: number,
-  kind: string = "inputs",
-): Promise<AnalysisRow | null> {
+export async function getCompareAnalysis(idA: number, idB: number, kind: string = "inputs"): Promise<AnalysisRow | null> {
   const lo = Math.min(idA, idB);
   const hi = Math.max(idA, idB);
+  const identity = await getCompareQualityIdentity(lo, hi);
+  if (!identity) return null;
   const row = await db
     .select({
       analysis: compareAnalyses.analysis,
@@ -108,34 +202,26 @@ export async function getCompareAnalysis(
         eq(compareAnalyses.lapAId, lo),
         eq(compareAnalyses.lapBId, hi),
         eq(compareAnalyses.kind, kind),
+        eq(compareAnalyses.qualityGeneration, identity.generation),
+        eq(compareAnalyses.qualityPolicyVersion, identity.policyVersion),
       ),
     )
     .get();
   return row ?? null;
 }
 
-
-export async function saveCompareAnalysis(
-  idA: number,
-  idB: number,
-  analysis: string,
-  usage: AnalysisUsage,
-  kind: string = "inputs",
-): Promise<void> {
+export async function saveCompareAnalysis(idA: number, idB: number, analysis: string, usage: AnalysisUsage, expectedIdentity: QualityCacheIdentity, kind: string = "inputs"): Promise<boolean> {
   const lo = Math.min(idA, idB);
   const hi = Math.max(idA, idB);
+  const currentIdentity = await getCompareQualityIdentity(lo, hi);
+  if (!currentIdentity || expectedIdentity.generation !== currentIdentity.generation || expectedIdentity.policyVersion !== currentIdentity.policyVersion) {
+    return false;
+  }
   const existing = await db
     .select({ id: compareAnalyses.id })
     .from(compareAnalyses)
-    .where(
-      and(
-        eq(compareAnalyses.lapAId, lo),
-        eq(compareAnalyses.lapBId, hi),
-        eq(compareAnalyses.kind, kind),
-      ),
-    )
+    .where(and(eq(compareAnalyses.lapAId, lo), eq(compareAnalyses.lapBId, hi), eq(compareAnalyses.kind, kind)))
     .get();
-
   const values = {
     analysis,
     inputTokens: usage.inputTokens,
@@ -144,41 +230,29 @@ export async function saveCompareAnalysis(
     durationMs: usage.durationMs,
     model: usage.model,
     createdAt: sql`(datetime('now'))`,
+    qualityGeneration: expectedIdentity.generation,
+    qualityPolicyVersion: expectedIdentity.policyVersion,
   };
-
   if (existing) {
-    await db.update(compareAnalyses)
+    await db
+      .update(compareAnalyses)
       .set(values)
-      .where(
-        and(
-          eq(compareAnalyses.lapAId, lo),
-          eq(compareAnalyses.lapBId, hi),
-          eq(compareAnalyses.kind, kind),
-        ),
-      )
+      .where(and(eq(compareAnalyses.lapAId, lo), eq(compareAnalyses.lapBId, hi), eq(compareAnalyses.kind, kind)))
       .run();
   } else {
-    await db.insert(compareAnalyses)
+    await db
+      .insert(compareAnalyses)
       .values({ lapAId: lo, lapBId: hi, kind, ...values })
       .run();
   }
+  return true;
 }
 
-
-export async function deleteCompareAnalysis(
-  idA: number,
-  idB: number,
-  kind: string = "inputs",
-): Promise<void> {
+export async function deleteCompareAnalysis(idA: number, idB: number, kind: string = "inputs"): Promise<void> {
   const lo = Math.min(idA, idB);
   const hi = Math.max(idA, idB);
-  await db.delete(compareAnalyses)
-    .where(
-      and(
-        eq(compareAnalyses.lapAId, lo),
-        eq(compareAnalyses.lapBId, hi),
-        eq(compareAnalyses.kind, kind),
-      ),
-    )
+  await db
+    .delete(compareAnalyses)
+    .where(and(eq(compareAnalyses.lapAId, lo), eq(compareAnalyses.lapBId, hi), eq(compareAnalyses.kind, kind)))
     .run();
 }

--- a/server/db/experiment-lap-queries.ts
+++ b/server/db/experiment-lap-queries.ts
@@ -3,6 +3,7 @@ import { db } from "./index";
 import { lapMetaProjection, toLapMeta } from "./lap-meta";
 import { sessions, laps, tunes } from "./schema";
 import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import type { LapClassification } from "../../shared/racing/laps/classification";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import type { GameId } from "../../shared/games/ids";
 
@@ -28,19 +29,16 @@ export async function getLapsForExclusionScope(
   experimentId: number,
   tuneId: number,
 ): Promise<
-  {
+  (Pick<LapClassification, "phase" | "conditions" | "paceEligibility"> & {
     id: number;
     lapTime: number;
     isValid: boolean;
-    phase: LapMeta["phase"];
-    conditions: LapMeta["conditions"];
-    paceEligibility: LapMeta["paceEligibility"];
     quality: LapQualitySummary | null;
     eligibility: EligibilityDecisionSet | null;
     invalidReason: string | null;
     experimentExcluded: boolean;
     experimentExcludedSource: "auto" | "manual" | null;
-  }[]
+  })[]
 > {
   const rows = await db
     .select({

--- a/server/db/experiment-lap-queries.ts
+++ b/server/db/experiment-lap-queries.ts
@@ -1,19 +1,13 @@
 import { eq, desc, and, inArray, isNull } from "drizzle-orm";
 import { db } from "./index";
-import { toLapMeta } from "./lap-meta";
+import { lapMetaProjection, toLapMeta } from "./lap-meta";
 import { sessions, laps, tunes } from "./schema";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import type { GameId } from "../../shared/games/ids";
 
-export async function setLapExperimentExcluded(
-  lapId: number,
-  excluded: boolean,
-): Promise<{ ok: boolean; prev: boolean; experimentId: number | null }> {
-  const row = await db
-    .select({ experimentExcluded: laps.experimentExcluded, experimentId: laps.experimentId })
-    .from(laps)
-    .where(eq(laps.id, lapId))
-    .get();
+export async function setLapExperimentExcluded(lapId: number, excluded: boolean): Promise<{ ok: boolean; prev: boolean; experimentId: number | null }> {
+  const row = await db.select({ experimentExcluded: laps.experimentExcluded, experimentId: laps.experimentId }).from(laps).where(eq(laps.id, lapId)).get();
   if (!row) return { ok: false, prev: false, experimentId: null };
   const prev = Boolean(row.experimentExcluded);
   await db
@@ -34,13 +28,30 @@ export async function getLapsForExclusionScope(
   experimentId: number,
   tuneId: number,
 ): Promise<
-  { id: number; lapTime: number; isValid: boolean; invalidReason: string | null; experimentExcluded: boolean; experimentExcludedSource: "auto" | "manual" | null }[]
+  {
+    id: number;
+    lapTime: number;
+    isValid: boolean;
+    phase: LapMeta["phase"];
+    conditions: LapMeta["conditions"];
+    paceEligibility: LapMeta["paceEligibility"];
+    quality: LapQualitySummary | null;
+    eligibility: EligibilityDecisionSet | null;
+    invalidReason: string | null;
+    experimentExcluded: boolean;
+    experimentExcludedSource: "auto" | "manual" | null;
+  }[]
 > {
   const rows = await db
     .select({
       id: laps.id,
       lapTime: laps.lapTime,
       isValid: laps.isValid,
+      phase: laps.phase,
+      conditions: laps.conditions,
+      paceEligibility: laps.paceEligibility,
+      quality: laps.quality,
+      eligibility: laps.eligibility,
       invalidReason: laps.invalidReason,
       experimentExcluded: laps.experimentExcluded,
       experimentExcludedSource: laps.experimentExcludedSource,
@@ -52,6 +63,11 @@ export async function getLapsForExclusionScope(
     id: r.id,
     lapTime: r.lapTime,
     isValid: Boolean(r.isValid),
+    phase: r.phase,
+    conditions: r.conditions,
+    paceEligibility: r.paceEligibility,
+    quality: r.quality,
+    eligibility: r.eligibility,
     invalidReason: r.invalidReason,
     experimentExcluded: Boolean(r.experimentExcluded),
     experimentExcludedSource: (r.experimentExcludedSource as "auto" | "manual" | null) ?? null,
@@ -79,14 +95,8 @@ export async function setLapAutoExclusion(lapId: number, excluded: boolean): Pro
  * docs/architecture/setup-engineer.md §Trigger).
  */
 
-export async function getLapExperimentScope(
-  lapId: number,
-): Promise<{ experimentId: number | null; tuneId: number | null }> {
-  const row = await db
-    .select({ experimentId: laps.experimentId, tuneId: laps.tuneId })
-    .from(laps)
-    .where(eq(laps.id, lapId))
-    .get();
+export async function getLapExperimentScope(lapId: number): Promise<{ experimentId: number | null; tuneId: number | null }> {
+  const row = await db.select({ experimentId: laps.experimentId, tuneId: laps.tuneId }).from(laps).where(eq(laps.id, lapId)).get();
   return { experimentId: row?.experimentId ?? null, tuneId: row?.tuneId ?? null };
 }
 
@@ -96,35 +106,7 @@ export async function getLapExperimentScope(
 
 export async function getLapsForExperiment(experimentId: number): Promise<LapMeta[]> {
   const rows = await db
-    .select({
-      id: laps.id,
-      sessionId: laps.sessionId,
-      lapNumber: laps.lapNumber,
-      lapTime: laps.lapTime,
-      isValid: laps.isValid,
-      phase: laps.phase,
-      conditions: laps.conditions,
-      paceEligibility: laps.paceEligibility,
-      invalidReason: laps.invalidReason,
-      notes: laps.notes,
-      pi: laps.pi,
-      carSetup: laps.carSetup,
-      createdAt: laps.createdAt,
-      carOrdinal: sessions.carOrdinal,
-      trackOrdinal: sessions.trackOrdinal,
-      tuneId: laps.tuneId,
-      tuneName: tunes.name,
-      gameId: sessions.gameId,
-      sectorTimes: laps.sectorTimes,
-      ownership: sessions.ownership,
-      source: sessions.source,
-      experimentId: laps.experimentId,
-      experimentVersionId: laps.experimentVersionId,
-      experimentExcluded: laps.experimentExcluded,
-      experimentExcludedSource: laps.experimentExcludedSource,
-      fuelPerLap: laps.fuelPerLap,
-      tyreWear: laps.tyreWear,
-    })
+    .select(lapMetaProjection)
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
     .leftJoin(tunes, eq(laps.tuneId, tunes.id))
@@ -144,38 +126,7 @@ export async function getLapsForExperiment(experimentId: number): Promise<LapMet
 
 export async function getLapMetaForExperimentVersion(experimentVersionId: number): Promise<LapMeta[]> {
   const rows = await db
-    .select({
-      id: laps.id,
-      sessionId: laps.sessionId,
-      lapNumber: laps.lapNumber,
-      lapTime: laps.lapTime,
-      isValid: laps.isValid,
-      phase: laps.phase,
-      conditions: laps.conditions,
-      paceEligibility: laps.paceEligibility,
-      invalidReason: laps.invalidReason,
-      notes: laps.notes,
-      pi: laps.pi,
-      carSetup: laps.carSetup,
-      createdAt: laps.createdAt,
-      carOrdinal: sessions.carOrdinal,
-      trackOrdinal: sessions.trackOrdinal,
-      tuneId: laps.tuneId,
-      tuneName: tunes.name,
-      gameId: sessions.gameId,
-      ownership: sessions.ownership,
-      sectorTimes: laps.sectorTimes,
-      source: sessions.source,
-      experimentId: laps.experimentId,
-      experimentVersionId: laps.experimentVersionId,
-      experimentExcluded: laps.experimentExcluded,
-      experimentExcludedSource: laps.experimentExcludedSource,
-      fuelPerLap: laps.fuelPerLap,
-      tyreWear: laps.tyreWear,
-      // Frame count only — never the frames. Lets the arm-comparison loader size
-      // its decode budget from metadata (server/experiments/comparison/stream.ts).
-      rawFrameCount: laps.rawFrameCount,
-    })
+    .select(lapMetaProjection)
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
     .leftJoin(tunes, eq(laps.tuneId, tunes.id))
@@ -196,45 +147,13 @@ export async function getLapMetaForExperimentVersion(experimentVersionId: number
  * rather than excluding everything. Newest-first, same shape as getLapsForExperiment.
  */
 
-export async function getImportableLapsForExperiment(
-  gameId: GameId,
-  carOrdinal: number | null,
-  trackOrdinal: number | null,
-): Promise<LapMeta[]> {
+export async function getImportableLapsForExperiment(gameId: GameId, carOrdinal: number | null, trackOrdinal: number | null): Promise<LapMeta[]> {
   const conds = [eq(sessions.gameId, gameId), isNull(laps.experimentId)];
   if (carOrdinal != null) conds.push(eq(sessions.carOrdinal, carOrdinal));
   if (trackOrdinal != null) conds.push(eq(sessions.trackOrdinal, trackOrdinal));
 
   const rows = await db
-    .select({
-      id: laps.id,
-      sessionId: laps.sessionId,
-      lapNumber: laps.lapNumber,
-      lapTime: laps.lapTime,
-      isValid: laps.isValid,
-      phase: laps.phase,
-      conditions: laps.conditions,
-      paceEligibility: laps.paceEligibility,
-      invalidReason: laps.invalidReason,
-      notes: laps.notes,
-      pi: laps.pi,
-      carSetup: laps.carSetup,
-      createdAt: laps.createdAt,
-      carOrdinal: sessions.carOrdinal,
-      trackOrdinal: sessions.trackOrdinal,
-      tuneId: laps.tuneId,
-      tuneName: tunes.name,
-      gameId: sessions.gameId,
-      ownership: sessions.ownership,
-      sectorTimes: laps.sectorTimes,
-      source: sessions.source,
-      experimentId: laps.experimentId,
-      experimentVersionId: laps.experimentVersionId,
-      experimentExcluded: laps.experimentExcluded,
-      experimentExcludedSource: laps.experimentExcludedSource,
-      fuelPerLap: laps.fuelPerLap,
-      tyreWear: laps.tyreWear,
-    })
+    .select(lapMetaProjection)
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
     .leftJoin(tunes, eq(laps.tuneId, tunes.id))
@@ -253,11 +172,7 @@ export async function getImportableLapsForExperiment(
  * actually updated.
  */
 
-export async function importLapsToExperiment(
-  experimentId: number,
-  lapIds: number[],
-  experimentVersionId: number | null,
-): Promise<number[]> {
+export async function importLapsToExperiment(experimentId: number, lapIds: number[], experimentVersionId: number | null): Promise<number[]> {
   if (lapIds.length === 0) return [];
   const result = await db
     .update(laps)

--- a/server/db/experiment-version-queries.ts
+++ b/server/db/experiment-version-queries.ts
@@ -3,6 +3,7 @@ import { db } from "./index";
 import { laps, experiments, experimentVersions } from "./schema";
 import { setSessionHead } from "./experiment-queries";
 import { DEFAULT_EXPERIMENT_FOCUS, type ExperimentFocus, versionKindForFocus, type VersionKind } from "../../shared/racing/experiments/focus";
+import { selectEvaluationLaps } from "../../shared/racing/laps/review-selection";
 
 interface CreateExperimentVersionData {
   experimentId: number;
@@ -30,11 +31,7 @@ export async function createExperimentVersion(data: CreateExperimentVersionData)
   // setup versions already recorded into drills.
   let kind = data.kind;
   if (!kind) {
-    const parent = await db
-      .select({ focus: experiments.focus })
-      .from(experiments)
-      .where(eq(experiments.id, data.experimentId))
-      .get();
+    const parent = await db.select({ focus: experiments.focus }).from(experiments).where(eq(experiments.id, data.experimentId)).get();
     kind = versionKindForFocus((parent?.focus as ExperimentFocus | undefined) ?? DEFAULT_EXPERIMENT_FOCUS);
   }
 
@@ -77,10 +74,7 @@ export async function listExperimentVersions(sessionId: number, opts: { includeD
 /** Walk `parentVersionId` children transitively from `rootId` (inclusive) over an
  *  already-fetched test list — pure/pure-ish helper shared by delete/restore
  *  so the subtree definition can't drift between the two ops. */
-function collectSubtreeIds(
-  tests: { id: number; parentVersionId: number | null }[],
-  rootId: number,
-): number[] {
+function collectSubtreeIds(tests: { id: number; parentVersionId: number | null }[], rootId: number): number[] {
   const childrenOf = new Map<number, number[]>();
   for (const t of tests) {
     if (t.parentVersionId == null) continue;
@@ -105,11 +99,7 @@ function collectSubtreeIds(
  *  `status='deleted'` — where a trashed head gets moved to. `null` when no
  *  surviving ancestor exists (falls back to the mainline tip via
  *  `resolveActiveTestId`). */
-function findNearestSurvivingAncestor(
-  tests: { id: number; parentVersionId: number | null; status: string }[],
-  fromId: number,
-  trashedIds: Set<number>,
-): number | null {
+function findNearestSurvivingAncestor(tests: { id: number; parentVersionId: number | null; status: string }[], fromId: number, trashedIds: Set<number>): number | null {
   const byId = new Map(tests.map((t) => [t.id, t]));
   let cur = byId.get(fromId);
   while (cur?.parentVersionId != null) {
@@ -142,11 +132,7 @@ interface DeleteSubtreeResult {
  * inside the trashed subtree, the session head is moved off it to the
  * nearest surviving ancestor (or cleared, falling back to the mainline tip).
  */
-export async function deleteTestSubtree(
-  sessionId: number,
-  versionId: number,
-  currentHeadTestId: number | null,
-): Promise<DeleteSubtreeResult> {
+export async function deleteTestSubtree(sessionId: number, versionId: number, currentHeadTestId: number | null): Promise<DeleteSubtreeResult> {
   const allTests = await listExperimentVersions(sessionId, { includeDeleted: true });
   const deletedIds = collectSubtreeIds(allTests, versionId);
   await setTestsStatus(deletedIds, "deleted");
@@ -236,11 +222,7 @@ export async function nextVersion(sessionId: number): Promise<number> {
  * null when the session has no tests yet.
  */
 export async function resolveActiveTestId(sessionId: number): Promise<number | null> {
-  const session = await db
-    .select({ headVersionId: experiments.headVersionId })
-    .from(experiments)
-    .where(eq(experiments.id, sessionId))
-    .get();
+  const session = await db.select({ headVersionId: experiments.headVersionId }).from(experiments).where(eq(experiments.id, sessionId)).get();
   if (session?.headVersionId != null) return session.headVersionId;
 
   const tip = await db
@@ -252,25 +234,46 @@ export async function resolveActiveTestId(sessionId: number): Promise<number | n
   return tip?.id ?? null;
 }
 
-/** Lap count + best (min positive) lap time per experiment_version_id for a session. */
-export async function getLapCountsByTest(
-  sessionId: number,
-): Promise<Map<number, { lapCount: number; bestLapMs: number | null }>> {
+/** Recorded-lap count plus best pace-eligible lap time per experiment version. */
+export async function getLapCountsByTest(sessionId: number): Promise<Map<number, { lapCount: number; bestLapMs: number | null }>> {
   const rows = await db
     .select({
+      id: laps.id,
       versionId: laps.experimentVersionId,
-      lapCount: sql<number>`COUNT(*)`,
-      bestLapMs: sql<number | null>`MIN(CASE WHEN ${laps.lapTime} > 0 THEN ${laps.lapTime} END)`,
+      lapTime: laps.lapTime,
+      isValid: laps.isValid,
+      quality: laps.quality,
+      eligibility: laps.eligibility,
+      experimentExcluded: laps.experimentExcluded,
+      experimentExcludedSource: laps.experimentExcludedSource,
     })
     .from(laps)
     .where(eq(laps.experimentId, sessionId))
-    .groupBy(laps.experimentVersionId)
     .all();
 
-  const map = new Map<number, { lapCount: number; bestLapMs: number | null }>();
-  for (const r of rows) {
-    if (r.versionId == null) continue;
-    map.set(r.versionId, { lapCount: Number(r.lapCount), bestLapMs: r.bestLapMs ?? null });
+  const grouped = new Map<number, typeof rows>();
+  for (const row of rows) {
+    if (row.versionId == null) continue;
+    const existing = grouped.get(row.versionId);
+    if (existing) existing.push(row);
+    else grouped.set(row.versionId, [row]);
   }
-  return map;
+
+  const result = new Map<number, { lapCount: number; bestLapMs: number | null }>();
+  for (const [versionId, versionLaps] of grouped) {
+    const selection = selectEvaluationLaps(
+      versionLaps.map((lap) => ({
+        ...lap,
+        experimentExcluded: lap.experimentExcluded === 1,
+        experimentExcludedSource: lap.experimentExcludedSource === "auto" || lap.experimentExcludedSource === "manual" ? lap.experimentExcludedSource : null,
+      })),
+      Number.POSITIVE_INFINITY,
+    );
+    const usableLapTimes = selection.chosen.map(({ lapTime }) => lapTime);
+    result.set(versionId, {
+      lapCount: versionLaps.length,
+      bestLapMs: usableLapTimes.length > 0 ? Math.min(...usableLapTimes) : null,
+    });
+  }
+  return result;
 }

--- a/server/db/lap-eligibility.ts
+++ b/server/db/lap-eligibility.ts
@@ -1,0 +1,37 @@
+import { inArray, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityPolicyId,
+  type EligibilityStatus,
+} from "../../shared/racing/quality/contracts";
+
+export const USABLE_ELIGIBILITY_STATUSES = ["eligible", "eligible_with_warning"] as const satisfies readonly EligibilityStatus[];
+type PersistedQualitySnapshotColumns = {
+  quality: AnySQLiteColumn;
+  qualitySchemaVersion: AnySQLiteColumn;
+  qualityPolicyVersion: AnySQLiteColumn;
+  qualityConfigVersion: AnySQLiteColumn;
+  qualityGeneration: AnySQLiteColumn;
+};
+
+/** Require persisted quality columns and JSON provenance to describe one current snapshot. */
+export function currentQualitySnapshot(table: PersistedQualitySnapshotColumns): SQL {
+  return sql`(
+    ${table.qualitySchemaVersion} = ${QUALITY_SCHEMA_VERSION}
+    AND ${table.qualityPolicyVersion} = ${ELIGIBILITY_POLICY_VERSION}
+    AND ${table.qualityConfigVersion} = ${QUALITY_CONFIG_VERSION}
+    AND json_extract(${table.quality}, '$.provenance.schemaVersion') = ${QUALITY_SCHEMA_VERSION}
+    AND json_extract(${table.quality}, '$.provenance.policyVersion') = ${ELIGIBILITY_POLICY_VERSION}
+    AND json_extract(${table.quality}, '$.provenance.configurationVersion') = ${QUALITY_CONFIG_VERSION}
+    AND ${table.qualityGeneration} = json_extract(${table.quality}, '$.provenance.outputGeneration')
+  )`;
+}
+
+/** Read one persisted policy decision. Policy rules never live in SQL. */
+export function analysisEligibility(table: { eligibility: AnySQLiteColumn }, policyId: EligibilityPolicyId, acceptedStatuses: readonly EligibilityStatus[] = USABLE_ELIGIBILITY_STATUSES): SQL {
+  return inArray(sql<string>`json_extract(${table.eligibility}, ${`$."${policyId}".status`})`, [...acceptedStatuses]);
+}

--- a/server/db/lap-meta.ts
+++ b/server/db/lap-meta.ts
@@ -1,7 +1,59 @@
+import { laps, sessions, tunes } from "./schema";
+
 import type { GameId } from "../../shared/games/ids";
 import type { LapCondition, LapPhase, PaceEligibility } from "../../shared/racing/laps/classification";
 import type { LapMeta } from "../../shared/racing/sessions/types";
-import type { EvidenceSourceKind } from "../../shared/racing/quality/contracts";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecisionSet,
+  type EvidenceSourceKind,
+  type LapQualitySummary,
+} from "../../shared/racing/quality/contracts";
+
+export const lapMetaProjection = {
+  id: laps.id,
+  sessionId: laps.sessionId,
+  lapNumber: laps.lapNumber,
+  lapTime: laps.lapTime,
+  isValid: laps.isValid,
+  phase: laps.phase,
+  conditions: laps.conditions,
+  paceEligibility: laps.paceEligibility,
+  invalidReason: laps.invalidReason,
+  notes: laps.notes,
+  pi: laps.pi,
+  carSetup: laps.carSetup,
+  createdAt: laps.createdAt,
+  carOrdinal: sessions.carOrdinal,
+  trackOrdinal: sessions.trackOrdinal,
+  tuneId: laps.tuneId,
+  tuneName: tunes.name,
+  gameId: sessions.gameId,
+  sectorTimes: laps.sectorTimes,
+  source: sessions.source,
+  ownership: sessions.ownership,
+  experimentId: laps.experimentId,
+  experimentVersionId: laps.experimentVersionId,
+  experimentExcluded: laps.experimentExcluded,
+  experimentExcludedSource: laps.experimentExcludedSource,
+  fuelPerLap: laps.fuelPerLap,
+  tyreWear: laps.tyreWear,
+  catalogVersion: laps.catalogVersion,
+  catalogHash: laps.catalogHash,
+  catalogSchemaVersion: laps.catalogSchemaVersion,
+  parserVersion: laps.parserVersion,
+  resolverVersion: laps.resolverVersion,
+  derivationVersion: laps.derivationVersion,
+  rawFrameCount: laps.rawFrameCount,
+  quality: laps.quality,
+  eligibility: laps.eligibility,
+  qualitySchemaVersion: laps.qualitySchemaVersion,
+  qualityPolicyVersion: laps.qualityPolicyVersion,
+  qualityConfigVersion: laps.qualityConfigVersion,
+  qualityGeneration: laps.qualityGeneration,
+};
 
 type StoredLapMetaRow = {
   id: number;
@@ -30,14 +82,20 @@ type StoredLapMetaRow = {
   experimentExcludedSource: string | null;
   fuelPerLap: number | null;
   tyreWear: number | null;
-  catalogVersion?: string | null;
-  catalogHash?: string | null;
-  catalogSchemaVersion?: string | null;
-  parserVersion?: string | null;
-  resolverVersion?: string | null;
-  derivationVersion?: string | null;
-  rawFrameCount?: number | null;
-  ownership?: string | null;
+  catalogVersion: string | null;
+  catalogHash: string | null;
+  catalogSchemaVersion: string | null;
+  parserVersion: string | null;
+  resolverVersion: string | null;
+  derivationVersion: string | null;
+  rawFrameCount: number | null;
+  ownership: string | null;
+  quality: LapQualitySummary | null;
+  eligibility: EligibilityDecisionSet | null;
+  qualitySchemaVersion: string | null;
+  qualityPolicyVersion: string | null;
+  qualityConfigVersion: string | null;
+  qualityGeneration: string | null;
 };
 
 /** Normalize nullable SQLite fields into the public LapMeta representation. */
@@ -70,22 +128,14 @@ export function toLapMeta(row: StoredLapMetaRow): LapMeta {
     derivationVersion,
     ownership,
     rawFrameCount,
+    quality,
+    eligibility,
+    qualitySchemaVersion,
+    qualityPolicyVersion,
+    qualityConfigVersion,
+    qualityGeneration,
     ...base
   } = row;
-
-  const versionIdentity = "catalogVersion" in row
-    ? {
-        catalogVersion: catalogVersion ?? undefined,
-        catalogHash: catalogHash ?? undefined,
-        catalogSchemaVersion: catalogSchemaVersion ?? undefined,
-        parserVersion: parserVersion ?? undefined,
-        resolverVersion: resolverVersion ?? undefined,
-        derivationVersion: derivationVersion ?? undefined,
-      }
-    : {};
-  const frameCount = "rawFrameCount" in row
-    ? { rawFrameCount: rawFrameCount ?? null }
-    : {};
 
   return {
     ...base,
@@ -108,11 +158,25 @@ export function toLapMeta(row: StoredLapMetaRow): LapMeta {
     experimentExcluded: Boolean(experimentExcluded),
     // Manual provenance must travel with the flag or review selection can
     // incorrectly rank an excluded lap back into the fastest-N pool.
-    experimentExcludedSource:
-      (experimentExcludedSource as "auto" | "manual" | null) ?? null,
+    experimentExcludedSource: (experimentExcludedSource as "auto" | "manual" | null) ?? null,
     fuelPerLap: fuelPerLap ?? null,
     tyreWear: tyreWear ?? null,
-    ...versionIdentity,
-    ...frameCount,
+    catalogVersion: catalogVersion ?? undefined,
+    catalogHash: catalogHash ?? undefined,
+    catalogSchemaVersion: catalogSchemaVersion ?? undefined,
+    parserVersion: parserVersion ?? undefined,
+    resolverVersion: resolverVersion ?? undefined,
+    derivationVersion: derivationVersion ?? undefined,
+    rawFrameCount: rawFrameCount ?? null,
+    quality: quality ?? undefined,
+    eligibility: eligibility ?? undefined,
+    qualityGeneration: qualityGeneration ?? undefined,
+    qualityStale:
+      !quality ||
+      !eligibility ||
+      qualitySchemaVersion !== QUALITY_SCHEMA_VERSION ||
+      qualityPolicyVersion !== ELIGIBILITY_POLICY_VERSION ||
+      qualityConfigVersion !== QUALITY_CONFIG_VERSION ||
+      qualityGeneration !== quality.provenance.outputGeneration,
   };
 }

--- a/server/db/lap-mutation-queries.ts
+++ b/server/db/lap-mutation-queries.ts
@@ -2,15 +2,15 @@ import { cacheDelete } from "./telemetry-replay-storage";
 import { eq } from "drizzle-orm";
 import { db } from "./index";
 import { sessions, laps } from "./schema";
-import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
 import type { LapClassification } from "../../shared/racing/laps/classification";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
 import { getActiveExperiment } from "../experiments/active";
 import { resolveActiveTestId } from "./experiment-version-queries";
 
 export async function updateLapNotes(id: number, notes: string | null): Promise<void> {
   await db.update(laps).set({ notes }).where(eq(laps.id, id)).run();
 }
-
 
 export async function updateLapValidity(id: number, isValid: boolean, invalidReason: string | null, sectors?: number[] | null): Promise<void> {
   const values: Record<string, unknown> = { isValid, invalidReason };
@@ -33,45 +33,32 @@ export async function updateLapValidity(id: number, isValid: boolean, invalidRea
  * the fastest-5 rule silently re-excluding it on the next lap save.
  */
 
-export function insertLap(
-  sessionId: number,
-  lapNumber: number,
-  lapTime: number,
-  isValid: boolean,
-  rawByteOffset: number | null,
-  rawFrameCount: number,
-  profileId: number | null = null,
-  tuneId: number | null = null,
-  invalidReason: string | null = null,
-  sectors: number[] | null = null,
-  versionIdentity?: TelemetryVersionIdentity,
-  classification?: LapClassification,
-): Promise<number> {
-  return doInsertLap(sessionId, lapNumber, lapTime, isValid, rawByteOffset, rawFrameCount, profileId, tuneId, invalidReason, sectors, versionIdentity, classification);
+export interface PersistLapInput {
+  sessionId: number;
+  lapNumber: number;
+  lapTime: number;
+  isValid: boolean;
+  rawByteOffset: number | null;
+  rawFrameCount: number;
+  profileId: number | null;
+  tuneId: number | null;
+  invalidReason: string | null;
+  sectors: number[] | null;
+  classification: LapClassification;
+  quality: LapQualitySummary | null;
+  eligibility: EligibilityDecisionSet | null;
+  versionIdentity?: TelemetryVersionIdentity;
 }
 
-async function doInsertLap(
-  sessionId: number,
-  lapNumber: number,
-  lapTime: number,
-  isValid: boolean,
-  rawByteOffset: number | null,
-  rawFrameCount: number,
-  profileId: number | null,
-  tuneId: number | null,
-  invalidReason: string | null,
-  sectors: number[] | null = null,
-  versionIdentity?: TelemetryVersionIdentity,
-  classification?: LapClassification,
-): Promise<number> {
+export async function insertLap(input: PersistLapInput): Promise<number> {
+  const { sessionId, lapNumber, lapTime, isValid, rawByteOffset, rawFrameCount, profileId, tuneId, invalidReason, sectors, classification, quality, eligibility, versionIdentity } = input;
   // Stamp the lap with the active tuning session (if any). This is the single
   // choke point every live lap-detector funnels through (via the DbAdapter), so
   // reading the in-memory active id here links laps to a tuning session
   // independent of race sessionId — a tuning session can span many race
   // sessions. Cheap, unconditional on game; null when no session is active.
   const activeExperimentId = getActiveExperiment();
-  const activeExperimentVersionId =
-    activeExperimentId != null ? await resolveActiveTestId(activeExperimentId) : null;
+  const activeExperimentVersionId = activeExperimentId != null ? await resolveActiveTestId(activeExperimentId) : null;
   const result = await db
     .insert(laps)
     .values({
@@ -86,6 +73,12 @@ async function doInsertLap(
       tuneId,
       invalidReason,
       ...classification,
+      quality,
+      eligibility,
+      qualitySchemaVersion: quality?.provenance.schemaVersion ?? null,
+      qualityPolicyVersion: quality?.provenance.policyVersion ?? null,
+      qualityConfigVersion: quality?.provenance.configurationVersion ?? null,
+      qualityGeneration: quality?.provenance.outputGeneration ?? null,
       experimentId: activeExperimentId,
       experimentVersionId: activeExperimentVersionId,
       ...versionIdentity,
@@ -110,7 +103,6 @@ async function doInsertLap(
 export async function setLapMetrics(lapId: number, fuelPerLap: number | null, tyreWear: number | null): Promise<void> {
   await db.update(laps).set({ fuelPerLap, tyreWear }).where(eq(laps.id, lapId)).run();
 }
-
 
 export async function deleteLap(id: number): Promise<boolean> {
   // Get session ID before deleting

--- a/server/db/lap-read-queries.ts
+++ b/server/db/lap-read-queries.ts
@@ -1,12 +1,12 @@
 import { cacheGet, cacheSet, LapParseError, parseRawLapFrames, parseSessionLapsBatched } from "./telemetry-replay-storage";
-import { toLapMeta } from "./lap-meta";
+import { lapMetaProjection, toLapMeta } from "./lap-meta";
 import { eq, desc, and, or, sql, inArray } from "drizzle-orm";
 import { db } from "./index";
 import { sessions, laps, tunes } from "./schema";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import type { GameId } from "../../shared/games/ids";
-import type { LapCondition, LapPhase, PaceEligibility } from "../../shared/racing/laps/classification";
+import { ELIGIBILITY_POLICY_VERSION, QUALITY_CONFIG_VERSION, QUALITY_SCHEMA_VERSION } from "../../shared/racing/quality/contracts";
 
 interface LapStats {
   totalLaps: number;
@@ -16,7 +16,6 @@ interface LapStats {
   uniqueTracks: number;
   lapsByTrack: { trackOrdinal: number; count: number }[];
 }
-
 
 export async function getLapStats(gameId?: GameId): Promise<LapStats> {
   const owned = sql`COALESCE(sessions.ownership, 'mine') != 'others'`;
@@ -68,51 +67,9 @@ export async function getLapStats(gameId?: GameId): Promise<LapStats> {
  */
 
 export async function getLaps(gameId?: GameId, limit: number = 200): Promise<LapMeta[]> {
-  const query = db
-    .select({
-      id: laps.id,
-      sessionId: laps.sessionId,
-      lapNumber: laps.lapNumber,
-      lapTime: laps.lapTime,
-      isValid: laps.isValid,
-      phase: laps.phase,
-      conditions: laps.conditions,
-      paceEligibility: laps.paceEligibility,
-      invalidReason: laps.invalidReason,
-      notes: laps.notes,
-      pi: laps.pi,
-      carSetup: laps.carSetup,
-      createdAt: laps.createdAt,
-      carOrdinal: sessions.carOrdinal,
-      trackOrdinal: sessions.trackOrdinal,
-      tuneId: laps.tuneId,
-      tuneName: tunes.name,
-      gameId: sessions.gameId,
-      sectorTimes: laps.sectorTimes,
-      ownership: sessions.ownership,
-      source: sessions.source,
-      experimentId: laps.experimentId,
-      experimentVersionId: laps.experimentVersionId,
-      experimentExcluded: laps.experimentExcluded,
-      experimentExcludedSource: laps.experimentExcludedSource,
-      fuelPerLap: laps.fuelPerLap,
-      tyreWear: laps.tyreWear,
-      catalogVersion: laps.catalogVersion,
-      catalogHash: laps.catalogHash,
-      catalogSchemaVersion: laps.catalogSchemaVersion,
-      parserVersion: laps.parserVersion,
-      resolverVersion: laps.resolverVersion,
-      derivationVersion: laps.derivationVersion,
-    })
-    .from(laps)
-    .innerJoin(sessions, eq(laps.sessionId, sessions.id))
-    .leftJoin(tunes, eq(laps.tuneId, tunes.id))
-    .orderBy(desc(laps.id))
-    .limit(limit);
+  const query = db.select(lapMetaProjection).from(laps).innerJoin(sessions, eq(laps.sessionId, sessions.id)).leftJoin(tunes, eq(laps.tuneId, tunes.id)).orderBy(desc(laps.id)).limit(limit);
 
-  const rows = gameId
-    ? await query.where(eq(sessions.gameId, gameId)).all()
-    : await query.all();
+  const rows = gameId ? await query.where(eq(sessions.gameId, gameId)).all() : await query.all();
 
   return rows.map(toLapMeta);
 }
@@ -133,35 +90,7 @@ export async function getLapMetaForProfileScope(gameId: GameId, carOrdinal?: num
   if (trackOrdinal != null) filters.push(eq(sessions.trackOrdinal, trackOrdinal));
 
   const rows = await db
-    .select({
-      id: laps.id,
-      sessionId: laps.sessionId,
-      lapNumber: laps.lapNumber,
-      lapTime: laps.lapTime,
-      isValid: laps.isValid,
-      phase: laps.phase,
-      conditions: laps.conditions,
-      paceEligibility: laps.paceEligibility,
-      invalidReason: laps.invalidReason,
-      notes: laps.notes,
-      pi: laps.pi,
-      carSetup: laps.carSetup,
-      createdAt: laps.createdAt,
-      carOrdinal: sessions.carOrdinal,
-      trackOrdinal: sessions.trackOrdinal,
-      tuneId: laps.tuneId,
-      tuneName: tunes.name,
-      gameId: sessions.gameId,
-      sectorTimes: laps.sectorTimes,
-      ownership: sessions.ownership,
-      source: sessions.source,
-      experimentId: laps.experimentId,
-      experimentVersionId: laps.experimentVersionId,
-      experimentExcluded: laps.experimentExcluded,
-      experimentExcludedSource: laps.experimentExcludedSource,
-      fuelPerLap: laps.fuelPerLap,
-      tyreWear: laps.tyreWear,
-    })
+    .select(lapMetaProjection)
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
     .leftJoin(tunes, eq(laps.tuneId, tunes.id))
@@ -195,13 +124,17 @@ type LapSummary = {
   createdAt: string;
   sectorTimes: number[] | null;
   isValid: boolean;
-  phase: LapPhase;
-  conditions: LapCondition[];
-  paceEligibility: PaceEligibility;
+  phase: LapMeta["phase"];
+  conditions: LapMeta["conditions"];
+  paceEligibility: LapMeta["paceEligibility"];
+  eligibility: LapMeta["eligibility"] | null;
   invalidReason: string | null;
   notes: string | null;
+  quality: LapMeta["quality"] | null;
+  qualityGeneration: string | null;
+  qualityStale: boolean;
+  source: LapMeta["source"];
 };
-
 
 export async function getLapSummariesByTrack(trackOrdinal: number, gameId?: GameId): Promise<LapSummary[]> {
   const query = db
@@ -219,22 +152,25 @@ export async function getLapSummariesByTrack(trackOrdinal: number, gameId?: Game
       phase: laps.phase,
       conditions: laps.conditions,
       paceEligibility: laps.paceEligibility,
+      eligibility: laps.eligibility,
       invalidReason: laps.invalidReason,
       notes: laps.notes,
+      quality: laps.quality,
+      qualityGeneration: laps.qualityGeneration,
+      qualitySchemaVersion: laps.qualitySchemaVersion,
+      qualityPolicyVersion: laps.qualityPolicyVersion,
+      qualityConfigVersion: laps.qualityConfigVersion,
+      source: sessions.source,
     })
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
-    .where(
-      gameId
-        ? and(eq(sessions.trackOrdinal, trackOrdinal), eq(sessions.gameId, gameId))
-        : eq(sessions.trackOrdinal, trackOrdinal)
-    )
+    .where(gameId ? and(eq(sessions.trackOrdinal, trackOrdinal), eq(sessions.gameId, gameId)) : eq(sessions.trackOrdinal, trackOrdinal))
     .orderBy(desc(laps.id));
 
   const rows = await query.all();
   return rows
-    .filter(r => (r.lapTime ?? 0) > 0)
-    .map(r => ({
+    .filter((r) => (r.lapTime ?? 0) > 0)
+    .map((r) => ({
       lapId: r.lapId,
       lapNumber: r.lapNumber ?? 0,
       lapTime: r.lapTime,
@@ -248,14 +184,23 @@ export async function getLapSummariesByTrack(trackOrdinal: number, gameId?: Game
       phase: r.phase,
       conditions: r.conditions,
       paceEligibility: r.paceEligibility,
+      eligibility: r.eligibility ?? null,
       invalidReason: r.invalidReason ?? null,
       notes: r.notes ?? null,
+      quality: r.quality ?? null,
+      qualityGeneration: r.qualityGeneration ?? null,
+      qualityStale:
+        !r.quality ||
+        !r.eligibility ||
+        r.qualitySchemaVersion !== QUALITY_SCHEMA_VERSION ||
+        r.qualityPolicyVersion !== ELIGIBILITY_POLICY_VERSION ||
+        r.qualityConfigVersion !== QUALITY_CONFIG_VERSION ||
+        r.qualityGeneration !== r.quality.provenance.outputGeneration,
+      source: (r.source as LapMeta["source"] | null) ?? "unknown",
     }));
 }
 
-export async function getLapById(
-  id: number
-): Promise<(LapMeta & { telemetry: TelemetryPacket[]; parseError?: string }) | null> {
+export async function getLapById(id: number): Promise<(LapMeta & { telemetry: TelemetryPacket[]; parseError?: string }) | null> {
   const row = await db
     .select({
       id: laps.id,
@@ -284,6 +229,13 @@ export async function getLapById(
       parserVersion: laps.parserVersion,
       resolverVersion: laps.resolverVersion,
       derivationVersion: laps.derivationVersion,
+      source: sessions.source,
+      quality: laps.quality,
+      eligibility: laps.eligibility,
+      qualitySchemaVersion: laps.qualitySchemaVersion,
+      qualityPolicyVersion: laps.qualityPolicyVersion,
+      qualityConfigVersion: laps.qualityConfigVersion,
+      qualityGeneration: laps.qualityGeneration,
     })
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
@@ -302,18 +254,10 @@ export async function getLapById(
   const rawFile = row.rawFile;
   const rawByteOffset = row.rawByteOffset;
   const rawFrameCount = row.rawFrameCount;
-  const shouldParseRaw =
-    rawFile != null &&
-    rawByteOffset != null &&
-    rawFrameCount != null;
+  const shouldParseRaw = rawFile != null && rawByteOffset != null && rawFrameCount != null;
   if (shouldParseRaw) {
     try {
-      telemetry = await parseRawLapFrames(
-        rawFile,
-        rawByteOffset,
-        rawFrameCount,
-        row.gameId as GameId,
-      );
+      telemetry = await parseRawLapFrames(rawFile, rawByteOffset, rawFrameCount, row.gameId as GameId);
     } catch (err) {
       if (err instanceof LapParseError) {
         console.error(`[DB] Lap ${id} parse failed (${err.details.reason}): ${err.message}`, err.details);
@@ -339,9 +283,9 @@ type LapResultRow = {
   lapNumber: number;
   lapTime: number;
   isValid: number | boolean;
-  phase: LapPhase;
-  conditions: LapCondition[];
-  paceEligibility: PaceEligibility;
+  phase: LapMeta["phase"];
+  conditions: LapMeta["conditions"];
+  paceEligibility: LapMeta["paceEligibility"];
   createdAt: string;
   carOrdinal: number;
   trackOrdinal: number;
@@ -358,12 +302,16 @@ type LapResultRow = {
   resolverVersion: string | null;
   derivationVersion: string | null;
   rawFile?: string | null;
+  source: string | null;
+  quality: LapMeta["quality"] | null;
+  eligibility: LapMeta["eligibility"] | null;
+  qualitySchemaVersion: string | null;
+  qualityPolicyVersion: string | null;
+  qualityConfigVersion: string | null;
+  qualityGeneration: string | null;
 };
 
-function buildLapResult(
-  row: LapResultRow,
-  telemetry: TelemetryPacket[]
-): LapMeta & { telemetry: TelemetryPacket[] } {
+function buildLapResult(row: LapResultRow, telemetry: TelemetryPacket[]): LapMeta & { telemetry: TelemetryPacket[] } {
   return {
     id: row.id,
     sessionId: row.sessionId,
@@ -388,10 +336,20 @@ function buildLapResult(
     parserVersion: row.parserVersion ?? undefined,
     resolverVersion: row.resolverVersion ?? undefined,
     derivationVersion: row.derivationVersion ?? undefined,
+    source: (row.source as LapMeta["source"] | null) ?? "unknown",
+    quality: row.quality ?? undefined,
+    eligibility: row.eligibility ?? undefined,
+    qualityGeneration: row.qualityGeneration ?? undefined,
+    qualityStale:
+      !row.quality ||
+      !row.eligibility ||
+      row.qualitySchemaVersion !== QUALITY_SCHEMA_VERSION ||
+      row.qualityPolicyVersion !== ELIGIBILITY_POLICY_VERSION ||
+      row.qualityConfigVersion !== QUALITY_CONFIG_VERSION ||
+      row.qualityGeneration !== row.quality.provenance.outputGeneration,
     telemetry,
   };
 }
-
 
 /**
  * Load several laps' telemetry at once, decoding each session's laps in a single
@@ -402,9 +360,7 @@ function buildLapResult(
  * order. Laps the batch pass can't resolve fall back to getLapById.
  */
 
-export async function getLapsByIds(
-  ids: number[]
-): Promise<(LapMeta & { telemetry: TelemetryPacket[]; parseError?: string })[]> {
+export async function getLapsByIds(ids: number[]): Promise<(LapMeta & { telemetry: TelemetryPacket[]; parseError?: string })[]> {
   if (ids.length === 0) return [];
 
   const rows = await db
@@ -435,6 +391,13 @@ export async function getLapsByIds(
       parserVersion: laps.parserVersion,
       resolverVersion: laps.resolverVersion,
       derivationVersion: laps.derivationVersion,
+      source: sessions.source,
+      quality: laps.quality,
+      eligibility: laps.eligibility,
+      qualitySchemaVersion: laps.qualitySchemaVersion,
+      qualityPolicyVersion: laps.qualityPolicyVersion,
+      qualityConfigVersion: laps.qualityConfigVersion,
+      qualityGeneration: laps.qualityGeneration,
     })
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id))
@@ -519,6 +482,10 @@ export async function getLapsRaw(ids?: number[]) {
       parserVersion: laps.parserVersion,
       resolverVersion: laps.resolverVersion,
       derivationVersion: laps.derivationVersion,
+      source: sessions.source,
+      sourceChannelProfile: sessions.sourceChannelProfile,
+      recordingQuality: sessions.recordingQuality,
+      recordingQualitySchemaVersion: sessions.qualitySchemaVersion,
     })
     .from(laps)
     .innerJoin(sessions, eq(laps.sessionId, sessions.id));

--- a/server/db/lap-reprocessing-queries.ts
+++ b/server/db/lap-reprocessing-queries.ts
@@ -4,15 +4,27 @@ import { db } from "./index";
 import { laps } from "./schema";
 import type { LapClassification } from "../../shared/racing/laps/classification";
 import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
 
-export async function getLapsForSession(sessionId: number): Promise<Array<{
-  id: number; lapNumber: number; lapTime: number; isValid: boolean;
-  phase: LapClassification["phase"]; conditions: LapClassification["conditions"];
-  paceEligibility: LapClassification["paceEligibility"];
-  notes: string | null; tuneId: number | null;
-  rawByteOffset: number | null; rawFrameCount: number | null;
-  sectorTimes: number[] | null;
-}>> {
+export async function getLapsForSession(sessionId: number): Promise<
+  Array<{
+    id: number;
+    lapNumber: number;
+    lapTime: number;
+    isValid: boolean;
+    phase: LapClassification["phase"];
+    conditions: LapClassification["conditions"];
+    paceEligibility: LapClassification["paceEligibility"];
+    notes: string | null;
+    tuneId: number | null;
+    rawByteOffset: number | null;
+    rawFrameCount: number | null;
+    sectorTimes: number[] | null;
+    quality: LapQualitySummary | null;
+    eligibility: EligibilityDecisionSet | null;
+    qualityGeneration: string | null;
+  }>
+> {
   const rows = await db
     .select({
       id: laps.id,
@@ -27,95 +39,112 @@ export async function getLapsForSession(sessionId: number): Promise<Array<{
       rawByteOffset: laps.rawByteOffset,
       rawFrameCount: laps.rawFrameCount,
       sectorTimes: laps.sectorTimes,
+      quality: laps.quality,
+      eligibility: laps.eligibility,
+      qualityGeneration: laps.qualityGeneration,
     })
     .from(laps)
     .where(eq(laps.sessionId, sessionId))
     .orderBy(laps.lapNumber)
     .all();
-  return rows.map(r => ({ ...r, isValid: Boolean(r.isValid) }));
+  return rows.map((r) => ({ ...r, isValid: Boolean(r.isValid) }));
 }
 
 /** Update lap frame index and metadata after reprocessing. */
-
-export async function updateLapRawIndex(
-  lapId: number,
-  rawByteOffset: number | null,
-  rawFrameCount: number,
-  lapTime: number,
-  isValid: boolean,
-  invalidReason: string | null,
-  sectors: number[] | null,
-  versionIdentity?: TelemetryVersionIdentity,
-  classification?: LapClassification,
-): Promise<void> {
-  cacheDelete(lapId);
-  await db.update(laps).set({
-    rawByteOffset,
-    rawFrameCount,
-    lapTime,
-    isValid,
-    invalidReason,
-    sectorTimes: sectors,
-    ...classification,
-    ...versionIdentity,
-  }).where(eq(laps.id, lapId));
+export interface UpdateLapRawIndexInput {
+  lapId: number;
+  rawByteOffset: number | null;
+  rawFrameCount: number;
+  lapTime: number;
+  isValid: boolean;
+  invalidReason: string | null;
+  sectors: number[] | null;
+  classification: LapClassification;
+  quality: LapQualitySummary;
+  eligibility: EligibilityDecisionSet;
+  versionIdentity: TelemetryVersionIdentity;
 }
 
-/** Insert a detected replacement while preserving matched row metadata. */
+export async function updateLapRawIndex(input: UpdateLapRawIndexInput): Promise<void> {
+  cacheDelete(input.lapId);
+  await db
+    .update(laps)
+    .set({
+      rawByteOffset: input.rawByteOffset,
+      rawFrameCount: input.rawFrameCount,
+      lapTime: input.lapTime,
+      isValid: input.isValid,
+      invalidReason: input.invalidReason,
+      sectorTimes: input.sectors,
+      ...input.classification,
+      quality: input.quality,
+      eligibility: input.eligibility,
+      qualitySchemaVersion: input.quality.provenance.schemaVersion,
+      qualityPolicyVersion: input.quality.provenance.policyVersion,
+      qualityConfigVersion: input.quality.provenance.configurationVersion,
+      qualityGeneration: input.quality.provenance.outputGeneration,
+      ...input.versionIdentity,
+    })
+    .where(eq(laps.id, input.lapId));
+}
 
-export async function insertReprocessedLap(
-  sessionId: number,
-  lapNumber: number,
-  lapTime: number,
-  isValid: boolean,
-  rawByteOffset: number | null,
-  rawFrameCount: number,
-  tuneId: number | null,
-  notes: string | null,
-  invalidReason: string | null,
-  sectors: number[] | null,
-  versionIdentity?: TelemetryVersionIdentity,
-  classification?: LapClassification,
-): Promise<number> {
-  const result = await db.insert(laps).values({
-    sessionId, lapNumber, lapTime, isValid,
-    ...classification,
-    rawByteOffset, rawFrameCount,
-    tuneId, notes, invalidReason,
-    sectorTimes: sectors,
-    ...versionIdentity,
-  }).returning({ id: laps.id }).get();
+/** Insert detected replacement while preserving matched row metadata. */
+export interface InsertReprocessedLapInput {
+  sessionId: number;
+  lapNumber: number;
+  lapTime: number;
+  isValid: boolean;
+  rawByteOffset: number | null;
+  rawFrameCount: number;
+  tuneId: number | null;
+  notes: string | null;
+  invalidReason: string | null;
+  sectors: number[] | null;
+  classification: LapClassification;
+  quality: LapQualitySummary;
+  eligibility: EligibilityDecisionSet;
+  versionIdentity: TelemetryVersionIdentity;
+}
+
+export async function insertReprocessedLap(input: InsertReprocessedLapInput): Promise<number> {
+  const result = await db
+    .insert(laps)
+    .values({
+      sessionId: input.sessionId,
+      lapNumber: input.lapNumber,
+      lapTime: input.lapTime,
+      isValid: input.isValid,
+      rawByteOffset: input.rawByteOffset,
+      rawFrameCount: input.rawFrameCount,
+      tuneId: input.tuneId,
+      notes: input.notes,
+      invalidReason: input.invalidReason,
+      ...input.classification,
+      sectorTimes: input.sectors,
+      quality: input.quality,
+      eligibility: input.eligibility,
+      qualitySchemaVersion: input.quality.provenance.schemaVersion,
+      qualityPolicyVersion: input.quality.provenance.policyVersion,
+      qualityConfigVersion: input.quality.provenance.configurationVersion,
+      qualityGeneration: input.quality.provenance.outputGeneration,
+      ...input.versionIdentity,
+    })
+    .returning({ id: laps.id })
+    .get();
   return result.id;
 }
 
 /** Delete replaceable laps while retaining explicitly archived fallback rows. */
 
-export async function deleteLapsForSession(
-  sessionId: number,
-  preserveLapIds: readonly number[] = [],
-): Promise<void> {
-  const rows = await db
-    .select({ id: laps.id })
-    .from(laps)
-    .where(eq(laps.sessionId, sessionId))
-    .all();
+export async function deleteLapsForSession(sessionId: number, preserveLapIds: readonly number[] = []): Promise<void> {
+  const rows = await db.select({ id: laps.id }).from(laps).where(eq(laps.sessionId, sessionId)).all();
   const preserved = new Set(preserveLapIds);
-  const deletedIds = rows
-    .map(({ id }) => id)
-    .filter((id) => !preserved.has(id));
+  const deletedIds = rows.map(({ id }) => id).filter((id) => !preserved.has(id));
   for (const id of deletedIds) cacheDelete(id);
   if (deletedIds.length === 0) return;
   if (preserveLapIds.length === 0) {
     await db.delete(laps).where(eq(laps.sessionId, sessionId));
     return;
   }
-  await db.delete(laps).where(
-    and(
-      eq(laps.sessionId, sessionId),
-      notInArray(laps.id, [
-        preserveLapIds[0]!,
-        ...preserveLapIds.slice(1),
-      ]),
-    ),
-  );
+  await db.delete(laps).where(and(eq(laps.sessionId, sessionId), notInArray(laps.id, [preserveLapIds[0]!, ...preserveLapIds.slice(1)])));
 }

--- a/server/db/migrations.ts
+++ b/server/db/migrations.ts
@@ -119,26 +119,17 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 13,
     name: "add car setup to laps",
-    sql: [
-      `ALTER TABLE laps ADD COLUMN car_setup TEXT`,
-    ],
+    sql: [`ALTER TABLE laps ADD COLUMN car_setup TEXT`],
   },
   {
     version: 14,
     name: "add notes to sessions and laps",
-    sql: [
-      `ALTER TABLE sessions ADD COLUMN notes TEXT`,
-      `ALTER TABLE laps ADD COLUMN notes TEXT`,
-    ],
+    sql: [`ALTER TABLE sessions ADD COLUMN notes TEXT`, `ALTER TABLE laps ADD COLUMN notes TEXT`],
   },
   {
     version: 15,
     name: "add sector times to laps",
-    sql: [
-      `ALTER TABLE laps ADD COLUMN s1_time REAL`,
-      `ALTER TABLE laps ADD COLUMN s2_time REAL`,
-      `ALTER TABLE laps ADD COLUMN s3_time REAL`,
-    ],
+    sql: [`ALTER TABLE laps ADD COLUMN s1_time REAL`, `ALTER TABLE laps ADD COLUMN s2_time REAL`, `ALTER TABLE laps ADD COLUMN s3_time REAL`],
   },
   {
     version: 16,
@@ -163,9 +154,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 17,
     name: "drop sectors column from track_outlines",
-    sql: [
-      `ALTER TABLE track_outlines DROP COLUMN sectors`,
-    ],
+    sql: [`ALTER TABLE track_outlines DROP COLUMN sectors`],
   },
 
   // ── v18: drop DEFAULT 'fm-2023' from game_id columns ─────────────────
@@ -275,10 +264,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 21,
     name: "add game_id to tunes",
-    sql: [
-      `ALTER TABLE tunes ADD COLUMN game_id TEXT NOT NULL DEFAULT 'fm-2023'`,
-      `CREATE INDEX IF NOT EXISTS idx_tunes_game_car ON tunes(game_id, car_ordinal)`,
-    ],
+    sql: [`ALTER TABLE tunes ADD COLUMN game_id TEXT NOT NULL DEFAULT 'fm-2023'`, `CREATE INDEX IF NOT EXISTS idx_tunes_game_car ON tunes(game_id, car_ordinal)`],
   },
 
   // ── v22: scope tune_assignments by game_id ────────────────────────────
@@ -408,10 +394,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 26,
     name: "explicit lap to tuning-session link",
-    sql: [
-      `ALTER TABLE laps ADD COLUMN tuning_session_id INTEGER`,
-      `CREATE INDEX IF NOT EXISTS idx_laps_tuning_session ON laps(tuning_session_id)`,
-    ],
+    sql: [`ALTER TABLE laps ADD COLUMN tuning_session_id INTEGER`, `CREATE INDEX IF NOT EXISTS idx_laps_tuning_session ON laps(tuning_session_id)`],
   },
 
   // ── v27: per-game tuning-session display number ───────────────────────────
@@ -436,9 +419,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 28,
     name: "tuning-session head test id",
-    sql: [
-      `ALTER TABLE tuning_sessions ADD COLUMN head_test_id INTEGER`,
-    ],
+    sql: [`ALTER TABLE tuning_sessions ADD COLUMN head_test_id INTEGER`],
   },
 
   // ── v29: explicit lap → tuning-test link ──────────────────────────────────
@@ -448,10 +429,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 29,
     name: "explicit lap to tuning-test link",
-    sql: [
-      `ALTER TABLE laps ADD COLUMN tuning_test_id INTEGER`,
-      `CREATE INDEX IF NOT EXISTS idx_laps_tuning_test ON laps(tuning_test_id)`,
-    ],
+    sql: [`ALTER TABLE laps ADD COLUMN tuning_test_id INTEGER`, `CREATE INDEX IF NOT EXISTS idx_laps_tuning_test ON laps(tuning_test_id)`],
   },
 
   // ── v30: Setup Engineer flow — exclusions, F1 snapshot, action log ─────────
@@ -503,10 +481,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 32,
     name: "persisted per-lap fuel/tyre metrics",
-    sql: [
-      `ALTER TABLE laps ADD COLUMN fuel_per_lap REAL`,
-      `ALTER TABLE laps ADD COLUMN tyre_wear REAL`,
-    ],
+    sql: [`ALTER TABLE laps ADD COLUMN fuel_per_lap REAL`, `ALTER TABLE laps ADD COLUMN tyre_wear REAL`],
   },
 
   // ── v33: Cached racing-line spread trace ───────────────────────────────────
@@ -544,10 +519,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 34,
     name: "auto-exclude source tracking for fastest-5 curation",
-    sql: [
-      `ALTER TABLE laps ADD COLUMN tuning_excluded_source TEXT`,
-      `UPDATE laps SET tuning_excluded_source = 'manual' WHERE tuning_excluded = 1`,
-    ],
+    sql: [`ALTER TABLE laps ADD COLUMN tuning_excluded_source TEXT`, `UPDATE laps SET tuning_excluded_source = 'manual' WHERE tuning_excluded = 1`],
   },
 
   // ── v35: purge pre-v0.8.0 laps (no raw capture) ─────────────────────────────
@@ -1137,9 +1109,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 49,
     name: "version race result processor",
-    sql: [
-      `ALTER TABLE session_results ADD COLUMN processor_version TEXT NOT NULL DEFAULT 'race-result-v1'`,
-    ],
+    sql: [`ALTER TABLE session_results ADD COLUMN processor_version TEXT NOT NULL DEFAULT 'race-result-v1'`],
   },
   // v50: Persist race timeline event types and position transitions.
   {
@@ -1184,9 +1154,7 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 52,
     name: "version race result processor",
-    sql: [
-      `ALTER TABLE session_results ADD COLUMN processor_version TEXT NOT NULL DEFAULT 'legacy-race-result-v0'`,
-    ],
+    sql: [`ALTER TABLE session_results ADD COLUMN processor_version TEXT NOT NULL DEFAULT 'legacy-race-result-v0'`],
   },
   // v53: Persist race timeline event types and position transitions.
   {
@@ -1228,17 +1196,13 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
   {
     version: 56,
     name: "persist race result outcome status",
-    sql: [
-      `ALTER TABLE session_results ADD COLUMN outcome_status TEXT NOT NULL DEFAULT 'unavailable'`,
-    ],
+    sql: [`ALTER TABLE session_results ADD COLUMN outcome_status TEXT NOT NULL DEFAULT 'unavailable'`],
   },
   // v57: Persist structured race-result evidence.
   {
     version: 57,
     name: "persist race result evidence",
-    sql: [
-      `ALTER TABLE session_results ADD COLUMN evidence TEXT`,
-    ],
+    sql: [`ALTER TABLE session_results ADD COLUMN evidence TEXT`],
   },
   // v58: Persist whether a session belongs to the user or another driver.
   {
@@ -1272,5 +1236,371 @@ export const migrations: { version: number; name: string; sql: string[] }[] = [
        WHERE invalid_reason IN ('outlap', 'inlap', 'pit lap')`,
     ],
   },
+  // v60: Separate recording quality from policy-specific analysis eligibility.
+  {
+    version: 60,
+    name: "persist telemetry quality and eligibility",
+    sql: [
+      `ALTER TABLE sessions ADD COLUMN recording_quality TEXT`,
+      `ALTER TABLE sessions ADD COLUMN quality_schema_version TEXT`,
+      `ALTER TABLE sessions ADD COLUMN quality_policy_version TEXT`,
+      `ALTER TABLE sessions ADD COLUMN quality_config_version TEXT`,
+      `ALTER TABLE sessions ADD COLUMN quality_generation TEXT`,
+      `ALTER TABLE laps ADD COLUMN quality TEXT`,
+      `ALTER TABLE laps ADD COLUMN eligibility TEXT`,
+      `ALTER TABLE laps ADD COLUMN quality_schema_version TEXT`,
+      `ALTER TABLE laps ADD COLUMN quality_policy_version TEXT`,
+      `ALTER TABLE laps ADD COLUMN quality_config_version TEXT`,
+      `ALTER TABLE laps ADD COLUMN quality_generation TEXT`,
+      `ALTER TABLE lap_analyses ADD COLUMN quality_generation TEXT`,
+      `ALTER TABLE lap_analyses ADD COLUMN quality_policy_version TEXT`,
+      `ALTER TABLE compare_analyses ADD COLUMN quality_generation TEXT`,
+      `ALTER TABLE compare_analyses ADD COLUMN quality_policy_version TEXT`,
+      `UPDATE sessions SET source = 'native-live' WHERE source IS NULL`,
+      `UPDATE sessions
+       SET recording_quality = json_object(
+         'lifecycleState', 'unavailable',
+         'gapSummary', json_object(
+           'expectedCount', 0,
+           'observedCount', 0,
+           'totalMissingCount', NULL,
+           'totalMissingFraction', NULL,
+           'largestContiguousGapMs', 0,
+           'countMethod', 'unavailable'
+         ),
+         'facts', json_array(
+           json_object(
+             'id', 'legacy:quality_not_rebuilt',
+             'code', 'quality_not_rebuilt',
+             'severity', 'warning',
+             'timeRange', NULL,
+             'distanceRange', NULL,
+             'semanticIds', json_array(),
+             'channelFamilies', json_array(),
+             'provenance', json_object(
+               'schemaVersion', 'legacy',
+               'policyVersion', 'legacy',
+               'configurationVersion', 'legacy',
+               'sourceGeneration', 'legacy',
+               'outputGeneration', 'legacy'
+             ),
+             'eventIds', json_array()
+           ),
+           json_object(
+             'id', 'legacy:provenance_missing',
+             'code', 'provenance_missing',
+             'severity', 'error',
+             'timeRange', NULL,
+             'distanceRange', NULL,
+             'semanticIds', json_array(),
+             'channelFamilies', json_array(),
+             'provenance', json_object(
+               'schemaVersion', 'legacy',
+               'policyVersion', 'legacy',
+               'configurationVersion', 'legacy',
+               'sourceGeneration', 'legacy',
+               'outputGeneration', 'legacy'
+             ),
+             'eventIds', json_array()
+           )
+         ),
+        'sourceKind', COALESCE(source, 'unknown'),
+         'participant', json_object(
+           'kind', 'player',
+           'sourceId', NULL,
+           'stableId', 'local-player',
+           'identityState', 'stable'
+         ),
+         'startTimestampMs', NULL,
+         'endTimestampMs', NULL,
+         'endReason', 'legacy-not-rebuilt',
+         'archiveVerification', json_object(
+           'state', 'unknown',
+           'sourceGeneration', NULL
+         ),
+         'thresholds', json_object(
+           'minorGapMaxMs', 250,
+           'minorMissingFractionMax', 0.01,
+           'degradedMissingFraction', 0.05,
+           'lapComparisonCoverage', 0.95,
+           'lapComparisonGapMaxMs', 1000,
+           'cornerTraceCoverage', 0.98,
+           'cornerTraceGapMaxMs', 250,
+           'transientCoverage', 0.995,
+           'transientGapFloorMs', 50,
+           'transientIntervalMultiplier', 2
+         ),
+         'versionIdentity', json_object(
+           'catalogVersion', 'legacy',
+           'catalogHash', 'legacy',
+           'catalogSchemaVersion', 'legacy',
+           'parserVersion', 'legacy',
+           'resolverVersion', 'legacy',
+           'derivationVersion', 'legacy'
+         ),
+         'provenance', json_object(
+           'schemaVersion', 'legacy',
+           'policyVersion', 'legacy',
+           'configurationVersion', 'legacy',
+           'sourceGeneration', 'legacy',
+           'outputGeneration', 'legacy'
+         )
+       ),
+       quality_schema_version = 'legacy',
+       quality_policy_version = 'legacy',
+       quality_config_version = 'legacy',
+       quality_generation = 'legacy'
+       WHERE recording_quality IS NULL`,
+      `UPDATE laps
+       SET quality = json_object(
+         'lifecycleState', 'unavailable',
+         'complete', json(CASE WHEN lap_time > 0 THEN 'true' ELSE 'false' END),
+         'structurallyValid', json(CASE WHEN is_valid = 1 THEN 'true' ELSE 'false' END),
+         'invalidReason', invalid_reason,
+         'timing', json_object(
+           'source', CASE WHEN lap_time > 0 THEN 'simulator-history' ELSE 'estimated' END,
+           'lapTimeMs', lap_time * 1000,
+           'peakTelemetryLapTimeMs', NULL,
+           'confirmed', json(CASE WHEN lap_time > 0 THEN 'true' ELSE 'false' END)
+         ),
+         'gapSummary', json_object(
+           'expectedCount', 0,
+           'observedCount', 0,
+           'totalMissingCount', NULL,
+           'totalMissingFraction', NULL,
+           'largestContiguousGapMs', 0,
+           'countMethod', 'unavailable'
+         ),
+         'trackDistanceCoverage', NULL,
+         'worldPositionCoverage', NULL,
+         'channelQuality', json_array(),
+         'facts', json_array(
+           json_object(
+             'id', 'legacy:quality_not_rebuilt',
+             'code', 'quality_not_rebuilt',
+             'severity', 'warning',
+             'timeRange', NULL,
+             'distanceRange', NULL,
+             'semanticIds', json_array(),
+             'channelFamilies', json_array(),
+             'provenance', json_object(
+               'schemaVersion', 'legacy',
+               'policyVersion', 'legacy',
+               'configurationVersion', 'legacy',
+               'sourceGeneration', 'legacy',
+               'outputGeneration', 'legacy'
+             ),
+             'eventIds', json_array()
+           ),
+           json_object(
+             'id', 'legacy:provenance_missing',
+             'code', 'provenance_missing',
+             'severity', 'error',
+             'timeRange', NULL,
+             'distanceRange', NULL,
+             'semanticIds', json_array(),
+             'channelFamilies', json_array(),
+             'provenance', json_object(
+               'schemaVersion', 'legacy',
+               'policyVersion', 'legacy',
+               'configurationVersion', 'legacy',
+               'sourceGeneration', 'legacy',
+               'outputGeneration', 'legacy'
+             ),
+             'eventIds', json_array()
+           )
+         ),
+         'sourceKind', COALESCE((SELECT source FROM sessions WHERE sessions.id = laps.session_id), 'unknown'),
+         'participant', json_object(
+           'kind', 'player',
+           'sourceId', NULL,
+           'stableId', 'local-player',
+           'identityState', 'stable'
+         ),
+         'classification', json_object(
+           'phase', phase,
+           'conditions', json(conditions),
+           'paceEligibility', pace_eligibility
+         ),
+         'thresholds', json_object(
+           'minorGapMaxMs', 250,
+           'minorMissingFractionMax', 0.01,
+           'degradedMissingFraction', 0.05,
+           'lapComparisonCoverage', 0.95,
+           'lapComparisonGapMaxMs', 1000,
+           'cornerTraceCoverage', 0.98,
+           'cornerTraceGapMaxMs', 250,
+           'transientCoverage', 0.995,
+           'transientGapFloorMs', 50,
+           'transientIntervalMultiplier', 2
+         ),
+         'versionIdentity', json_object(
+           'catalogVersion', COALESCE(catalog_version, 'legacy'),
+           'catalogHash', COALESCE(catalog_hash, 'legacy'),
+           'catalogSchemaVersion', COALESCE(catalog_schema_version, 'legacy'),
+           'parserVersion', COALESCE(parser_version, 'legacy'),
+           'resolverVersion', COALESCE(resolver_version, 'legacy'),
+           'derivationVersion', COALESCE(derivation_version, 'legacy')
+         ),
+         'provenance', json_object(
+           'schemaVersion', 'legacy',
+           'policyVersion', 'legacy',
+           'configurationVersion', 'legacy',
+           'sourceGeneration', 'legacy',
+           'outputGeneration', 'legacy'
+         )
+       ),
+       eligibility = json_object(
+         'official-timing', json_object(
+           'status', CASE WHEN lap_time > 0 THEN 'eligible_with_warning' ELSE 'ineligible' END,
+           'policyId', 'official-timing',
+           'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', CASE WHEN lap_time > 0 THEN 'quality_not_rebuilt' ELSE 'lap_time_unconfirmed' END,
+             'severity', CASE WHEN lap_time > 0 THEN 'warning' ELSE 'error' END,
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL,
+             'distanceRange', NULL,
+             'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'normal-pace', json_object(
+           'status', CASE
+             WHEN lap_time > 0 AND is_valid = 1 AND pace_eligibility = 'eligible'
+               THEN 'eligible_with_warning'
+             ELSE 'ineligible'
+           END,
+           'policyId', 'normal-pace',
+           'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', CASE
+               WHEN lap_time <= 0 THEN 'lap_time_unconfirmed'
+               WHEN is_valid != 1 THEN 'structurally_invalid'
+               WHEN pace_eligibility != 'eligible' THEN 'non_pace_classification'
+               ELSE 'quality_not_rebuilt'
+             END,
+             'severity', CASE
+               WHEN lap_time > 0 AND is_valid = 1 AND pace_eligibility = 'eligible' THEN 'warning'
+               ELSE 'error'
+             END,
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL,
+             'distanceRange', NULL,
+             'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'lap-comparison', json_object(
+           'status', 'unknown', 'policyId', 'lap-comparison', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'corner-trace', json_object(
+           'status', 'unknown', 'policyId', 'corner-trace', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'transient-event', json_object(
+           'status', 'unknown', 'policyId', 'transient-event', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'fuel-burn', json_object(
+           'status', 'unknown', 'policyId', 'fuel-burn', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'tire-analysis', json_object(
+           'status', 'unknown', 'policyId', 'tire-analysis', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'stint-falloff', json_object(
+           'status', 'unknown', 'policyId', 'stint-falloff', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'setup-analysis', json_object(
+           'status', 'unknown', 'policyId', 'setup-analysis', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'driver-profile', json_object(
+           'status', 'unknown', 'policyId', 'driver-profile', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'quality_not_rebuilt', 'severity', 'warning',
+             'evidenceIds', json_array('legacy:quality_not_rebuilt'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:quality_not_rebuilt')
+         ),
+         'ml-training', json_object(
+           'status', 'unknown', 'policyId', 'ml-training', 'policyVersion', 'legacy',
+           'confidence', json_object('level', 'unknown', 'score', NULL),
+           'reasons', json_array(json_object(
+             'code', 'provenance_missing', 'severity', 'error',
+             'evidenceIds', json_array('legacy:provenance_missing'),
+             'timeRange', NULL, 'distanceRange', NULL, 'semanticIds', json_array()
+           )),
+           'evidenceIds', json_array('legacy:provenance_missing')
+         )
+       ),
+       quality_schema_version = 'legacy',
+       quality_policy_version = 'legacy',
+       quality_config_version = 'legacy',
+       quality_generation = 'legacy'
+       WHERE quality IS NULL`,
+    ],
+  },
+  // v61: Persist source-authored channel fidelity for transcoded sessions.
+  {
+    version: 61,
+    name: "persist source channel profiles",
+    sql: [`ALTER TABLE sessions ADD COLUMN source_channel_profile TEXT`],
+  },
+  // v62: Tie derived lap metrics to exact quality evidence generation.
+  {
+    version: 62,
+    name: "version lap metrics by quality generation",
+    sql: [`ALTER TABLE lap_metrics ADD COLUMN quality_generation TEXT`],
+  },
 ];
-

--- a/server/db/quality-event-queries.ts
+++ b/server/db/quality-event-queries.ts
@@ -1,0 +1,139 @@
+import { eq, inArray, or } from "drizzle-orm";
+import { GameIdSchema, type GameId } from "../../shared/games/ids";
+import type { QualityFact, QualityTimeRange } from "../../shared/racing/quality/contracts";
+import { finalizeLapQualityGeneration } from "../lap-analysis/quality-generation";
+import { db } from "./index";
+import { compareAnalyses, lapAnalyses, laps, pitEvents, sessionResults, sessions } from "./schema";
+
+interface DurableQualityEvent {
+  id: number;
+  eventType: string;
+  lapNumber: number | null;
+  elapsedSeconds: number | null;
+  durationSeconds: number | null;
+}
+
+type QualityEventClockDomain = "session" | "race" | "lap" | "game-uptime" | "source";
+
+const CLOCK_DOMAINS_BY_GAME: Record<GameId, { event: QualityEventClockDomain; fact: QualityEventClockDomain }> = {
+  "fm-2023": { event: "race", fact: "game-uptime" },
+  "f1-2025": { event: "session", fact: "session" },
+  acc: { event: "lap", fact: "source" },
+  "ac-evo": { event: "lap", fact: "source" },
+  iracing: { event: "session", fact: "session" },
+};
+
+function normalizeEventTimeRange(event: DurableQualityEvent, gameId: GameId | null): QualityTimeRange | null {
+  if (gameId == null || event.elapsedSeconds == null) return null;
+  const domains = CLOCK_DOMAINS_BY_GAME[gameId];
+  if (domains.event !== domains.fact) return null;
+  const startMs = event.elapsedSeconds * 1_000;
+  return {
+    startMs,
+    endMs: startMs + Math.max(0, event.durationSeconds ?? 0) * 1_000,
+  };
+}
+
+export function qualityEventOverlapsFact(
+  event: DurableQualityEvent,
+  lapNumber: number,
+  fact: Pick<QualityFact, "timeRange">,
+  gameId: GameId | null,
+): boolean {
+  const lapMatches = event.lapNumber === lapNumber;
+  if (event.lapNumber != null && !lapMatches) return false;
+  if (event.elapsedSeconds != null && fact.timeRange != null) {
+    const normalizedEventRange = normalizeEventTimeRange(event, gameId);
+    if (normalizedEventRange == null) return lapMatches;
+    return normalizedEventRange.startMs <= fact.timeRange.endMs && normalizedEventRange.endMs >= fact.timeRange.startMs;
+  }
+  return lapMatches;
+}
+
+function durableEventId(event: DurableQualityEvent): string {
+  return `${event.eventType === "position-change" ? "position-event" : "pit-event"}:${event.id}`;
+}
+
+export async function linkSessionQualityEvents(sessionId: number): Promise<number> {
+  const session = await db.select({ gameId: sessions.gameId, recordingQuality: sessions.recordingQuality }).from(sessions).where(eq(sessions.id, sessionId)).get();
+  const result = await db.select({ id: sessionResults.id }).from(sessionResults).where(eq(sessionResults.sessionId, sessionId)).get();
+  if (!session?.recordingQuality || !result) return 0;
+  const parsedGameId = GameIdSchema.safeParse(session.gameId);
+  const gameId = parsedGameId.success ? parsedGameId.data : null;
+
+  const events = await db
+    .select({
+      id: pitEvents.id,
+      eventType: pitEvents.eventType,
+      lapNumber: pitEvents.lapNumber,
+      elapsedSeconds: pitEvents.elapsedSeconds,
+      durationSeconds: pitEvents.durationSeconds,
+    })
+    .from(pitEvents)
+    .where(eq(pitEvents.resultId, result.id))
+    .all();
+
+  const lapRows = await db
+    .select({
+      id: laps.id,
+      lapNumber: laps.lapNumber,
+      rawByteOffset: laps.rawByteOffset,
+      rawFrameCount: laps.rawFrameCount,
+      quality: laps.quality,
+    })
+    .from(laps)
+    .where(eq(laps.sessionId, sessionId))
+    .all();
+  const changedLapIds: number[] = [];
+
+  for (const lap of lapRows) {
+    if (!lap.quality) continue;
+    let changed = false;
+    const facts = lap.quality.facts.map((fact) => {
+      const currentIds = fact.eventIds.filter(
+        (eventId) =>
+          !eventId.startsWith("pit:") &&
+          !eventId.startsWith("position-change:") &&
+          !eventId.startsWith("pit-event:") &&
+          !eventId.startsWith("position-event:"),
+      );
+      for (const event of events) {
+        if (qualityEventOverlapsFact(event, lap.lapNumber, fact, gameId)) currentIds.push(durableEventId(event));
+      }
+      const eventIds = [...new Set(currentIds)].sort();
+      if (eventIds.length !== fact.eventIds.length || eventIds.some((id, index) => id !== fact.eventIds[index])) {
+        changed = true;
+      }
+      return { ...fact, eventIds };
+    });
+    if (!changed) continue;
+
+    const generated = finalizeLapQualityGeneration({ ...lap.quality, facts }, session.recordingQuality.provenance.sourceGeneration, {
+      lapNumber: lap.lapNumber,
+      rawByteOffset: lap.rawByteOffset,
+      rawFrameCount: lap.rawFrameCount ?? 0,
+    });
+    await db
+      .update(laps)
+      .set({
+        quality: generated.quality,
+        eligibility: generated.eligibility,
+        qualityGeneration: generated.quality.provenance.outputGeneration,
+        qualityPolicyVersion: generated.quality.provenance.policyVersion,
+        qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+        qualityConfigVersion: generated.quality.provenance.configurationVersion,
+      })
+      .where(eq(laps.id, lap.id))
+      .run();
+    changedLapIds.push(lap.id);
+  }
+
+  if (changedLapIds.length > 0) {
+    await db.delete(lapAnalyses).where(inArray(lapAnalyses.lapId, changedLapIds)).run();
+    await db
+      .delete(compareAnalyses)
+      .where(or(inArray(compareAnalyses.lapAId, changedLapIds), inArray(compareAnalyses.lapBId, changedLapIds)))
+      .run();
+  }
+  return changedLapIds.length;
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -11,6 +11,12 @@ import {
 import { sql } from "drizzle-orm";
 import type { RaceResultEvidence, RaceResultOutcomeStatus, RaceResultProvenance } from "../../shared/racing/results/types";
 import type { LapCondition, LapPhase, PaceEligibility } from "../../shared/racing/laps/classification";
+import type {
+	EligibilityDecisionSet,
+	LapQualitySummary,
+	RecordingQualitySummary,
+	SourceChannelProfile,
+} from "../../shared/racing/quality/contracts";
 import type { SessionOwnership } from "../../shared/racing/sessions/types";
 
 export const profiles = sqliteTable("profiles", {
@@ -103,11 +109,18 @@ export const sessions = sqliteTable("sessions", {
 	parserVersion: text("parser_version"),
 	resolverVersion: text("resolver_version"),
 	derivationVersion: text("derivation_version"),
-	// How this session's telemetry was obtained (migration v43). NULL = recorded
-	// live from the game. 'motec' = transcoded from a MoTeC .ld export, where the
-	// racing line is dead-reckoned rather than logged — see server/motec/.
+	// How this session's telemetry was obtained (migration v43). Pre-v43 NULL
+	// values are direct live captures and migrate to 'native-live' in v60.
+	// 'motec' marks a transcoded MoTeC .ld export, where the racing line is
+	// dead-reckoned rather than logged — see server/motec/.
 	source: text("source"),
 	ownership: text("ownership").$type<SessionOwnership>().notNull().default("mine"),
+	sourceChannelProfile: text("source_channel_profile", { mode: "json" }).$type<SourceChannelProfile>(),
+	recordingQuality: text("recording_quality", { mode: "json" }).$type<RecordingQualitySummary>(),
+	qualitySchemaVersion: text("quality_schema_version"),
+	qualityPolicyVersion: text("quality_policy_version"),
+	qualityConfigVersion: text("quality_config_version"),
+	qualityGeneration: text("quality_generation"),
 	createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
 });
 export const sessionResults = sqliteTable(
@@ -202,6 +215,12 @@ export const laps = sqliteTable(
 		parserVersion: text("parser_version"),
 		resolverVersion: text("resolver_version"),
 		derivationVersion: text("derivation_version"),
+		quality: text("quality", { mode: "json" }).$type<LapQualitySummary>(),
+		eligibility: text("eligibility", { mode: "json" }).$type<EligibilityDecisionSet>(),
+		qualitySchemaVersion: text("quality_schema_version"),
+		qualityPolicyVersion: text("quality_policy_version"),
+		qualityConfigVersion: text("quality_config_version"),
+		qualityGeneration: text("quality_generation"),
 		// Explicit experiment link (migration v25). Stamped at insert from the
 		// in-memory active tuning session (server/experiments/active.ts) so a tuning
 		// session can span many race sessions. The `.references()` here is
@@ -303,6 +322,8 @@ export const lapAnalyses = sqliteTable(
 		durationMs: integer("duration_ms").notNull().default(0),
 		model: text("model").notNull().default(""),
 		createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+		qualityGeneration: text("quality_generation"),
+		qualityPolicyVersion: text("quality_policy_version"),
 	},
 	(table) => [unique().on(table.lapId)],
 );
@@ -548,6 +569,8 @@ export const compareAnalyses = sqliteTable(
 		durationMs: integer("duration_ms").notNull().default(0),
 		model: text("model").notNull().default(""),
 		createdAt: text("created_at").notNull().default(sql`(datetime('now'))`),
+		qualityGeneration: text("quality_generation"),
+		qualityPolicyVersion: text("quality_policy_version"),
 	},
 	(table) => [unique().on(table.lapAId, table.lapBId, table.kind)],
 );
@@ -556,16 +579,16 @@ export const compareAnalyses = sqliteTable(
  * Per-lap derived metrics (insights + per-segment input stats), cached so the
  * tuning views don't re-decode a lap's raw .bin on every read.
  *
- * `algo_version` is the cache key alongside `lap_id`: bumping
- * `LAP_METRICS_ALGO_VERSION` invalidates every stored row on next read rather
- * than requiring a migration to recompute. One row per lap — the recompute
- * overwrites in place.
+ * `algo_version` and `quality_generation` validate the cache alongside
+ * `lap_id`: changing either dependency invalidates the stored row on next
+ * read. One row per lap — the recompute overwrites in place.
  */
 export const lapMetrics = sqliteTable("lap_metrics", {
 	lapId: integer("lap_id")
 		.primaryKey()
 		.references(() => laps.id, { onDelete: "cascade" }),
 	algoVersion: integer("algo_version").notNull().default(1),
+	qualityGeneration: text("quality_generation"),
 	insights: text("insights").notNull(),
 	segmentStats: text("segment_stats").notNull(),
 	computedAt: text("computed_at").notNull().default(sql`(datetime('now'))`),

--- a/server/db/session-queries.ts
+++ b/server/db/session-queries.ts
@@ -1,19 +1,31 @@
 import { deleteLap } from "./lap-mutation-queries";
 import { getLapById } from "./lap-read-queries";
+import { analysisEligibility, currentQualitySnapshot } from "./lap-eligibility";
 import { eq, desc, and, or, sql, inArray, notInArray, isNull } from "drizzle-orm";
 import { db } from "./index";
-import { sessions, laps, sessionResults, pitEvents } from "./schema";
+import { sessions, laps, sessionResults, pitEvents, lapAnalyses, compareAnalyses } from "./schema";
 import type { SessionMeta, SessionOwnership } from "../../shared/racing/sessions/types";
 import type { GameId } from "../../shared/games/ids";
 import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
-import type { EvidenceSourceKind } from "../../shared/racing/quality/contracts";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EvidenceSourceKind,
+  type LapQualitySummary,
+  type QualityFact,
+  type QualityReasonCode,
+  type RecordingQualitySummary,
+  type SourceChannelProfile,
+} from "../../shared/racing/quality/contracts";
+import { isTimedLapEligibilityUsable } from "../../shared/racing/quality/policies";
 import { tryGetGame } from "../../shared/games/registry";
 import { existsSync, unlinkSync } from "node:fs";
 import { relative, resolve, sep } from "node:path";
+import { finalizeLapQualityGeneration, finalizeRecordingQualityGeneration } from "../lap-analysis/quality-generation";
 import { resolveDataDir } from "../runtime/config/data-dir";
 import { getTrackLengthMeters } from "../../shared/racing/tracks/recording/outlines";
 import type { RecapLapInput, RecapSessionInput } from "../lap-analysis/recap";
-
 export async function insertSession(
   carOrdinal: number,
   trackOrdinal: number,
@@ -21,23 +33,172 @@ export async function insertSession(
   sessionType?: string,
   versionIdentity?: TelemetryVersionIdentity,
   ownership?: SessionOwnership,
+  source: EvidenceSourceKind = "native-live",
+  sourceChannelProfile?: SourceChannelProfile,
 ): Promise<number> {
   const result = await db
     .insert(sessions)
-    .values({ carOrdinal, trackOrdinal, gameId, sessionType, ownership, ...versionIdentity })
+    .values({ carOrdinal, trackOrdinal, gameId, sessionType, source, sourceChannelProfile, ownership, ...versionIdentity })
     .returning({ id: sessions.id })
     .get();
   return result.id;
+}
+
+const SESSION_LAP_FACT_CODES: Partial<Record<QualityReasonCode, true>> = {
+  recording_corrupt: true,
+  recording_incompatible: true,
+  recording_incomplete: true,
+  recording_unavailable: true,
+  source_reconnect: true,
+  timeline_discontinuity: true,
+  out_of_order_observations: true,
+  writer_drop: true,
+};
+
+const SESSION_WIDE_FACT_CODES: Partial<Record<QualityReasonCode, true>> = {
+  recording_corrupt: true,
+  recording_incompatible: true,
+  recording_unavailable: true,
+};
+
+const DEGRADED_LAP_FACT_CODES: Partial<Record<QualityReasonCode, true>> = {
+  source_reconnect: true,
+  timeline_discontinuity: true,
+  out_of_order_observations: true,
+  writer_drop: true,
+};
+
+const LAP_MEASURED_FACT_CODES: Partial<Record<QualityReasonCode, true>> = {
+  timeline_discontinuity: true,
+  out_of_order_observations: true,
+};
+
+function timeRangesOverlap(left: NonNullable<QualityFact["timeRange"]>, right: NonNullable<QualityFact["timeRange"]>): boolean {
+  return left.startMs <= right.endMs && right.startMs <= left.endMs;
+}
+
+function lifecycleWithoutSessionFacts(quality: LapQualitySummary, facts: readonly QualityFact[]): LapQualitySummary["lifecycleState"] {
+  if (!quality.complete) return "incomplete";
+  if (quality.gapSummary.observedCount === 0) return "unavailable";
+  if (facts.some(({ code }) => code === "telemetry_gap_major" || code === "timeline_discontinuity" || code === "out_of_order_observations" || code === "writer_drop")) {
+    return "degraded";
+  }
+  if (facts.some(({ code }) => code === "telemetry_gap_minor")) return "minor_gaps";
+  return "exact";
+}
+
+function recordingFactsForLap(recordingQuality: RecordingQualitySummary, lapQuality: LapQualitySummary): QualityFact[] {
+  const lapRange = lapQuality.timeRange;
+  return recordingQuality.facts
+    .filter((fact) => {
+      if (!SESSION_LAP_FACT_CODES[fact.code]) return false;
+      if (SESSION_WIDE_FACT_CODES[fact.code]) return true;
+      if (!fact.timeRange || !lapRange || !timeRangesOverlap(fact.timeRange, lapRange)) return !fact.timeRange || !lapRange;
+      if (LAP_MEASURED_FACT_CODES[fact.code] && lapQuality.facts.some((lapFact) => lapFact.code === fact.code && lapFact.timeRange && timeRangesOverlap(lapFact.timeRange, fact.timeRange!))) {
+        return false;
+      }
+      return true;
+    })
+    .map((fact) => ({ ...fact, id: `session:${fact.id}` }));
+}
+
+export async function updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+  const finalized = finalizeRecordingQualityGeneration(quality);
+  return db.transaction(async (tx) => {
+    const lapRows = await tx
+      .select({
+        id: laps.id,
+        lapNumber: laps.lapNumber,
+        rawByteOffset: laps.rawByteOffset,
+        rawFrameCount: laps.rawFrameCount,
+        quality: laps.quality,
+        qualitySchemaVersion: laps.qualitySchemaVersion,
+        qualityPolicyVersion: laps.qualityPolicyVersion,
+        qualityConfigVersion: laps.qualityConfigVersion,
+        qualityGeneration: laps.qualityGeneration,
+      })
+      .from(laps)
+      .where(eq(laps.sessionId, sessionId))
+      .all();
+    const changedLapIds: number[] = [];
+
+    for (const lap of lapRows) {
+      if (!lap.quality) continue;
+      const sessionFacts = recordingFactsForLap(finalized, lap.quality);
+      const sessionLifecycle: LapQualitySummary["lifecycleState"] | null = sessionFacts.some(({ code }) => code === "recording_corrupt")
+        ? "corrupt"
+        : sessionFacts.some(({ code }) => code === "recording_incompatible")
+          ? "incompatible"
+          : sessionFacts.some(({ code }) => code === "recording_unavailable")
+            ? "unavailable"
+            : sessionFacts.some(({ code }) => code === "recording_incomplete")
+              ? "incomplete"
+              : sessionFacts.some(({ code }) => DEGRADED_LAP_FACT_CODES[code])
+                ? "degraded"
+                : null;
+      const lapFacts = lap.quality.facts.filter(({ id }) => !id.startsWith("session:"));
+      const hadSessionFacts = lapFacts.length !== lap.quality.facts.length;
+      const lapLifecycle = hadSessionFacts ? lifecycleWithoutSessionFacts(lap.quality, lapFacts) : lap.quality.lifecycleState;
+      const qualityWithSessionEvidence = {
+        ...lap.quality,
+        lifecycleState: sessionLifecycle ?? lapLifecycle,
+        facts: [...lapFacts, ...sessionFacts],
+      };
+      const generated = finalizeLapQualityGeneration(qualityWithSessionEvidence, finalized.provenance.sourceGeneration, {
+        lapNumber: lap.lapNumber,
+        rawByteOffset: lap.rawByteOffset,
+        rawFrameCount: lap.rawFrameCount ?? 0,
+      });
+      if (
+        generated.quality.provenance.outputGeneration === lap.qualityGeneration &&
+        lap.qualitySchemaVersion === generated.quality.provenance.schemaVersion &&
+        lap.qualityPolicyVersion === generated.quality.provenance.policyVersion &&
+        lap.qualityConfigVersion === generated.quality.provenance.configurationVersion
+      ) {
+        continue;
+      }
+      await tx
+        .update(laps)
+        .set({
+          quality: generated.quality,
+          eligibility: generated.eligibility,
+          qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+          qualityPolicyVersion: generated.quality.provenance.policyVersion,
+          qualityConfigVersion: generated.quality.provenance.configurationVersion,
+          qualityGeneration: generated.quality.provenance.outputGeneration,
+        })
+        .where(eq(laps.id, lap.id))
+        .run();
+      changedLapIds.push(lap.id);
+    }
+
+    if (changedLapIds.length > 0) {
+      await tx.delete(lapAnalyses).where(inArray(lapAnalyses.lapId, changedLapIds)).run();
+      await tx
+        .delete(compareAnalyses)
+        .where(or(inArray(compareAnalyses.lapAId, changedLapIds), inArray(compareAnalyses.lapBId, changedLapIds)))
+        .run();
+    }
+    await tx
+      .update(sessions)
+      .set({
+        recordingQuality: finalized,
+        qualitySchemaVersion: finalized.provenance.schemaVersion,
+        qualityPolicyVersion: finalized.provenance.policyVersion,
+        qualityConfigVersion: finalized.provenance.configurationVersion,
+        qualityGeneration: finalized.provenance.outputGeneration,
+      })
+      .where(eq(sessions.id, sessionId))
+      .run();
+    return finalized;
+  });
 }
 
 /**
  * Update session metadata (e.g. session type discovered after session start).
  */
 
-export async function updateSession(
-  id: number,
-  updates: { sessionType?: string; notes?: string | null }
-): Promise<void> {
+export async function updateSession(id: number, updates: { sessionType?: string; notes?: string | null }): Promise<void> {
   await db.update(sessions).set(updates).where(eq(sessions.id, id)).run();
 }
 
@@ -45,13 +206,7 @@ export async function updateSessionCarTrack(sessionId: number, carOrdinal: numbe
   await db.update(sessions).set({ carOrdinal, trackOrdinal }).where(eq(sessions.id, sessionId)).run();
 }
 
-
-export async function updateSessionRawFile(
-  sessionId: number,
-  rawFile: string,
-  lapDetectorVersion: string,
-  versionIdentity?: TelemetryVersionIdentity,
-): Promise<void> {
+export async function updateSessionRawFile(sessionId: number, rawFile: string, lapDetectorVersion: string, versionIdentity?: TelemetryVersionIdentity): Promise<void> {
   await db
     .update(sessions)
     .set({ rawFile, lapDetectorVersion, ...versionIdentity })
@@ -73,10 +228,21 @@ async function getAvailableStaleSessionRows(
     .select({ id: sessions.id, rawFile: sessions.rawFile })
     .from(sessions)
     .where(
-      and(
-        sql`${sessions.rawFile} IS NOT NULL`,
-        or(isNull(sessions.lapDetectorVersion), notInArray(sessions.lapDetectorVersion, ids))
-      )
+      or(
+        and(
+          sql`${sessions.rawFile} IS NOT NULL`,
+          or(
+            isNull(sessions.lapDetectorVersion),
+            notInArray(sessions.lapDetectorVersion, ids),
+            sql`${sessions.qualitySchemaVersion} IS NULL OR ${sessions.qualitySchemaVersion} <> ${QUALITY_SCHEMA_VERSION}`,
+          ),
+        ),
+        and(
+          sql`${sessions.recordingQuality} IS NOT NULL`,
+          sql`(${sessions.qualityPolicyVersion} IS NULL OR ${sessions.qualityPolicyVersion} <> ${ELIGIBILITY_POLICY_VERSION}
+            OR ${sessions.qualityConfigVersion} IS NULL OR ${sessions.qualityConfigVersion} <> ${QUALITY_CONFIG_VERSION})`,
+        ),
+      ),
     )
     .all();
   return rows.filter(
@@ -105,13 +271,7 @@ export async function getUncompressedSessions(olderThanMs: number): Promise<{ id
   const rows = await db
     .select({ id: sessions.id, rawFile: sessions.rawFile })
     .from(sessions)
-    .where(
-      and(
-        sql`${sessions.rawFile} IS NOT NULL`,
-        sql`${sessions.rawFile} NOT LIKE '%.gz'`,
-        sql`${sessions.createdAt} < ${cutoff}`
-      )
-    )
+    .where(and(sql`${sessions.rawFile} IS NOT NULL`, sql`${sessions.rawFile} NOT LIKE '%.gz'`, sql`${sessions.createdAt} < ${cutoff}`))
     .all();
   return rows.filter((r): r is { id: number; rawFile: string } => r.rawFile !== null);
 }
@@ -123,12 +283,7 @@ function isOwnedSessionRawFile(rawFile: string): boolean {
 
 async function unlinkOwnedSessionRawFile(rawFile: string | null): Promise<void> {
   if (!rawFile || !isOwnedSessionRawFile(rawFile)) return;
-  const stillReferenced = await db
-    .select({ id: sessions.id })
-    .from(sessions)
-    .where(eq(sessions.rawFile, rawFile))
-    .limit(1)
-    .get();
+  const stillReferenced = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.rawFile, rawFile)).limit(1).get();
   if (stillReferenced) return;
   try {
     if (existsSync(rawFile)) unlinkSync(rawFile);
@@ -137,17 +292,12 @@ async function unlinkOwnedSessionRawFile(rawFile: string | null): Promise<void> 
   }
 }
 
-
 /**
  * Delete a session and all its laps. Returns number of laps deleted.
  */
 
 export async function deleteSession(sessionId: number): Promise<number> {
-  const session = await db
-    .select({ rawFile: sessions.rawFile })
-    .from(sessions)
-    .where(eq(sessions.id, sessionId))
-    .get();
+  const session = await db.select({ rawFile: sessions.rawFile }).from(sessions).where(eq(sessions.id, sessionId)).get();
   const sessionLaps = await db.select({ id: laps.id }).from(laps).where(eq(laps.sessionId, sessionId)).all();
   let count = 0;
   for (const lap of sessionLaps) {
@@ -168,9 +318,7 @@ export async function deleteEmptySessions(activeSessionId?: number): Promise<num
     .groupBy(sessions.id)
     .having(sql`count(${laps.id}) = 0`)
     .all();
-  const filtered = activeSessionId
-    ? empties.filter((e) => e.id !== activeSessionId)
-    : empties;
+  const filtered = activeSessionId ? empties.filter((e) => e.id !== activeSessionId) : empties;
   if (filtered.length === 0) return 0;
   for (const { rawFile } of filtered) {
     if (!rawFile) continue;
@@ -180,7 +328,7 @@ export async function deleteEmptySessions(activeSessionId?: number): Promise<num
       console.warn(`[DB] Failed to unlink raw file ${rawFile}:`, err instanceof Error ? err.message : err);
     }
   }
-  const ids = filtered.map(r => r.id);
+  const ids = filtered.map((r) => r.id);
   await db.delete(sessions).where(inArray(sessions.id, ids)).run();
   return ids.length;
 }
@@ -200,20 +348,24 @@ export async function getSessions(gameId?: GameId): Promise<SessionMeta[]> {
       sessionType: sessions.sessionType,
       notes: sessions.notes,
       source: sessions.source,
+      sourceChannelProfile: sessions.sourceChannelProfile,
       catalogVersion: sessions.catalogVersion,
       catalogHash: sessions.catalogHash,
       catalogSchemaVersion: sessions.catalogSchemaVersion,
       parserVersion: sessions.parserVersion,
       resolverVersion: sessions.resolverVersion,
       derivationVersion: sessions.derivationVersion,
+      recordingQuality: sessions.recordingQuality,
+      qualitySchemaVersion: sessions.qualitySchemaVersion,
+      qualityPolicyVersion: sessions.qualityPolicyVersion,
+      qualityConfigVersion: sessions.qualityConfigVersion,
+      qualityGeneration: sessions.qualityGeneration,
       ownership: sessions.ownership,
     })
     .from(sessions)
     .orderBy(desc(sessions.id));
 
-  const rows = gameId
-    ? await query.where(eq(sessions.gameId, gameId)).all()
-    : await query.all();
+  const rows = gameId ? await query.where(eq(sessions.gameId, gameId)).all() : await query.all();
 
   // Get lap counts and best lap per session
   const result: SessionMeta[] = [];
@@ -222,14 +374,18 @@ export async function getSessions(gameId?: GameId): Promise<SessionMeta[]> {
       .select({
         id: laps.id,
         lapTime: laps.lapTime,
-        isValid: laps.isValid,
-        paceEligibility: laps.paceEligibility,
+        quality: laps.quality,
+        eligibility: laps.eligibility,
+        qualitySchemaVersion: laps.qualitySchemaVersion,
+        qualityPolicyVersion: laps.qualityPolicyVersion,
+        qualityConfigVersion: laps.qualityConfigVersion,
+        qualityGeneration: laps.qualityGeneration,
       })
       .from(laps)
       .where(eq(laps.sessionId, session.id))
       .all();
 
-    const validLaps = lapRows.filter((l) => l.isValid && l.paceEligibility === "eligible" && l.lapTime > 0);
+    const validLaps = lapRows.filter((lap) => isTimedLapEligibilityUsable(lap));
     const bestLapTime = validLaps.length > 0 ? Math.min(...validLaps.map((l) => l.lapTime)) : undefined;
     const normalizedSession = {
       ...session,
@@ -250,10 +406,10 @@ export async function getSessions(gameId?: GameId): Promise<SessionMeta[]> {
       .get();
     const pitDurationRow = resultRow
       ? await db
-        .select({ duration: sql<number | null>`sum(${pitEvents.durationSeconds})` })
-        .from(pitEvents)
-        .where(eq(pitEvents.resultId, resultRow.id))
-        .get()
+          .select({ duration: sql<number | null>`sum(${pitEvents.durationSeconds})` })
+          .from(pitEvents)
+          .where(eq(pitEvents.resultId, resultRow.id))
+          .get()
       : null;
     result.push({
       ...normalizedSession,
@@ -268,6 +424,7 @@ export async function getSessions(gameId?: GameId): Promise<SessionMeta[]> {
       pitDurationSeconds: pitDurationRow?.duration ?? null,
       notes: session.notes ?? undefined,
       source: (session.source as EvidenceSourceKind | null) ?? "unknown",
+      sourceChannelProfile: session.sourceChannelProfile ?? undefined,
       gameId: session.gameId as GameId,
       catalogVersion: session.catalogVersion ?? undefined,
       catalogHash: session.catalogHash ?? undefined,
@@ -275,6 +432,14 @@ export async function getSessions(gameId?: GameId): Promise<SessionMeta[]> {
       parserVersion: session.parserVersion ?? undefined,
       resolverVersion: session.resolverVersion ?? undefined,
       derivationVersion: session.derivationVersion ?? undefined,
+      recordingQuality: session.recordingQuality ?? undefined,
+      qualityGeneration: session.qualityGeneration ?? undefined,
+      qualityStale:
+        !session.recordingQuality ||
+        session.qualitySchemaVersion !== QUALITY_SCHEMA_VERSION ||
+        session.qualityPolicyVersion !== ELIGIBILITY_POLICY_VERSION ||
+        session.qualityConfigVersion !== QUALITY_CONFIG_VERSION ||
+        session.qualityGeneration !== session.recordingQuality.provenance.outputGeneration,
       ownership: session.ownership === "others" ? "others" : "mine",
     });
   }
@@ -325,6 +490,12 @@ export async function getSessionRecapData(
       phase: laps.phase,
       conditions: laps.conditions,
       paceEligibility: laps.paceEligibility,
+      eligibility: laps.eligibility,
+      quality: laps.quality,
+      qualitySchemaVersion: laps.qualitySchemaVersion,
+      qualityPolicyVersion: laps.qualityPolicyVersion,
+      qualityConfigVersion: laps.qualityConfigVersion,
+      qualityGeneration: laps.qualityGeneration,
       sectorTimes: laps.sectorTimes,
       invalidReason: laps.invalidReason,
     })
@@ -337,11 +508,7 @@ export async function getSessionRecapData(
   const sessionSectorCount =
     lapRows.find(
       (lap) =>
-        Boolean(lap.isValid) &&
-        lap.paceEligibility === "eligible" &&
-        lap.sectorTimes != null &&
-        lap.sectorTimes.length >= 2 &&
-        lap.sectorTimes.every((time) => time > 0),
+        isTimedLapEligibilityUsable(lap) && lap.sectorTimes != null && lap.sectorTimes.length >= 2 && lap.sectorTimes.every((time) => time > 0),
     )?.sectorTimes?.length ?? 0;
 
   let sectorStarts: number[] | null = null;
@@ -350,9 +517,7 @@ export async function getSessionRecapData(
     for (const row of lapRows) {
       if (row.sectorTimes?.length !== sessionSectorCount) continue;
       const lap = await getLapById(row.id);
-      const layout = lap?.telemetry
-        .map((packet) => gameAdapter.getNativeSectorLayout!(packet))
-        .find((candidate) => candidate?.starts.length === sessionSectorCount);
+      const layout = lap?.telemetry.map((packet) => gameAdapter.getNativeSectorLayout!(packet)).find((candidate) => candidate?.starts.length === sessionSectorCount);
       if (layout) {
         sectorStarts = [...layout.starts];
         break;
@@ -371,7 +536,8 @@ export async function getSessionRecapData(
         eq(sessions.gameId, gameId),
         sql`${sessions.id} != ${id}`,
         eq(laps.isValid, true),
-        eq(laps.paceEligibility, "eligible"),
+        analysisEligibility(laps, "normal-pace"),
+        currentQualitySnapshot(laps),
         sql`${laps.lapTime} > 0`,
       ),
     )
@@ -390,25 +556,23 @@ export async function getSessionRecapData(
         eq(sessions.gameId, gameId),
         sql`${sessions.id} != ${id}`,
         eq(laps.isValid, true),
-        eq(laps.paceEligibility, "eligible"),
+        analysisEligibility(laps, "normal-pace"),
+        currentQualitySnapshot(laps),
         sql`${laps.lapTime} > 0`,
         sql`${laps.sectorTimes} IS NOT NULL`,
       ),
     )
     .all();
-  const allTimeBestSectors = otherSectorRows.reduce<Array<number | null>>(
-    (best, row) => {
-      if (row.sectorTimes?.length !== sessionSectorCount) return best;
-      for (let index = 0; index < (row.sectorTimes?.length ?? 0); index++) {
-        const time = row.sectorTimes![index];
-        if (time > 0 && (best[index] === undefined || best[index] === null || time < best[index]!)) {
-          best[index] = time;
-        }
+  const allTimeBestSectors = otherSectorRows.reduce<Array<number | null>>((best, row) => {
+    if (row.sectorTimes?.length !== sessionSectorCount) return best;
+    for (let index = 0; index < (row.sectorTimes?.length ?? 0); index++) {
+      const time = row.sectorTimes![index];
+      if (time > 0 && (best[index] === undefined || best[index] === null || time < best[index]!)) {
+        best[index] = time;
       }
-      return best;
-    },
-    [],
-  );
+    }
+    return best;
+  }, []);
 
   return {
     session: {
@@ -422,8 +586,7 @@ export async function getSessionRecapData(
     laps: lapRows.map((l) => ({ ...l, isValid: Boolean(l.isValid) })),
     trackLengthM,
     allTimeBestSec: bestOtherRow?.lapTime ?? null,
-    allTimeBestSectors:
-      allTimeBestSectors.length > 0 ? allTimeBestSectors : null,
+    allTimeBestSectors: allTimeBestSectors.length > 0 ? allTimeBestSectors : null,
     sectorStarts,
   };
 }

--- a/server/db/session-result-queries.ts
+++ b/server/db/session-result-queries.ts
@@ -1,8 +1,11 @@
-import { eq, desc, and, inArray, ne, or, isNull } from "drizzle-orm";
+import { finalizeLapQualityGeneration } from "../lap-analysis/quality-generation";
+import { and, desc, eq, inArray, isNull, ne, or } from "drizzle-orm";
 import { db } from "./index";
-import { laps, sessions, sessionResults, pitEvents } from "./schema";
-import type { GameId } from "../../shared/games/ids";
-import type { RaceResultEvidence, RaceResultOutcomeStatus, RaceResultProvenance, RaceResultStatus } from "../../shared/racing/results/types";
+import { compareAnalyses, lapAnalyses, laps, pitEvents, sessionResults, sessions } from "./schema";
+
+import { type GameId } from "../../shared/games/ids";
+import type { RaceResultEvidence, RaceResultLapQualityEvidence, RaceResultOutcomeStatus, RaceResultProvenance, RaceResultStatus } from "../../shared/racing/results/types";
+import { resolveEligibilityDecision } from "../../shared/racing/quality/policies";
 
 const UNAVAILABLE_RACE_RESULT_EVIDENCE: RaceResultEvidence = {
   fieldStatus: {
@@ -32,7 +35,38 @@ const LEGACY_RACE_RESULT_PROVENANCE: RaceResultProvenance = {
   authorityPolicyId: "legacy-outcome-status",
   authorityPolicyVersion: "unavailable",
 };
+export async function loadRaceResultLapQuality(sessionIds: readonly number[]): Promise<Map<number, RaceResultLapQualityEvidence[]>> {
+  const result = new Map<number, RaceResultLapQualityEvidence[]>();
+  if (sessionIds.length === 0) return result;
 
+  const rows = await db
+    .select({
+      id: laps.id,
+      sessionId: laps.sessionId,
+      lapNumber: laps.lapNumber,
+      quality: laps.quality,
+      eligibility: laps.eligibility,
+      qualityGeneration: laps.qualityGeneration,
+    })
+    .from(laps)
+    .where(inArray(laps.sessionId, [...sessionIds]))
+    .orderBy(laps.sessionId, laps.lapNumber, laps.id)
+    .all();
+
+  for (const row of rows) {
+    const evidence: RaceResultLapQualityEvidence = {
+      lapId: row.id,
+      lapNumber: row.lapNumber,
+      qualityGeneration: row.qualityGeneration,
+      officialTiming: resolveEligibilityDecision(row, "official-timing"),
+      normalPace: resolveEligibilityDecision(row, "normal-pace"),
+    };
+    const sessionQuality = result.get(row.sessionId);
+    if (sessionQuality) sessionQuality.push(evidence);
+    else result.set(row.sessionId, [evidence]);
+  }
+  return result;
+}
 
 export type SessionResultInput = {
   sessionId: number;
@@ -69,32 +103,95 @@ export type PitEventInput = {
   source: unknown;
 };
 
-async function markPitCycleLaps(sessionId: number, events: readonly PitEventInput[]): Promise<void> {
-  const inlapNumbers = [...new Set(events.filter((event) => (event.eventType ?? "pit") === "pit" && event.linkage === "linked" && event.lapNumber !== null).map((event) => event.lapNumber!))];
+type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
-  await db
+async function markPitCycleLaps(tx: DbTransaction, sessionId: number, events: readonly PitEventInput[]): Promise<void> {
+  const inlapNumbers = [...new Set(events.filter((event) => (event.eventType ?? "pit") === "pit" && event.linkage === "linked" && event.lapNumber !== null).map((event) => event.lapNumber!))];
+  if (inlapNumbers.length === 0) return;
+  const outlapNumbers = inlapNumbers.map((lapNumber) => lapNumber + 1);
+
+  await tx
     .update(laps)
-    .set({ isValid: false, invalidReason: "inlap" })
-    .where(and(eq(laps.sessionId, sessionId), eq(laps.isValid, true), inArray(laps.lapNumber, inlapNumbers)))
+    .set({ phase: "in", paceEligibility: "excluded" })
+    .where(and(eq(laps.sessionId, sessionId), inArray(laps.lapNumber, inlapNumbers)))
     .run();
-  await db
+  await tx
     .update(laps)
-    .set({ isValid: false, invalidReason: "outlap" })
-    .where(and(eq(laps.sessionId, sessionId), eq(laps.isValid, true), inArray(laps.lapNumber, inlapNumbers.map((lapNumber) => lapNumber + 1))))
+    .set({ phase: "out", paceEligibility: "excluded" })
+    .where(and(eq(laps.sessionId, sessionId), inArray(laps.lapNumber, outlapNumbers)))
     .run();
+
+  const session = await tx.select({ recordingQuality: sessions.recordingQuality }).from(sessions).where(eq(sessions.id, sessionId)).get();
+  const affectedLaps = await tx
+    .select({
+      id: laps.id,
+      lapNumber: laps.lapNumber,
+      phase: laps.phase,
+      conditions: laps.conditions,
+      paceEligibility: laps.paceEligibility,
+      rawByteOffset: laps.rawByteOffset,
+      rawFrameCount: laps.rawFrameCount,
+      quality: laps.quality,
+      qualitySchemaVersion: laps.qualitySchemaVersion,
+      qualityPolicyVersion: laps.qualityPolicyVersion,
+      qualityConfigVersion: laps.qualityConfigVersion,
+      qualityGeneration: laps.qualityGeneration,
+    })
+    .from(laps)
+    .where(and(eq(laps.sessionId, sessionId), inArray(laps.lapNumber, [...new Set([...inlapNumbers, ...outlapNumbers])])))
+    .all();
+  const changedLapIds: number[] = [];
+
+  for (const lap of affectedLaps) {
+    if (!lap.quality) continue;
+    const quality = {
+      ...lap.quality,
+      classification: {
+        phase: lap.phase,
+        conditions: lap.conditions,
+        paceEligibility: lap.paceEligibility,
+      },
+    };
+    const generated = finalizeLapQualityGeneration(quality, session?.recordingQuality?.provenance.sourceGeneration ?? "legacy", {
+      lapNumber: lap.lapNumber,
+      rawByteOffset: lap.rawByteOffset,
+      rawFrameCount: lap.rawFrameCount ?? 0,
+    });
+    if (
+      generated.quality.provenance.outputGeneration === lap.qualityGeneration &&
+      generated.quality.provenance.schemaVersion === lap.qualitySchemaVersion &&
+      generated.quality.provenance.policyVersion === lap.qualityPolicyVersion &&
+      generated.quality.provenance.configurationVersion === lap.qualityConfigVersion
+    ) {
+      continue;
+    }
+    await tx
+      .update(laps)
+      .set({
+        quality: generated.quality,
+        eligibility: generated.eligibility,
+        qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+        qualityPolicyVersion: generated.quality.provenance.policyVersion,
+        qualityConfigVersion: generated.quality.provenance.configurationVersion,
+        qualityGeneration: generated.quality.provenance.outputGeneration,
+      })
+      .where(eq(laps.id, lap.id))
+      .run();
+    changedLapIds.push(lap.id);
+  }
+
+  if (changedLapIds.length > 0) {
+    await tx.delete(lapAnalyses).where(inArray(lapAnalyses.lapId, changedLapIds)).run();
+    await tx
+      .delete(compareAnalyses)
+      .where(or(inArray(compareAnalyses.lapAId, changedLapIds), inArray(compareAnalyses.lapBId, changedLapIds)))
+      .run();
+  }
 }
 
-
-export async function upsertSessionResult(
-  input: SessionResultInput,
-  events?: PitEventInput[],
-): Promise<{ id: number; changed: boolean }> {
+export async function upsertSessionResult(input: SessionResultInput, events?: PitEventInput[]): Promise<{ id: number; changed: boolean }> {
   const result = await db.transaction(async (tx) => {
-    const existing = await tx
-      .select({ id: sessionResults.id })
-      .from(sessionResults)
-      .where(eq(sessionResults.sessionId, input.sessionId))
-      .get();
+    const existing = await tx.select({ id: sessionResults.id }).from(sessionResults).where(eq(sessionResults.sessionId, input.sessionId)).get();
     const values = {
       sessionId: input.sessionId,
       processorVersion: input.processorVersion ?? "race-result-v2",
@@ -113,9 +210,7 @@ export async function upsertSessionResult(
       reasons: input.reasons,
       updatedAt: new Date().toISOString(),
     };
-    const id = existing
-      ? existing.id
-      : (await tx.insert(sessionResults).values(values).returning({ id: sessionResults.id }).get()).id;
+    const id = existing ? existing.id : (await tx.insert(sessionResults).values(values).returning({ id: sessionResults.id }).get()).id;
     if (existing) {
       await tx.update(sessionResults).set(values).where(eq(sessionResults.id, existing.id)).run();
     }
@@ -124,25 +219,23 @@ export async function upsertSessionResult(
       if (events.length > 0) {
         await tx.insert(pitEvents).values(events.map((event) => ({ resultId: id, ...event })));
       }
+      await markPitCycleLaps(tx, input.sessionId, events);
     }
     return { id, changed: true };
   });
-  if (events !== undefined) await markPitCycleLaps(input.sessionId, events);
   return result;
 }
 
-
 export async function replacePitEvents(resultId: number, events: PitEventInput[]): Promise<void> {
-  const result = await db.select({ sessionId: sessionResults.sessionId }).from(sessionResults).where(eq(sessionResults.id, resultId)).get();
   await db.transaction(async (tx) => {
+    const result = await tx.select({ sessionId: sessionResults.sessionId }).from(sessionResults).where(eq(sessionResults.id, resultId)).get();
     await tx.delete(pitEvents).where(eq(pitEvents.resultId, resultId));
     if (events.length > 0) {
       await tx.insert(pitEvents).values(events.map((event) => ({ resultId, ...event })));
     }
+    if (result) await markPitCycleLaps(tx, result.sessionId, events);
   });
-  if (result) await markPitCycleLaps(result.sessionId, events);
 }
-
 
 export async function getSessionResult(sessionId: number, gameId: GameId) {
   const row = await db
@@ -152,12 +245,10 @@ export async function getSessionResult(sessionId: number, gameId: GameId) {
     .where(and(eq(sessionResults.sessionId, sessionId), eq(sessions.gameId, gameId)))
     .get();
   if (!row) return null;
-  const events = await db
-    .select()
-    .from(pitEvents)
-    .where(eq(pitEvents.resultId, row.result.id))
-    .orderBy(pitEvents.sequence)
-    .all();
+  const [events, lapQualityBySession] = await Promise.all([
+    db.select().from(pitEvents).where(eq(pitEvents.resultId, row.result.id)).orderBy(pitEvents.sequence).all(),
+    loadRaceResultLapQuality([sessionId]),
+  ]);
   return {
     ...row.result,
     gameId: row.gameId as GameId,
@@ -165,6 +256,7 @@ export async function getSessionResult(sessionId: number, gameId: GameId) {
     provenance: row.result.provenance ?? LEGACY_RACE_RESULT_PROVENANCE,
     evidence: row.result.evidence ?? UNAVAILABLE_RACE_RESULT_EVIDENCE,
     reasons: row.result.reasons ?? [],
+    lapQuality: lapQualityBySession.get(sessionId) ?? [],
     events,
   };
 }
@@ -180,12 +272,20 @@ export async function getRecentSessionResults(gameId: GameId, limit: number) {
     .all();
   if (rows.length === 0) return [];
 
-  const storedEvents = await db
-    .select()
-    .from(pitEvents)
-    .where(inArray(pitEvents.resultId, rows.map((row) => row.result.id)))
-    .orderBy(pitEvents.resultId, pitEvents.sequence)
-    .all();
+  const [storedEvents, lapQualityBySession] = await Promise.all([
+    db
+      .select()
+      .from(pitEvents)
+      .where(
+        inArray(
+          pitEvents.resultId,
+          rows.map((row) => row.result.id),
+        ),
+      )
+      .orderBy(pitEvents.resultId, pitEvents.sequence)
+      .all(),
+    loadRaceResultLapQuality(rows.map((row) => row.result.sessionId)),
+  ]);
   const eventsByResult = new Map<number, typeof storedEvents>();
   for (const event of storedEvents) {
     const events = eventsByResult.get(event.resultId);
@@ -200,6 +300,7 @@ export async function getRecentSessionResults(gameId: GameId, limit: number) {
     provenance: row.result.provenance ?? LEGACY_RACE_RESULT_PROVENANCE,
     evidence: row.result.evidence ?? UNAVAILABLE_RACE_RESULT_EVIDENCE,
     reasons: row.result.reasons ?? [],
+    lapQuality: lapQualityBySession.get(row.result.sessionId) ?? [],
 
     events: eventsByResult.get(row.result.id) ?? [],
   }));
@@ -209,12 +310,7 @@ export async function countStaleRaceResults(currentProcessorVersion: string): Pr
     .select({ sessionId: sessions.id })
     .from(sessions)
     .leftJoin(sessionResults, eq(sessionResults.sessionId, sessions.id))
-    .where(
-      or(
-        isNull(sessionResults.id),
-        ne(sessionResults.processorVersion, currentProcessorVersion),
-      ),
-    )
+    .where(or(isNull(sessionResults.id), ne(sessionResults.processorVersion, currentProcessorVersion)))
     .all();
   return rows.length;
 }
@@ -224,12 +320,7 @@ export async function getStaleRaceResultSessionIds(currentProcessorVersion: stri
     .select({ sessionId: sessions.id })
     .from(sessions)
     .leftJoin(sessionResults, eq(sessionResults.sessionId, sessions.id))
-    .where(
-      or(
-        isNull(sessionResults.id),
-        ne(sessionResults.processorVersion, currentProcessorVersion),
-      ),
-    )
+    .where(or(isNull(sessionResults.id), ne(sessionResults.processorVersion, currentProcessorVersion)))
     .orderBy(sessions.id)
     .all();
   return rows.map((row) => row.sessionId);

--- a/server/games/iracing/lap-detector.ts
+++ b/server/games/iracing/lap-detector.ts
@@ -143,6 +143,10 @@ export class LapDetectorIRacing implements ILapDetector {
     await this.detector.finalizeCurrentSession();
   }
 
+  async waitForPendingLapWrites(): Promise<void> {
+    await this.detector.waitForPendingLapWrites();
+  }
+
   getDebugState(): Record<string, unknown> {
     return {
       ...this.detector.getDebugState(),

--- a/server/games/kunos/lap-detector.ts
+++ b/server/games/kunos/lap-detector.ts
@@ -1,22 +1,26 @@
 import type { TelemetryPacket } from "../../../shared/telemetry/types";
-import type { DbAdapter } from "../../telemetry/pipeline-ports";
+import { currentTelemetryVersionIdentity, type DbAdapter } from "../../telemetry/pipeline-ports";
+import { LOCAL_PLAYER_EVIDENCE, type EvidenceSourceKind, type ParticipantEvidence, type SourceChannelProfile } from "../../../shared/racing/quality/contracts";
+import { summarizeLapQuality } from "../../../shared/racing/quality/measure";
+import { evaluateAllEligibility, isEligibilityUsable } from "../../../shared/racing/quality/policies";
+import type { TelemetryVersionIdentity } from "../../../shared/telemetry/version";
 import { persistLapMetrics } from "../../lap-analysis/metrics-store";
 import { assessLapRecording } from "../../lap-analysis/quality";
 import { reconcileAutoExclusionsForLap } from "../../experiments/auto-exclude";
 import { computeLapSectors } from "../../lap-analysis/sectors";
-import type {
-  ILapDetector,
-  LapDetectorCallbacks,
-  LapDetectorOptions,
-  SessionState,
-} from "../../lap-detection/types";
+import type { ILapDetector, LapDetectorCallbacks, LapDetectorOptions, SessionState } from "../../lap-detection/types";
 import { kunosFirstPacketIsMidLap } from "./lap-rules";
 import { classifyLap } from "../../../shared/racing/laps/classification";
+import { classifyPitCycle } from "../../../shared/racing/laps/pit-cycle";
 
 /** Shared Kunos (ACC / AC Evo) lap detector state machine. */
 export abstract class KunosLapDetector implements ILapDetector {
   readonly detectorId: string;
   private readonly loggerLabel: string;
+  private readonly sourceKind: EvidenceSourceKind;
+  private readonly participant: ParticipantEvidence;
+  private readonly versionIdentity?: TelemetryVersionIdentity;
+  private readonly sourceChannelProfile?: SourceChannelProfile;
 
   protected readonly db: DbAdapter;
   private readonly onLapSaved?: LapDetectorCallbacks["onLapSaved"];
@@ -42,12 +46,12 @@ export abstract class KunosLapDetector implements ILapDetector {
   private _lapFrameCount = 0;
   private _currentRawByteOffset: number | null = null;
   private _lastActivePacketTime = 0;
-  protected constructor(
-    opts: LapDetectorOptions,
-    detectorId: string,
-    loggerLabel: string,
-  ) {
+  protected constructor(opts: LapDetectorOptions, detectorId: string, loggerLabel: string) {
     this.db = opts.db;
+    this.sourceKind = opts.sourceKind ?? "native-live";
+    this.participant = opts.participant ?? LOCAL_PLAYER_EVIDENCE;
+    this.versionIdentity = opts.versionIdentity;
+    this.sourceChannelProfile = opts.sourceChannelProfile;
     this.onLapSaved = opts.callbacks?.onLapSaved;
     this.onSessionStart = opts.callbacks?.onSessionStart;
     this.onLapComplete_ = opts.callbacks?.onLapComplete;
@@ -77,13 +81,15 @@ export abstract class KunosLapDetector implements ILapDetector {
     }
     if (!this.currentSession) {
       const carOrdinalResult = this.resolveCarOrdinal(packet);
-      const resolvedCarOrdinal =
-        typeof carOrdinalResult === "number" ? carOrdinalResult : await carOrdinalResult;
+      const resolvedCarOrdinal = typeof carOrdinalResult === "number" ? carOrdinalResult : await carOrdinalResult;
       const sessionId = await this.db.insertSession(
         resolvedCarOrdinal,
         packet.TrackOrdinal ?? 0,
         packet.gameId,
         packet.f1?.sessionType,
+        this.versionIdentity,
+        this.sourceKind,
+        this.sourceChannelProfile,
       );
       this.currentSession = {
         sessionId,
@@ -126,7 +132,7 @@ export abstract class KunosLapDetector implements ILapDetector {
         const bufStart = this.lapBuffer[0]?.DistanceTraveled ?? 0;
         const bufEnd = this.lapBuffer[this.lapBuffer.length - 1]?.DistanceTraveled ?? 0;
         const bufDist = bufEnd - bufStart;
-        const isPitOnly = classifyLap(this.lapBuffer).phase === "pit";
+        const isPitOnly = classifyPitCycle(this.lapBuffer) === "pit";
         if (bufDist < 100 || isPitOnly) {
           this.lapBuffer = [];
           this.peakCurrentLap = 0;
@@ -155,11 +161,7 @@ export abstract class KunosLapDetector implements ILapDetector {
   }
 
   async flushStaleLap(): Promise<void> {
-    if (
-      !this.currentSession ||
-      this._lastActivePacketTime === 0 ||
-      Date.now() - this._lastActivePacketTime < 10_000
-    ) return;
+    if (!this.currentSession || this._lastActivePacketTime === 0 || Date.now() - this._lastActivePacketTime < 10_000) return;
     // Packets stopped arriving for 10s — end the session so next race start
     // creates a fresh session.
     await this.finalizeCurrentSession();
@@ -184,10 +186,7 @@ export abstract class KunosLapDetector implements ILapDetector {
     this.currentLapNumber = -1;
   }
 
-  private async emitLap(
-    forcedInvalidReason: string | null,
-    opts?: { silent?: boolean; trigger?: TelemetryPacket },
-  ): Promise<void> {
+  private async emitLap(forcedInvalidReason: string | null, opts?: { silent?: boolean; trigger?: TelemetryPacket }): Promise<void> {
     // Kunos publishes LastLap around the timer reset. Use it only when the
     // trigger's value is fresh relative to the last buffered frame.
     const lastBufferedLastLap = this.lapBuffer[this.lapBuffer.length - 1]?.LastLap ?? 0;
@@ -221,34 +220,47 @@ export abstract class KunosLapDetector implements ILapDetector {
         invalidReason = cutReason;
       }
     }
-
-    const sectors = await computeLapSectors(
-      this.currentSession!.trackOrdinal,
-      this.currentSession!.gameId,
+    const versionIdentity = this.versionIdentity ?? currentTelemetryVersionIdentity(this.currentSession!.gameId);
+    const quality = summarizeLapQuality({
       packets,
       lapTime,
-      undefined,
-    );
+      timingSource: !complete ? "estimated" : gameLastLapFresh ? "simulator-last-lap" : "telemetry-elapsed",
+      complete,
+      structurallyValid: isValid,
+      invalidReason,
+      classification,
+      sourceKind: this.sourceKind,
+      participant: this.participant,
+      versionIdentity,
+      sourceChannelProfile: this.sourceChannelProfile,
+    });
+    const eligibility = evaluateAllEligibility(quality);
+    const normalPaceEligible =
+      isValid &&
+      classification.paceEligibility === "eligible" &&
+      isEligibilityUsable(eligibility["normal-pace"]);
+    const sectors = await computeLapSectors(this.currentSession!.trackOrdinal, this.currentSession!.gameId, packets, lapTime, undefined);
 
-    const normalPaceEligible = isValid && classification.paceEligibility === "eligible";
     if (normalPaceEligible && (this.currentSession!.bestLapTime === 0 || lapTime < this.currentSession!.bestLapTime)) {
       this.currentSession!.bestLapTime = lapTime;
     }
 
-    const lapId = await this.db.insertLap(
-      this.currentSession!.sessionId,
-      lapNum,
+    const lapId = await this.db.insertLap({
+      sessionId: this.currentSession!.sessionId,
+      lapNumber: lapNum,
       lapTime,
       isValid,
-      lapByteOffset,
-      lapFrameCount,
-      null,
-      null,
+      rawByteOffset: lapByteOffset,
+      rawFrameCount: lapFrameCount,
+      profileId: null,
+      tuneId: null,
       invalidReason,
       sectors,
-      undefined,
       classification,
-    );
+      quality,
+      eligibility,
+      versionIdentity,
+    });
     // Precompute fuel/tyre metrics now (frames already in memory) so
     // /lap-metrics never decodes on first open.
     await persistLapMetrics(this.db, lapId, packets);
@@ -256,7 +268,18 @@ export abstract class KunosLapDetector implements ILapDetector {
     // scope.
     await reconcileAutoExclusionsForLap(this.db, lapId);
     if (!opts?.silent) {
-
+      if (normalPaceEligible) {
+        this.onLapComplete_?.({
+          packets,
+          lapDistStart: packets[0]?.DistanceTraveled ?? 0,
+          lapTime,
+          isValid,
+          ...classification,
+          sectors,
+          quality,
+          eligibility,
+        });
+      }
       this.onLapSaved?.({
         type: "lap-saved",
         lapId,
@@ -266,17 +289,9 @@ export abstract class KunosLapDetector implements ILapDetector {
         ...classification,
         sectors,
         estimatedBestLapTime: this.currentSession!.bestLapTime,
+        quality,
+        eligibility,
       });
-      if (normalPaceEligible) {
-        this.onLapComplete_?.({
-          packets,
-          lapDistStart: packets[0]?.DistanceTraveled ?? 0,
-          lapTime,
-          isValid,
-          ...classification,
-          sectors,
-        });
-      }
     }
   }
 

--- a/server/lap-analysis/metrics-store.ts
+++ b/server/lap-analysis/metrics-store.ts
@@ -3,17 +3,10 @@ import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { GameId } from "../../shared/games/ids";
 import type { LapInsight } from "../../shared/racing/analysis/laps/insights/types";
 import { db } from "../db";
-import { lapMetrics } from "../db/schema";
+import { lapMetrics, laps } from "../db/schema";
 import { getLapById, getLapsByIds } from "../db/lap-read-queries";
 import { resolveTrack } from "../tracks/info";
-import {
-  computeLapMetrics,
-  deriveFuelPerLap,
-  deriveTyreWear,
-  LAP_METRICS_ALGO_VERSION,
-  type LapMetrics,
-  type SegmentStat,
-} from "./metrics";
+import { computeLapMetrics, deriveFuelPerLap, deriveTyreWear, LAP_METRICS_ALGO_VERSION, type LapMetrics, type SegmentStat } from "./metrics";
 
 /** Minimal DB surface persistLapMetrics needs (DbAdapter satisfies it). */
 interface LapMetricsWriter {
@@ -21,11 +14,7 @@ interface LapMetricsWriter {
 }
 
 /** Derive fuel + tyre metrics from in-memory frames and persist them on the lap row. */
-export async function persistLapMetrics(
-  writer: LapMetricsWriter,
-  lapId: number,
-  packets: TelemetryPacket[],
-): Promise<void> {
+export async function persistLapMetrics(writer: LapMetricsWriter, lapId: number, packets: TelemetryPacket[]): Promise<void> {
   const fuelPerLap = deriveFuelPerLap(packets) ?? null;
   const tyreWear = deriveTyreWear(packets) ?? null;
   if (fuelPerLap == null && tyreWear == null) return;
@@ -38,10 +27,11 @@ interface MetricsRow {
   insights: string;
   segmentStats: string;
   computedAt: string;
+  qualityGeneration: string | null;
 }
 
-function rowToMetrics(row: MetricsRow): LapMetrics | null {
-  if (row.algoVersion !== LAP_METRICS_ALGO_VERSION) return null;
+function rowToMetrics(row: MetricsRow, currentQualityGeneration: string | null): LapMetrics | null {
+  if (row.algoVersion !== LAP_METRICS_ALGO_VERSION || currentQualityGeneration == null || row.qualityGeneration !== currentQualityGeneration) return null;
   try {
     return {
       lapId: row.lapId,
@@ -55,7 +45,7 @@ function rowToMetrics(row: MetricsRow): LapMetrics | null {
   }
 }
 
-async function persist(metrics: LapMetrics): Promise<void> {
+async function persist(metrics: LapMetrics, qualityGeneration: string | null): Promise<void> {
   const insights = JSON.stringify(metrics.insights);
   const segmentStats = JSON.stringify(metrics.segmentStats);
   await db
@@ -65,6 +55,7 @@ async function persist(metrics: LapMetrics): Promise<void> {
       algoVersion: metrics.algoVersion,
       insights,
       segmentStats,
+      qualityGeneration,
       computedAt: metrics.computedAt,
     })
     .onConflictDoUpdate({
@@ -73,15 +64,29 @@ async function persist(metrics: LapMetrics): Promise<void> {
         algoVersion: metrics.algoVersion,
         insights,
         segmentStats,
+        qualityGeneration,
         computedAt: metrics.computedAt,
       },
     });
 }
 
 export async function getOrComputeLapMetrics(lapId: number): Promise<LapMetrics | null> {
-  const existing = await db.select().from(lapMetrics).where(eq(lapMetrics.lapId, lapId)).get();
+  const existing = await db
+    .select({
+      lapId: lapMetrics.lapId,
+      algoVersion: lapMetrics.algoVersion,
+      insights: lapMetrics.insights,
+      segmentStats: lapMetrics.segmentStats,
+      computedAt: lapMetrics.computedAt,
+      qualityGeneration: lapMetrics.qualityGeneration,
+      currentQualityGeneration: laps.qualityGeneration,
+    })
+    .from(lapMetrics)
+    .innerJoin(laps, eq(lapMetrics.lapId, laps.id))
+    .where(eq(lapMetrics.lapId, lapId))
+    .get();
   if (existing) {
-    const hit = rowToMetrics(existing);
+    const hit = rowToMetrics(existing, existing.currentQualityGeneration);
     if (hit) return hit;
   }
 
@@ -89,8 +94,8 @@ export async function getOrComputeLapMetrics(lapId: number): Promise<LapMetrics 
   if (!lap || lap.telemetry.length === 0 || !lap.gameId) return null;
 
   const segments = resolveTrack(lap.gameId, lap.trackOrdinal).segments;
-  const metrics = computeLapMetrics(lapId, lap.telemetry, lap.gameId as GameId, segments);
-  await persist(metrics);
+  const metrics = computeLapMetrics(lapId, lap.telemetry, lap.gameId as GameId, segments, lap.quality);
+  await persist(metrics, lap.qualityGeneration ?? null);
   return metrics;
 }
 
@@ -99,21 +104,34 @@ export async function getOrComputeLapMetricsBatch(lapIds: number[]): Promise<Map
   if (lapIds.length === 0) return output;
 
   const ids = [...new Set(lapIds)];
-  const rows = await db.select().from(lapMetrics).where(inArray(lapMetrics.lapId, ids)).all();
+  const rows = await db
+    .select({
+      lapId: lapMetrics.lapId,
+      algoVersion: lapMetrics.algoVersion,
+      insights: lapMetrics.insights,
+      segmentStats: lapMetrics.segmentStats,
+      computedAt: lapMetrics.computedAt,
+      qualityGeneration: lapMetrics.qualityGeneration,
+      currentQualityGeneration: laps.qualityGeneration,
+    })
+    .from(lapMetrics)
+    .innerJoin(laps, eq(lapMetrics.lapId, laps.id))
+    .where(inArray(lapMetrics.lapId, ids))
+    .all();
   for (const row of rows) {
-    const hit = rowToMetrics(row);
+    const hit = rowToMetrics(row, row.currentQualityGeneration);
     if (hit) output.set(hit.lapId, hit);
   }
 
   const missing = ids.filter((id) => !output.has(id));
   if (missing.length === 0) return output;
 
-  const laps = await getLapsByIds(missing);
-  for (const lap of laps) {
+  const loadedLaps = await getLapsByIds(missing);
+  for (const lap of loadedLaps) {
     if (lap.telemetry.length === 0 || !lap.gameId) continue;
     const segments = resolveTrack(lap.gameId, lap.trackOrdinal).segments;
-    const metrics = computeLapMetrics(lap.id, lap.telemetry, lap.gameId as GameId, segments);
-    await persist(metrics);
+    const metrics = computeLapMetrics(lap.id, lap.telemetry, lap.gameId as GameId, segments, lap.quality);
+    await persist(metrics, lap.qualityGeneration ?? null);
     output.set(lap.id, metrics);
   }
   return output;

--- a/server/lap-analysis/metrics.ts
+++ b/server/lap-analysis/metrics.ts
@@ -9,13 +9,14 @@ import { tryGetGame } from "../../shared/games/registry";
 import type { NamedSegment } from "../../shared/racing/tracks/named-segments";
 import type { GameId } from "../../shared/games/ids";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
+import type { LapQualitySummary } from "../../shared/racing/quality/contracts";
 
 /**
  * Bump when any detector or segment-stat definition changes, so cached rows
  * from the old definition are discarded instead of silently mixing with new
  * ones inside a single experiment.
  */
-export const LAP_METRICS_ALGO_VERSION = 1;
+export const LAP_METRICS_ALGO_VERSION = 2;
 
 const MPH_TO_KMH = 1.609344;
 
@@ -109,16 +110,7 @@ export function steerScaleFor(gameId: string | undefined): SteerScale {
  * own index bounds, and re-deriving them from distances inside here would make
  * the resampled case do a redundant search.
  */
-export function computeStatsRange(
-  throttle: number[],
-  brake: number[],
-  steer: number[],
-  speedMph: number[],
-  distances: number[],
-  startIdx: number,
-  endIdx: number,
-  steerScale: SteerScale,
-): InputStats {
+export function computeStatsRange(throttle: number[], brake: number[], steer: number[], speedMph: number[], distances: number[], startIdx: number, endIdx: number, steerScale: SteerScale): InputStats {
   const lo = Math.max(0, Math.min(startIdx, throttle.length - 1));
   const hi = Math.max(lo + 1, Math.min(endIdx, throttle.length));
   const n = hi - lo;
@@ -267,11 +259,7 @@ function extractChannels(packets: TelemetryPacket[]): LapChannels {
  *
  * Pure: no DB, no track lookup. `getOrComputeLapMetrics` supplies the segments.
  */
-function computeLapSegmentStats(
-  packets: TelemetryPacket[],
-  segments: NamedSegment[],
-  steerScale: SteerScale,
-): SegmentStat[] {
+function computeLapSegmentStats(packets: TelemetryPacket[], segments: NamedSegment[], steerScale: SteerScale): SegmentStat[] {
   if (packets.length < 2 || segments.length === 0) return [];
 
   const ch = extractChannels(packets);
@@ -307,16 +295,11 @@ function computeLapSegmentStats(
 }
 
 /** Compute (but do not persist) metrics for an already-decoded lap. */
-export function computeLapMetrics(
-  lapId: number,
-  packets: TelemetryPacket[],
-  gameId: GameId,
-  segments: NamedSegment[],
-): LapMetrics {
+export function computeLapMetrics(lapId: number, packets: TelemetryPacket[], gameId: GameId, segments: NamedSegment[], quality: LapQualitySummary | null | undefined): LapMetrics {
   return {
     lapId,
     algoVersion: LAP_METRICS_ALGO_VERSION,
-    insights: analyzeLap(packets, gameId),
+    insights: analyzeLap(packets, gameId, quality),
     segmentStats: computeLapSegmentStats(packets, segments, steerScaleFor(gameId)),
     computedAt: new Date().toISOString(),
   };
@@ -415,4 +398,3 @@ export function deriveTyreWear(packets: TelemetryPacket[]): number | undefined {
   }
   return undefined;
 }
-

--- a/server/lap-analysis/quality-generation.ts
+++ b/server/lap-analysis/quality-generation.ts
@@ -1,0 +1,119 @@
+import { createHash } from "node:crypto";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecisionSet,
+  type LapQualitySummary,
+  type QualityFact,
+  type QualityProvenance,
+  type RecordingQualitySummary,
+} from "../../shared/racing/quality/contracts";
+import { evaluateAllEligibility } from "../../shared/racing/quality/policies";
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, stableValue(child)]),
+    );
+  }
+  return value;
+}
+
+function generation(value: unknown): string {
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify(stableValue(value)))
+    .digest("hex")}`;
+}
+
+function replaceFactProvenance(facts: readonly QualityFact[], provenance: QualityProvenance): QualityFact[] {
+  return facts.map((fact) => ({ ...fact, provenance }));
+}
+export function combineQualityGenerations(generations: readonly string[]): string {
+  return generation({ kind: "quality-cache", generations: [...generations].sort() });
+}
+
+export function finalizeRecordingQualityGeneration(summary: RecordingQualitySummary): RecordingQualitySummary {
+  const archiveGeneration = summary.archiveVerification.sourceGeneration;
+  const sourceGeneration =
+    archiveGeneration === "legacy"
+      ? "legacy"
+      : generation({
+          archiveGeneration,
+          participant: summary.participant,
+          sourceKind: summary.sourceKind,
+          versionIdentity: summary.versionIdentity,
+        });
+  const draftProvenance: QualityProvenance = {
+    ...summary.provenance,
+    schemaVersion: QUALITY_SCHEMA_VERSION,
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+    configurationVersion: QUALITY_CONFIG_VERSION,
+    sourceGeneration,
+    outputGeneration: "",
+  };
+  const draft: RecordingQualitySummary = {
+    ...summary,
+    facts: replaceFactProvenance(summary.facts, draftProvenance),
+    provenance: draftProvenance,
+  };
+  const outputGeneration = generation({ kind: "recording-quality", summary: draft });
+  const provenance = { ...draftProvenance, outputGeneration };
+  return {
+    ...draft,
+    facts: replaceFactProvenance(draft.facts, provenance),
+    provenance,
+  };
+}
+
+export function finalizeLapQualityGeneration(
+  quality: LapQualitySummary,
+  sessionSourceGeneration: string,
+  identity: {
+    lapNumber: number;
+    rawByteOffset: number | null;
+    rawFrameCount: number;
+  },
+): { quality: LapQualitySummary; eligibility: EligibilityDecisionSet } {
+  const sourceGeneration =
+    sessionSourceGeneration === "legacy"
+      ? "legacy"
+      : generation({
+          identity,
+          participant: quality.participant,
+          sessionSourceGeneration,
+          sourceKind: quality.sourceKind,
+          versionIdentity: quality.versionIdentity,
+        });
+  const draftProvenance: QualityProvenance = {
+    ...quality.provenance,
+    schemaVersion: QUALITY_SCHEMA_VERSION,
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+    configurationVersion: QUALITY_CONFIG_VERSION,
+    sourceGeneration,
+    outputGeneration: "",
+  };
+  const draftQuality: LapQualitySummary = {
+    ...quality,
+    facts: replaceFactProvenance(quality.facts, draftProvenance),
+    provenance: draftProvenance,
+  };
+  const eligibility = evaluateAllEligibility(draftQuality);
+  const outputGeneration = generation({
+    eligibility,
+    kind: "lap-quality",
+    quality: draftQuality,
+  });
+  const provenance = { ...draftProvenance, outputGeneration };
+  return {
+    quality: {
+      ...draftQuality,
+      facts: replaceFactProvenance(draftQuality.facts, provenance),
+      provenance,
+    },
+    eligibility,
+  };
+}

--- a/server/lap-analysis/recap.ts
+++ b/server/lap-analysis/recap.ts
@@ -1,16 +1,22 @@
 import type { GameId } from "../../shared/games/ids";
 import type { SessionRecap } from "../../shared/racing/sessions/types";
-import { isPitCycleLap } from "../../shared/racing/laps/pit-cycle";
+import type { LapCondition, LapPhase, PaceEligibility } from "../../shared/racing/laps/classification";
+import type { EligibilityDecisionSet } from "../../shared/racing/quality/contracts";
+import { isTimedLapEligibilityUsable, type QualitySnapshotEvidence } from "../../shared/racing/quality/policies";
 import { stddevPopulation, consistencyRating } from "./stats";
 
 /** Plain lap data needed to compute a recap. Null sectors are legacy laps. */
-export interface RecapLapInput {
+export interface RecapLapInput extends QualitySnapshotEvidence {
   id: number;
   lapNumber: number;
   lapTime: number;
   isValid: boolean;
+  phase: LapPhase;
+  conditions: LapCondition[];
+  paceEligibility: PaceEligibility;
   sectorTimes: number[] | null;
   invalidReason?: string | null;
+  eligibility?: EligibilityDecisionSet | null;
 }
 
 export interface RecapSessionInput {
@@ -44,8 +50,8 @@ export interface ComputeRecapInput {
   sectorStarts?: number[] | null;
 }
 
-function isValidLap(lap: RecapLapInput): boolean {
-  return lap.isValid === true && lap.lapTime > 0 && !isPitCycleLap(lap);
+function isEligiblePaceLap(lap: RecapLapInput): boolean {
+  return isTimedLapEligibilityUsable(lap);
 }
 
 /**
@@ -62,7 +68,7 @@ export function computeRecap(input: ComputeRecapInput): SessionRecap {
   let firstValidLap: RecapLapInput | null = null;
   let timeOnTrackSec = 0;
   for (const lap of laps) {
-    if (!isValidLap(lap)) continue;
+    if (!isEligiblePaceLap(lap)) continue;
     validLaps.push(lap);
     validLapTimes.push(lap.lapTime);
     timeOnTrackSec += lap.lapTime;
@@ -75,27 +81,26 @@ export function computeRecap(input: ComputeRecapInput): SessionRecap {
 
   const distanceM = trackLengthM !== null ? trackLengthM * lapsValid : null;
 
-  const sparkline = laps.filter((lap) => !isPitCycleLap(lap)).map((l) => ({
-    lapId: l.id,
-    lapNumber: l.lapNumber,
-    lapTimeSec: l.lapTime,
-    isValid: isValidLap(l),
+  const sparkline = laps.map((lap) => ({
+    lapId: lap.id,
+    lapNumber: lap.lapNumber,
+    lapTimeSec: lap.lapTime,
+    isValid: lap.isValid,
+    phase: lap.phase,
+    conditions: lap.conditions,
+    paceEligibility: lap.paceEligibility,
+    quality: lap.quality ?? null,
+    eligibility: lap.eligibility ?? null,
+    qualityGeneration: lap.qualityGeneration ?? null,
+    qualitySchemaVersion: lap.qualitySchemaVersion ?? null,
+    qualityPolicyVersion: lap.qualityPolicyVersion ?? null,
+    qualityConfigVersion: lap.qualityConfigVersion ?? null,
   }));
 
   let theoretical: SessionRecap["theoretical"] = null;
   let sectors: SessionRecap["sectors"] = null;
-  const sectorCount =
-    validLaps.find(
-      (lap) =>
-        lap.sectorTimes != null &&
-        lap.sectorTimes.length >= 2 &&
-        lap.sectorTimes.every((time) => time > 0),
-    )?.sectorTimes?.length ?? 0;
-  const completeSectorLaps = validLaps.filter(
-    (lap) =>
-      lap.sectorTimes?.length === sectorCount &&
-      lap.sectorTimes.every((time) => time > 0),
-  );
+  const sectorCount = validLaps.find((lap) => lap.sectorTimes != null && lap.sectorTimes.length >= 2 && lap.sectorTimes.every((time) => time > 0))?.sectorTimes?.length ?? 0;
+  const completeSectorLaps = validLaps.filter((lap) => lap.sectorTimes?.length === sectorCount && lap.sectorTimes.every((time) => time > 0));
   if (completeSectorLaps.length > 0 && bestLapSec !== null) {
     const sessionBests = new Array<number>(sectorCount).fill(Infinity);
     for (const lap of completeSectorLaps) {
@@ -114,13 +119,8 @@ export function computeRecap(input: ComputeRecapInput): SessionRecap {
     // could own the fastest overall time with gaps in its sector splits). In
     // that case fall back to the session bests for every sector, and never
     // report "lost" since we have no real per-sector time from the best lap.
-    const bestLapHasCompleteSectors =
-      bestLap !== null &&
-      bestLap.sectorTimes?.length === sectorCount &&
-      bestLap.sectorTimes.every((time) => time > 0);
-    const bestLapSectors = bestLapHasCompleteSectors
-      ? bestLap!.sectorTimes!
-      : sessionBests;
+    const bestLapHasCompleteSectors = bestLap !== null && bestLap.sectorTimes?.length === sectorCount && bestLap.sectorTimes.every((time) => time > 0);
+    const bestLapSectors = bestLapHasCompleteSectors ? bestLap!.sectorTimes! : sessionBests;
 
     const EPS = 1e-6;
     sectors = sessionBests.map((sessionBestSec, i) => {
@@ -181,10 +181,7 @@ export function computeRecap(input: ComputeRecapInput): SessionRecap {
     timeOnTrackSec,
     distanceM,
     sparkline,
-    sectorStarts:
-      sectors !== null && input.sectorStarts?.length === sectorCount
-        ? [...input.sectorStarts]
-        : null,
+    sectorStarts: sectors !== null && input.sectorStarts?.length === sectorCount ? [...input.sectorStarts] : null,
     theoretical,
     improvementSec,
     consistency,

--- a/server/lap-detection/detector.ts
+++ b/server/lap-detection/detector.ts
@@ -16,15 +16,26 @@ import type { GameId } from "../../shared/games/ids";
 import type { ILapDetector, LapDetectorOptions } from "./types";
 import { extractCurbSegments, recordCurbData } from "../../shared/racing/tracks/recording/curbs";
 import { recordLapTrace } from "../../shared/racing/tracks/recording/outlines";
-import { getIRacingSharedTrackName } from "../../shared/racing/tracks/catalogs/iracing"
+import { getIRacingSharedTrackName } from "../../shared/racing/tracks/catalogs/iracing";
 import { lapPath } from "../../shared/racing/tracks/path";
 import { assessLapRecording } from "../lap-analysis/quality";
 import { classifyLap, type LapClassification } from "../../shared/racing/laps/classification";
+import {
+  LOCAL_PLAYER_EVIDENCE,
+  type EligibilityDecisionSet,
+  type EvidenceSourceKind,
+  type LapQualitySummary,
+  type ParticipantEvidence,
+  type SourceChannelProfile,
+} from "../../shared/racing/quality/contracts";
+import { summarizeLapQuality } from "../../shared/racing/quality/measure";
+import { evaluateAllEligibility, isEligibilityUsable } from "../../shared/racing/quality/policies";
+import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
+import { currentTelemetryVersionIdentity } from "../telemetry/pipeline-ports";
 import { persistLapMetrics } from "../lap-analysis/metrics-store";
 import { reconcileAutoExclusionsForLap } from "../experiments/auto-exclude";
 import { computeLapSectors as computeLapSectorsHelper } from "../lap-analysis/sectors";
 import { detectSessionBoundary, detectLapBoundary, detectLapReset } from "./boundaries";
-
 
 export interface SessionState {
   sessionId: number;
@@ -33,7 +44,7 @@ export interface SessionState {
   carPI: number;
   gameId: GameId;
   sessionUID?: string; // F1 session UID for reliable session boundary detection
-  bestLapTime: number; // best valid lap time in current session (0 = none yet)
+  bestLapTime: number; // best valid pace lap in current session (0 = none yet)
 }
 
 export interface LapFuelData {
@@ -57,13 +68,15 @@ export interface LapSavedEvent extends LapClassification {
   isValid: boolean;
   sectors: number[] | null;
   estimatedBestLapTime: number; // best valid pace lap in session (0 if none)
+  quality: LapQualitySummary;
+  eligibility: EligibilityDecisionSet;
 }
 export interface LapSavedNotification extends LapSavedEvent {
   type: "lap-saved";
 }
 
 /** Bump this whenever lap detection logic changes — triggers UI prompt to reprocess old sessions. */
-export const LAP_DETECTOR_ID = "lapdetector_v3";
+export const LAP_DETECTOR_ID = "lapdetector_v4";
 
 export interface LapCompleteEvent extends LapClassification {
   packets: TelemetryPacket[];
@@ -71,11 +84,17 @@ export interface LapCompleteEvent extends LapClassification {
   lapTime: number;
   isValid: boolean;
   sectors: number[] | null;
+  quality: LapQualitySummary;
+  eligibility: EligibilityDecisionSet;
 }
 
 export class LapDetector implements ILapDetector {
   readonly detectorId = LAP_DETECTOR_ID;
   private readonly bypassPacketRateFilter: boolean;
+  private readonly sourceKind: EvidenceSourceKind;
+  private readonly participant: ParticipantEvidence;
+  private readonly versionIdentity?: TelemetryVersionIdentity;
+  private readonly sourceChannelProfile?: SourceChannelProfile;
   private db: LapDetectorOptions["db"];
 
   onSessionStart?: (session: SessionState) => void | Promise<void>;
@@ -85,6 +104,10 @@ export class LapDetector implements ILapDetector {
   constructor(opts: LapDetectorOptions) {
     this.db = opts.db;
     this.bypassPacketRateFilter = opts.bypassPacketRateFilter ?? false;
+    this.sourceKind = opts.sourceKind ?? "native-live";
+    this.participant = opts.participant ?? LOCAL_PLAYER_EVIDENCE;
+    this.versionIdentity = opts.versionIdentity;
+    this.sourceChannelProfile = opts.sourceChannelProfile;
     this.onSessionStart = opts.callbacks?.onSessionStart;
     this.onLapComplete_ = opts.callbacks?.onLapComplete;
     this.onLapSaved = opts.callbacks?.onLapSaved;
@@ -110,6 +133,8 @@ export class LapDetector implements ILapDetector {
   private _lapByteOffset: number | null = null;
   private _lapFrameCount: number = 0;
   private _currentRawByteOffset: number | null = null;
+  private readonly _pendingLapWrites = new Set<Promise<void>>();
+  private _lapWriteFailure: { error: unknown } | null = null;
 
   get session(): SessionState | null {
     return this.currentSession;
@@ -182,16 +207,8 @@ export class LapDetector implements ILapDetector {
     }
 
     // Race restart / final lap detection
-    if (
-      this.currentLapNumber >= 0 &&
-      this.lapBuffer.length > 30 &&
-      packet.LapNumber === this.currentLapNumber
-    ) {
-      const resetResult = detectLapReset(
-        this.lapBuffer[this.lapBuffer.length - 1],
-        this.lastLastLap,
-        packet
-      );
+    if (this.currentLapNumber >= 0 && this.lapBuffer.length > 30 && packet.LapNumber === this.currentLapNumber) {
+      const resetResult = detectLapReset(this.lapBuffer[this.lapBuffer.length - 1], this.lastLastLap, packet);
       if (resetResult.action === "complete-final-lap") {
         console.log(`[Lap] Final lap completed: LastLap ${this.lastLastLap.toFixed(3)} -> ${packet.LastLap.toFixed(3)}`);
         await this.onLapComplete(packet);
@@ -202,11 +219,7 @@ export class LapDetector implements ILapDetector {
     }
 
     // Rewind detection: TimestampMS decreased (within same lap)
-    if (
-      this.lastTimestampMS > 0 &&
-      packet.TimestampMS < this.lastTimestampMS &&
-      packet.LapNumber === this.currentLapNumber
-    ) {
+    if (this.lastTimestampMS > 0 && packet.TimestampMS < this.lastTimestampMS && packet.LapNumber === this.currentLapNumber) {
       if (this.lapIsValid) {
         console.log(`[Lap] Rewind: timestamp ${this.lastTimestampMS} -> ${packet.TimestampMS}. Marking lap invalid.`);
       }
@@ -249,17 +262,8 @@ export class LapDetector implements ILapDetector {
   }
 
   private shouldStartNewSession(packet: TelemetryPacket, now: number): boolean {
-    const lastDist = this.lapBuffer.length > 0
-      ? this.lapBuffer[this.lapBuffer.length - 1].DistanceTraveled
-      : null;
-    const reason = detectSessionBoundary(
-      this.currentSession,
-      this.currentLapNumber,
-      lastDist,
-      this.lastPacketTime,
-      packet,
-      now
-    );
+    const lastDist = this.lapBuffer.length > 0 ? this.lapBuffer[this.lapBuffer.length - 1].DistanceTraveled : null;
+    const reason = detectSessionBoundary(this.currentSession, this.currentLapNumber, lastDist, this.lastPacketTime, packet, now);
     if (reason) console.log(`[Session] New session: ${reason}`);
     return reason !== null;
   }
@@ -270,12 +274,7 @@ export class LapDetector implements ILapDetector {
     const sessionType = packet.f1?.sessionType;
     let sessionId: number;
     try {
-      sessionId = await this.db.insertSession(
-        packet.CarOrdinal,
-        trackOrd,
-        gameId,
-        sessionType,
-      );
+      sessionId = await this.db.insertSession(packet.CarOrdinal, trackOrd, gameId, sessionType, this.versionIdentity, this.sourceKind, this.sourceChannelProfile);
     } catch (err) {
       console.error(`[LapDetector] Failed to insert session:`, (err as Error).message);
       return;
@@ -300,9 +299,7 @@ export class LapDetector implements ILapDetector {
     this._lapByteOffset = null;
     this._lapFrameCount = 0;
 
-    console.log(
-      `[Session] New session #${sessionId} | Car: ${packet.CarOrdinal} | Class: ${packet.CarClass} | PI: ${packet.CarPerformanceIndex}${sessionType ? ` | Type: ${sessionType}` : ""}`
-    );
+    console.log(`[Session] New session #${sessionId} | Car: ${packet.CarOrdinal} | Class: ${packet.CarClass} | PI: ${packet.CarPerformanceIndex}${sessionType ? ` | Type: ${sessionType}` : ""}`);
 
     await this.onSessionStart?.(this.currentSession!);
   }
@@ -312,7 +309,6 @@ export class LapDetector implements ILapDetector {
       this.resetLapState(newLapFirstPacket);
       return;
     }
-
 
     // Record fuel usage
     const fuelEnd = this.lapBuffer[this.lapBuffer.length - 1].Fuel;
@@ -349,25 +345,18 @@ export class LapDetector implements ILapDetector {
     // Use LastLap from the first packet of the new lap as authoritative lap time
     const lapTime = newLapFirstPacket.LastLap;
 
-
     // Running-start trim: strip pre-start-line packets
     this.trimRunningStartPackets();
 
     // Skip saving if lap time is too short (first lap, warmup, ghost fragments)
     if (lapTime < 10) {
-      console.log(
-        `[Lap] Skipping lap ${this.currentLapNumber} with time ${lapTime.toFixed(3)}s (< 10s)`
-      );
+      console.log(`[Lap] Skipping lap ${this.currentLapNumber} with time ${lapTime.toFixed(3)}s (< 10s)`);
       this.resetLapState(newLapFirstPacket);
       return;
     }
 
     {
-      const tuneAssignment = await this.db.getTuneAssignment(
-        this.currentSession.gameId,
-        this.currentSession.carOrdinal,
-        this.currentSession.trackOrdinal
-      );
+      const tuneAssignment = await this.db.getTuneAssignment(this.currentSession.gameId, this.currentSession.carOrdinal, this.currentSession.trackOrdinal);
       const tuneId = tuneAssignment?.tuneId ?? null;
       const lapNum = this.currentLapNumber;
       const packetCount = this.lapBuffer.length;
@@ -377,7 +366,22 @@ export class LapDetector implements ILapDetector {
       const classification = classifyLap(this.lapBuffer);
       const valid = this.lapIsValid && recordingAssessment.valid;
       const invalidReason = this.invalidReason ?? recordingAssessment.reason;
-      const normalPaceEligible = valid && classification.paceEligibility === "eligible";
+      const versionIdentity = this.versionIdentity ?? currentTelemetryVersionIdentity(this.currentSession.gameId);
+      const quality = summarizeLapQuality({
+        packets: this.lapBuffer,
+        lapTime,
+        timingSource: "simulator-last-lap",
+        complete: true,
+        structurallyValid: valid,
+        invalidReason,
+        classification,
+        sourceKind: this.sourceKind,
+        participant: this.participant,
+        versionIdentity,
+        sourceChannelProfile: this.sourceChannelProfile,
+      });
+      const eligibility = evaluateAllEligibility(quality);
+      const normalPaceEligible = valid && classification.paceEligibility === "eligible" && isEligibilityUsable(eligibility["normal-pace"]);
       const sectors = await this.computeLapSectors(this.lapBuffer, lapTime);
 
       // iRacing exposes heading, speed, and native LapDistPct but no public
@@ -396,22 +400,13 @@ export class LapDetector implements ILapDetector {
           x,
           z: path.z[index],
         }));
-        recordLapTrace(
-          this.currentSession.trackOrdinal,
-          trace,
-          trace[0] ?? null,
-          this.lapBuffer[0]?.Yaw ?? null,
-          "iracing",
-        );
+        recordLapTrace(this.currentSession.trackOrdinal, trace, trace[0] ?? null, this.lapBuffer[0]?.Yaw ?? null, "iracing");
       }
 
-      // Update session best lap time
       if (normalPaceEligible && (this.currentSession!.bestLapTime === 0 || lapTime < this.currentSession!.bestLapTime)) {
         this.currentSession!.bestLapTime = lapTime;
       }
 
-      // Existing consumers receive only normal-pace evidence until policy-aware
-      // callbacks land; saved-lap notifications still preserve classification.
       if (normalPaceEligible) {
         this.onLapComplete_?.({
           packets: this.lapBuffer,
@@ -420,47 +415,53 @@ export class LapDetector implements ILapDetector {
           isValid: valid,
           ...classification,
           sectors,
-
+          quality,
+          eligibility,
         });
       }
 
       // Capture the frame buffer before resetLapState reassigns it — the insert
       // below is fire-and-forget, so persistLapMetrics runs after the reset.
       const lapPackets = this.lapBuffer;
-      this.db.insertLap(
-        this.currentSession.sessionId,
-        lapNum,
-        lapTime,
-        valid,
-        this._lapByteOffset,
-        this._lapFrameCount,
-        null,
-        tuneId,
-        invalidReason,
-        sectors,
-        undefined,
-        classification
-      ).then(async (lapId) => {
-        // Precompute fuel/tyre metrics now (frames in memory) so /lap-metrics
-        // never decodes on first open.
-        await this.persistLapFollowups(lapId, lapPackets);
-        console.log(
-          `[Lap] Saved lap ${lapNum} | Time: ${formatLapTime(lapTime)} | Valid: ${valid}${invalidReason ? ` (${invalidReason})` : ""} | Packets: ${packetCount} | DB ID: ${lapId}`
-        );
-        this.onLapSaved?.({
-          lapId,
-          lapNumber: lapNum,
-          lapTime,
-          isValid: valid,
-          ...classification,
-          sectors,
-          estimatedBestLapTime: this.currentSession!.bestLapTime,
-        });
-      }).catch((err) => {
-        console.error(`[Lap] Failed to save lap ${lapNum}:`, err);
-      });
+      this.trackLapWrite(
+        this.db
+          .insertLap({
+            sessionId: this.currentSession.sessionId,
+            lapNumber: lapNum,
+            lapTime,
+            isValid: valid,
+            rawByteOffset: this._lapByteOffset,
+            rawFrameCount: this._lapFrameCount,
+            profileId: null,
+            tuneId,
+            invalidReason,
+            sectors,
+            classification,
+            quality,
+            eligibility,
+            versionIdentity,
+          })
+          .then(async (lapId) => {
+            // Precompute fuel/tyre metrics now (frames in memory) so /lap-metrics
+            // never decodes on first open.
+            await this.persistLapFollowups(lapId, lapPackets);
+            console.log(`[Lap] Saved lap ${lapNum} | Time: ${formatLapTime(lapTime)} | Valid: ${valid}${invalidReason ? ` (${invalidReason})` : ""} | Packets: ${packetCount} | DB ID: ${lapId}`);
+            this.onLapSaved?.({
+              lapId,
+              lapNumber: lapNum,
+              lapTime,
+              isValid: valid,
+              ...classification,
+              sectors,
+              estimatedBestLapTime: this.currentSession!.bestLapTime,
+              quality,
+              eligibility,
+            });
+          }),
+        `[Lap] Failed to save lap ${lapNum}:`,
+      );
 
-      // Only normal-pace laps may seed shared curb geometry.
+      // Extract and record curb data from laps allowed for normal-pace geometry seeding.
       if (normalPaceEligible && this.currentSession.trackOrdinal > 0 && this.lapBuffer.length > 50) {
         const curbSegments = extractCurbSegments(this.lapBuffer);
         if (curbSegments.length > 0) {
@@ -477,42 +478,54 @@ export class LapDetector implements ILapDetector {
   /** Best-effort save of an incomplete lap when the session ends mid-lap. */
   private async finalizeLapIfNeeded(): Promise<void> {
     // Try to save current in-progress lap when session changes
-    if (
-      this.currentSession &&
-      this.lapBuffer.length > 0 &&
-      this.currentLapNumber >= 0
-    ) {
+    if (this.currentSession && this.lapBuffer.length > 0 && this.currentLapNumber >= 0) {
       this.trimRunningStartPackets();
       // Use the last known CurrentLap as time estimate (not ideal but best we have)
       const lastPacket = this.lapBuffer[this.lapBuffer.length - 1];
       const lapTime = lastPacket.CurrentLap;
       if (lapTime >= 10) {
-          const tuneAssignment = await this.db.getTuneAssignment(
-            this.currentSession.gameId,
-            this.currentSession.carOrdinal,
-            this.currentSession.trackOrdinal
-          );
-          const lapPackets = this.lapBuffer;
-          const classification = classifyLap(lapPackets);
-          this.db.insertLap(
-            this.currentSession.sessionId,
-            this.currentLapNumber,
-            lapTime,
-            false,
-            this._lapByteOffset,
-            this._lapFrameCount,
-            null,
-            tuneAssignment?.tuneId ?? null,
-            "incomplete",
-            null,
-            undefined,
-            classification
-          ).then(async (lapId) => {
-            await this.persistLapFollowups(lapId, lapPackets);
-            console.log(`[Lap] Saved incomplete lap (session ended)`);
-          }).catch((err) => {
-            console.error("[Lap] Failed to save incomplete lap:", err);
-          });
+        const tuneAssignment = await this.db.getTuneAssignment(this.currentSession.gameId, this.currentSession.carOrdinal, this.currentSession.trackOrdinal);
+        const lapPackets = this.lapBuffer;
+        const classification = classifyLap(lapPackets);
+        const versionIdentity = this.versionIdentity ?? currentTelemetryVersionIdentity(this.currentSession.gameId);
+        const quality = summarizeLapQuality({
+          packets: lapPackets,
+          lapTime,
+          timingSource: "estimated",
+          complete: false,
+          structurallyValid: false,
+          invalidReason: "incomplete",
+          classification,
+          sourceKind: this.sourceKind,
+          participant: this.participant,
+          versionIdentity,
+          sourceChannelProfile: this.sourceChannelProfile,
+        });
+        const eligibility = evaluateAllEligibility(quality);
+        this.trackLapWrite(
+          this.db
+            .insertLap({
+              sessionId: this.currentSession.sessionId,
+              lapNumber: this.currentLapNumber,
+              lapTime,
+              isValid: false,
+              rawByteOffset: this._lapByteOffset,
+              rawFrameCount: this._lapFrameCount,
+              profileId: null,
+              tuneId: tuneAssignment?.tuneId ?? null,
+              invalidReason: "incomplete",
+              sectors: null,
+              classification,
+              quality,
+              eligibility,
+              versionIdentity,
+            })
+            .then(async (lapId) => {
+              await this.persistLapFollowups(lapId, lapPackets);
+              console.log(`[Lap] Saved incomplete lap (session ended)`);
+            }),
+          "[Lap] Failed to save incomplete lap:",
+        );
       }
     }
   }
@@ -523,12 +536,7 @@ export class LapDetector implements ILapDetector {
    * have been received for >10 seconds and there's meaningful data.
    */
   async flushStaleLap(): Promise<void> {
-    if (
-      !this.currentSession ||
-      this.lapBuffer.length < 30 ||
-      this.currentLapNumber < 0 ||
-      this.lastPacketTime === 0
-    ) return;
+    if (!this.currentSession || this.lapBuffer.length < 30 || this.currentLapNumber < 0 || this.lastPacketTime === 0) return;
 
     const silenceMs = Date.now() - this.lastPacketTime;
     if (silenceMs < 10_000) return;
@@ -537,9 +545,10 @@ export class LapDetector implements ILapDetector {
     if (this.lapBuffer.length < 30) return;
 
     const lastPacket = this.lapBuffer[this.lapBuffer.length - 1];
-    const lapTime = lastPacket.LastLap > 0 && lastPacket.LastLap !== this.lastLastLap
-      ? lastPacket.LastLap   // game reported a final lap time
-      : lastPacket.CurrentLap; // use elapsed time as best estimate
+    const lapTime =
+      lastPacket.LastLap > 0 && lastPacket.LastLap !== this.lastLastLap
+        ? lastPacket.LastLap // game reported a final lap time
+        : lastPacket.CurrentLap; // use elapsed time as best estimate
 
     if (lapTime < 10) return; // ignore trivial fragments (e.g. post-race trickle packets)
 
@@ -547,11 +556,7 @@ export class LapDetector implements ILapDetector {
     const isComplete = lastPacket.LastLap > 0 && lastPacket.LastLap !== this.lastLastLap;
 
     {
-      const tuneAssignment = await this.db.getTuneAssignment(
-        this.currentSession.gameId,
-        this.currentSession.carOrdinal,
-        this.currentSession.trackOrdinal
-      );
+      const tuneAssignment = await this.db.getTuneAssignment(this.currentSession.gameId, this.currentSession.carOrdinal, this.currentSession.trackOrdinal);
       const lapNum = this.currentLapNumber;
       const packetCount = this.lapBuffer.length;
       const lapPackets = this.lapBuffer;
@@ -559,27 +564,47 @@ export class LapDetector implements ILapDetector {
       const classification = classifyLap(lapPackets);
       const valid = isComplete && this.lapIsValid && recordingAssessment.valid;
       const invalidReason = isComplete ? (this.invalidReason ?? recordingAssessment.reason) : "incomplete";
-      this.db.insertLap(
-        this.currentSession.sessionId,
-        lapNum,
+      const versionIdentity = this.versionIdentity ?? currentTelemetryVersionIdentity(this.currentSession.gameId);
+      const quality = summarizeLapQuality({
+        packets: lapPackets,
         lapTime,
-        valid,
-        this._lapByteOffset,
-        this._lapFrameCount,
-        null,
-        tuneAssignment?.tuneId ?? null,
+        timingSource: isComplete ? "simulator-last-lap" : "estimated",
+        complete: isComplete,
+        structurallyValid: valid,
         invalidReason,
-        null,
-        undefined,
-        classification
-      ).then(async (lapId) => {
-        await this.persistLapFollowups(lapId, lapPackets);
-        console.log(
-          `[Lap] Flushed stale lap ${lapNum} | Time: ${formatLapTime(lapTime)} | ${isComplete ? "Complete" : "Incomplete"} | Packets: ${packetCount} | DB ID: ${lapId} (${(silenceMs / 1000).toFixed(0)}s silence)`
-        );
-      }).catch((err) => {
-        console.error("[Lap] Failed to flush stale lap:", err);
+        classification,
+        sourceKind: this.sourceKind,
+        participant: this.participant,
+        versionIdentity,
+        sourceChannelProfile: this.sourceChannelProfile,
       });
+      const eligibility = evaluateAllEligibility(quality);
+      this.trackLapWrite(
+        this.db
+          .insertLap({
+            sessionId: this.currentSession.sessionId,
+            lapNumber: lapNum,
+            lapTime,
+            isValid: valid,
+            rawByteOffset: this._lapByteOffset,
+            rawFrameCount: this._lapFrameCount,
+            profileId: null,
+            tuneId: tuneAssignment?.tuneId ?? null,
+            invalidReason,
+            sectors: null,
+            classification,
+            quality,
+            eligibility,
+            versionIdentity,
+          })
+          .then(async (lapId) => {
+            await this.persistLapFollowups(lapId, lapPackets);
+            console.log(
+              `[Lap] Flushed stale lap ${lapNum} | Time: ${formatLapTime(lapTime)} | ${isComplete ? "Complete" : "Incomplete"} | Packets: ${packetCount} | DB ID: ${lapId} (${(silenceMs / 1000).toFixed(0)}s silence)`,
+            );
+          }),
+        "[Lap] Failed to flush stale lap:",
+      );
     }
 
     // Reset state so we don't flush again
@@ -605,27 +630,19 @@ export class LapDetector implements ILapDetector {
     // A true running-start reset happens early (mid-previous-lap data at the front).
     // A lap-end reset happens at the very end and must not be treated as a running start.
     if (resetIdx > 0 && resetIdx < this.lapBuffer.length / 2) {
-      console.log(
-        `[Lap] Trimmed ${resetIdx} pre-start packets (running start), ${this.lapBuffer.length - resetIdx} remain`
-      );
+      console.log(`[Lap] Trimmed ${resetIdx} pre-start packets (running start), ${this.lapBuffer.length - resetIdx} remain`);
       this.lapBuffer = this.lapBuffer.slice(resetIdx);
     }
   }
 
   /** Compute s1/s2/s3 sector times from a lap's telemetry buffer. */
-  private async computeLapSectors(
-    packets: TelemetryPacket[],
-    lapTime: number
-  ): Promise<number[] | null> {
+  private async computeLapSectors(packets: TelemetryPacket[], lapTime: number): Promise<number[] | null> {
     if (!this.currentSession) return null;
     const { trackOrdinal, gameId } = this.currentSession;
     return computeLapSectorsHelper(trackOrdinal, gameId, packets, lapTime);
   }
 
-  private async persistLapFollowups(
-    lapId: number,
-    lapPackets: TelemetryPacket[],
-  ): Promise<void> {
+  private async persistLapFollowups(lapId: number, lapPackets: TelemetryPacket[]): Promise<void> {
     try {
       await persistLapMetrics(this.db, lapId, lapPackets);
     } catch (error) {
@@ -636,6 +653,27 @@ export class LapDetector implements ILapDetector {
     } catch (error) {
       console.error("[Lap] reconcileAutoExclusionsForLap failed:", error);
     }
+  }
+
+  private trackLapWrite(pending: Promise<void>, failureMessage: string): void {
+    this._pendingLapWrites.add(pending);
+    void pending.then(
+      () => this._pendingLapWrites.delete(pending),
+      (error) => {
+        this._pendingLapWrites.delete(pending);
+        this._lapWriteFailure ??= { error };
+        console.error(failureMessage, error);
+      },
+    );
+  }
+
+  async waitForPendingLapWrites(): Promise<void> {
+    while (this._pendingLapWrites.size > 0) {
+      await Promise.allSettled([...this._pendingLapWrites]);
+    }
+    const failure = this._lapWriteFailure;
+    this._lapWriteFailure = null;
+    if (failure) throw failure.error;
   }
 
   private invalidateLap(reason: string): void {
@@ -686,14 +724,12 @@ export class LapDetector implements ILapDetector {
 /**
  * Smooth an outline using a circular moving average (wraps around start/finish).
  */
-export function smoothOutline(
-  points: { x: number; z: number }[],
-  window: number = 5
-): { x: number; z: number }[] {
+export function smoothOutline(points: { x: number; z: number }[], window: number = 5): { x: number; z: number }[] {
   const n = points.length;
   const half = Math.floor(window / 2);
   return points.map((_, i) => {
-    let sx = 0, sz = 0;
+    let sx = 0,
+      sz = 0;
     const count = half * 2 + 1;
     for (let j = -half; j <= half; j++) {
       const idx = (i + j + n) % n;
@@ -708,10 +744,7 @@ export function smoothOutline(
  * Normalize a variable-length point array to a fixed number of points
  * using linear interpolation along cumulative distance.
  */
-export function normalizeToFixedPoints(
-  raw: { x: number; z: number; speed: number }[],
-  targetPoints: number
-): { x: number; z: number; speed: number }[] {
+export function normalizeToFixedPoints(raw: { x: number; z: number; speed: number }[], targetPoints: number): { x: number; z: number; speed: number }[] {
   if (raw.length <= targetPoints) return raw;
 
   // Compute cumulative distances
@@ -757,9 +790,7 @@ export function normalizeToFixedPoints(
  * Filter outlier jumps from raw lap telemetry (rewinds, pit teleports).
  * Removes points where the step distance exceeds median * 5.
  */
-export function filterLapOutliers(
-  points: { x: number; z: number; speed: number }[]
-): { x: number; z: number; speed: number }[] {
+export function filterLapOutliers(points: { x: number; z: number; speed: number }[]): { x: number; z: number; speed: number }[] {
   if (points.length < 10) return points;
 
   // Compute step distances
@@ -787,9 +818,7 @@ export function filterLapOutliers(
  * Aligns each subsequent lap to the reference (first lap) by finding
  * the best rotational offset that minimizes position error, then averages.
  */
-export function averageOutlines(
-  laps: { x: number; z: number; speed: number }[][]
-): { x: number; z: number; speed: number }[] {
+export function averageOutlines(laps: { x: number; z: number; speed: number }[][]): { x: number; z: number; speed: number }[] {
   if (laps.length === 0) return [];
   if (laps.length === 1) return laps[0];
 
@@ -800,7 +829,10 @@ export function averageOutlines(
   const aligned: typeof laps = [ref];
   for (let l = 1; l < laps.length; l++) {
     const lap = laps[l];
-    if (lap.length !== len) { aligned.push(lap); continue; }
+    if (lap.length !== len) {
+      aligned.push(lap);
+      continue;
+    }
 
     // Test shifts at coarse intervals, then refine around the best
     let bestShift = 0;
@@ -815,7 +847,10 @@ export function averageOutlines(
         const dz = lap[j].z - ref[i].z;
         err += dx * dx + dz * dz;
       }
-      if (err < bestError) { bestError = err; bestShift = shift; }
+      if (err < bestError) {
+        bestError = err;
+        bestShift = shift;
+      }
     }
     // Refine around best coarse shift
     const refineStart = Math.max(0, bestShift - step);
@@ -828,7 +863,10 @@ export function averageOutlines(
         const dz = lap[j].z - ref[i].z;
         err += dx * dx + dz * dz;
       }
-      if (err < bestError) { bestError = err; bestShift = shift; }
+      if (err < bestError) {
+        bestError = err;
+        bestShift = shift;
+      }
     }
 
     // Apply shift
@@ -842,7 +880,9 @@ export function averageOutlines(
   // Point-by-point average of aligned laps
   const result: { x: number; z: number; speed: number }[] = [];
   for (let i = 0; i < len; i++) {
-    let sx = 0, sz = 0, ss = 0;
+    let sx = 0,
+      sz = 0,
+      ss = 0;
     for (const lap of aligned) {
       sx += lap[i].x;
       sz += lap[i].z;
@@ -855,10 +895,8 @@ export function averageOutlines(
   return result;
 }
 
-
 function formatLapTime(seconds: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = seconds % 60;
   return `${mins}:${secs.toFixed(3).padStart(6, "0")}`;
 }
-

--- a/server/lap-detection/types.ts
+++ b/server/lap-detection/types.ts
@@ -5,6 +5,8 @@
  */
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { DbAdapter } from "../telemetry/pipeline-ports";
+import type { EvidenceSourceKind, ParticipantEvidence, SourceChannelProfile } from "../../shared/racing/quality/contracts";
+import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
 
 // Re-export all event/state types so callers only need one import point
 export type {
@@ -31,6 +33,14 @@ export interface LapDetectorOptions {
   callbacks?: LapDetectorCallbacks;
   /** Bypass an implementation's packet-rate guard when supported (used in tests). */
   bypassPacketRateFilter?: boolean;
+  /** Evidence origin used while measuring quality; live capture is default. */
+  sourceKind?: EvidenceSourceKind;
+  /** Participant identity; local player is default. */
+  participant?: ParticipantEvidence;
+  /** Override parser/catalog identity for imports and deterministic rebuilds. */
+  versionIdentity?: TelemetryVersionIdentity;
+  /** Session-wide fidelity overrides supplied by transcoded evidence sources. */
+  sourceChannelProfile?: SourceChannelProfile;
 }
 
 /** Common interface implemented by all lap detector variants. */

--- a/server/routes/laps/comparison-routes.ts
+++ b/server/routes/laps/comparison-routes.ts
@@ -3,9 +3,11 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 
 import type { GameId } from "../../../shared/games/ids";
+import { eligibilityDecisionText } from "../../../shared/racing/quality/display";
+import { isEligibilityUsable, resolveEligibilityDecision } from "../../../shared/racing/quality/policies";
 import { queryLapTelemetryBySemanticId } from "../../telemetry/replay";
 import { getLapById } from "../../db/lap-read-queries";
-import { deleteCompareAnalysis, getAnalysis, getCompareAnalysis, saveCompareAnalysis } from "../../db/analysis-queries";
+import { deleteCompareAnalysis, getAnalysis, getCompareAnalysis, getCompareQualityIdentity, qualityCacheIdentityForComparison, saveCompareAnalysis } from "../../db/analysis-queries";
 import { getCorners, saveCorners } from "../../db/track-queries";
 import { compareLaps } from "../../lap-analysis/comparison";
 import { detectCorners } from "../../lap-analysis/corners";
@@ -18,19 +20,10 @@ import { compareChatAgent, compareEngineerAgent } from "../../ai/agents";
 import { buildGoogleReasoningProviderOptions, buildGoogleThinkingProviderOptions } from "../../ai/google-provider-options";
 import { beginAnalysisRun, finishAnalysisRun, getAnalysisRun } from "../../ai/analysis-run-registry";
 import { streamAgentTurnResponse } from "../../ai/agent-stream";
-import {
-  CHAT_RESOURCE_ID,
-  compareChatThreadId,
-  generationThreadId,
-  getChatMemory,
-  listThreadGenerations,
-  resolveActiveThread,
-} from "../../ai/chat-agent";
+import { CHAT_RESOURCE_ID, compareChatThreadId, generationThreadId, getChatMemory, listThreadGenerations, resolveActiveThread } from "../../ai/chat-agent";
 import { getSecret } from "../../runtime/platform/keystore";
 import { AnalyseQuerySchema, ChatBodySchema, CompareParamsSchema } from "./support";
-const inputsAnalysisRunKey = (idA: number, idB: number) =>
-  `inputs:${Math.min(idA, idB)}:${Math.max(idA, idB)}`;
-
+const inputsAnalysisRunKey = (idA: number, idB: number) => `inputs:${Math.min(idA, idB)}:${Math.max(idA, idB)}`;
 
 export const comparisonRoutes = new Hono()
   .get("/api/laps/:id1/compare/:id2", zValidator("param", CompareParamsSchema), async (c) => {
@@ -42,6 +35,22 @@ export const comparisonRoutes = new Hono()
 
     const lapB = await getLapById(id2);
     if (!lapB) return c.json({ error: `Lap ${id2} not found` }, 404);
+    const decisions = {
+      lapA: resolveEligibilityDecision(lapA, "lap-comparison"),
+      lapB: resolveEligibilityDecision(lapB, "lap-comparison"),
+    };
+    if (!isEligibilityUsable(decisions.lapA) || !isEligibilityUsable(decisions.lapB)) {
+      return c.json(
+        {
+          error: [decisions.lapA, decisions.lapB]
+            .filter((decision) => !isEligibilityUsable(decision))
+            .map(eligibilityDecisionText)
+            .join(" "),
+          decisions,
+        },
+        422,
+      );
+    }
 
     if (lapA.telemetry.length === 0 || lapB.telemetry.length === 0) return c.json({ error: "One or both laps have no telemetry data" }, 400);
 
@@ -78,10 +87,7 @@ export const comparisonRoutes = new Hono()
       "timing.distance-traveled",
       "timing.current-lap",
     ] as const;
-    const [replayA, replayB] = await Promise.all([
-      queryLapTelemetryBySemanticId(id1, semanticIds),
-      queryLapTelemetryBySemanticId(id2, semanticIds),
-    ]);
+    const [replayA, replayB] = await Promise.all([queryLapTelemetryBySemanticId(id1, semanticIds), queryLapTelemetryBySemanticId(id2, semanticIds)]);
     if (!replayA || !replayB || replayA.envelopes.length === 0 || replayB.envelopes.length === 0) {
       return c.json({ error: "One or both laps have no semantic telemetry data" }, 400);
     }
@@ -125,6 +131,7 @@ export const comparisonRoutes = new Hono()
       telemetryA: toSamples(replayA),
       telemetryB: toSamples(replayB),
       gameId: lapA.gameId,
+      decisions,
     });
   })
 
@@ -137,13 +144,38 @@ export const comparisonRoutes = new Hono()
     const { regenerate, cacheOnly } = c.req.valid("query");
     if (id1 === id2) return c.json({ error: "Cannot compare a lap with itself" }, 400);
 
-    // Cache lookup first
+    const lapA = await getLapById(id1);
+    if (!lapA) return c.json({ error: `Lap ${id1} not found` }, 404);
+    const lapB = await getLapById(id2);
+    if (!lapB) return c.json({ error: `Lap ${id2} not found` }, 404);
+    const qualityIdentity = qualityCacheIdentityForComparison([lapA, lapB]);
+    const decisions = {
+      lapA: resolveEligibilityDecision(lapA, "corner-trace"),
+      lapB: resolveEligibilityDecision(lapB, "corner-trace"),
+    };
+    if (!isEligibilityUsable(decisions.lapA) || !isEligibilityUsable(decisions.lapB)) {
+      return c.json(
+        {
+          error: [decisions.lapA, decisions.lapB]
+            .filter((decision) => !isEligibilityUsable(decision))
+            .map(eligibilityDecisionText)
+            .join(" "),
+          decisions,
+        },
+        422,
+      );
+    }
+    if (!qualityIdentity) {
+      return c.json({ error: "Compared laps have no current quality generation", decisions }, 422);
+    }
+
     if (!regenerate) {
       const cached = await getCompareAnalysis(id1, id2, "inputs");
       if (cached) {
         return c.json({
           analysis: cached.analysis,
           cached: true,
+          decisions,
           usage: {
             inputTokens: cached.inputTokens,
             outputTokens: cached.outputTokens,
@@ -153,13 +185,8 @@ export const comparisonRoutes = new Hono()
           },
         });
       }
-      if (cacheOnly) return c.json({ analysis: null, cached: false });
+      if (cacheOnly) return c.json({ analysis: null, cached: false, decisions });
     }
-
-    const lapA = await getLapById(id1);
-    if (!lapA) return c.json({ error: `Lap ${id1} not found` }, 404);
-    const lapB = await getLapById(id2);
-    if (!lapB) return c.json({ error: `Lap ${id2} not found` }, 404);
     if (lapA.telemetry.length === 0 || lapB.telemetry.length === 0) return c.json({ error: "One or both laps have no telemetry data" }, 400);
 
     const trackOrdinal = lapA.trackOrdinal ?? 0;
@@ -197,6 +224,9 @@ export const comparisonRoutes = new Hono()
         carOrdinal: lapA.carOrdinal ?? undefined,
         trackOrdinal: lapA.trackOrdinal ?? undefined,
         gameId: lapA.gameId as GameId | undefined,
+        quality: lapA.quality,
+        eligibility: lapA.eligibility,
+        qualityGeneration: lapA.qualityGeneration,
       },
       {
         lapNumber: lapB.lapNumber,
@@ -205,12 +235,15 @@ export const comparisonRoutes = new Hono()
         carOrdinal: lapB.carOrdinal ?? undefined,
         trackOrdinal: lapB.trackOrdinal ?? undefined,
         gameId: lapB.gameId as GameId | undefined,
+        quality: lapB.quality,
+        eligibility: lapB.eligibility,
+        qualityGeneration: lapB.qualityGeneration,
       },
       comparison,
       segments,
       undefined,
-      buildCompareInsightsBlock("Lap A", lapA.telemetry, lapA.gameId as GameId | undefined) +
-        buildCompareInsightsBlock("Lap B", lapB.telemetry, lapB.gameId as GameId | undefined),
+      buildCompareInsightsBlock("Lap A", lapA.telemetry, lapA.gameId as GameId | undefined, lapA.quality) +
+        buildCompareInsightsBlock("Lap B", lapB.telemetry, lapB.gameId as GameId | undefined, lapB.quality),
     );
 
     // Set provider env vars before calling Mastra (the dynamic model resolver
@@ -257,10 +290,7 @@ export const comparisonRoutes = new Hono()
         modelSettings: { maxOutputTokens: 8192, temperature: 0 },
         providerOptions: {
           openai: { reasoningEffort: "medium" },
-          google: buildGoogleThinkingProviderOptions(
-            settings.aiModel || "gemini-flash-latest",
-            settings.aiThinkingBudget,
-          ) as never,
+          google: buildGoogleThinkingProviderOptions(settings.aiModel || "gemini-flash-latest", settings.aiThinkingBudget) as never,
         },
       });
       const durationMs = Math.round(performance.now() - start);
@@ -293,7 +323,10 @@ export const comparisonRoutes = new Hono()
         durationMs,
         model: settings.aiModel || settings.aiProvider,
       };
-      await saveCompareAnalysis(id1, id2, analysisJson, usage, "inputs");
+      const saved = await saveCompareAnalysis(id1, id2, analysisJson, usage, qualityIdentity, "inputs");
+      if (!saved) {
+        return c.json({ error: "Compared lap quality changed during analysis generation. Analysis not cached." }, 409);
+      }
       return c.json({ analysis: analysisJson, cached: false, usage });
     } catch (err: any) {
       console.error("[InputsCompare] Failed:", err.message);
@@ -317,11 +350,11 @@ export const comparisonRoutes = new Hono()
     const { id1, id2 } = c.req.valid("param");
     try {
       const memory = getChatMemory();
-      const base = compareChatThreadId(id1, id2);
+      const identity = await getCompareQualityIdentity(id1, id2);
+      if (!identity) return c.json({ messages: [] });
+      const base = compareChatThreadId(id1, id2, `${identity.policyVersion}:${identity.generation}`);
       const genParam = Number(c.req.query("gen"));
-      const threadId = Number.isInteger(genParam) && genParam >= 1
-        ? generationThreadId(base, genParam)
-        : await resolveActiveThread(base);
+      const threadId = Number.isInteger(genParam) && genParam >= 1 ? generationThreadId(base, genParam) : await resolveActiveThread(base);
       const thread = await memory.getThreadById({ threadId });
       if (!thread) return c.json({ messages: [] });
       const result = await memory.recall({ threadId });
@@ -329,9 +362,7 @@ export const comparisonRoutes = new Hono()
 
       const list = new MessageList({ threadId, resourceId: CHAT_RESOURCE_ID });
       list.add(raw, "memory");
-      const uiMessages = list.get.all.aiV5
-        .ui()
-        .filter((m) => m.role === "user" || m.role === "assistant");
+      const uiMessages = list.get.all.aiV5.ui().filter((m) => m.role === "user" || m.role === "assistant");
 
       return c.json({ messages: uiMessages });
     } catch (err: any) {
@@ -349,6 +380,22 @@ export const comparisonRoutes = new Hono()
     if (!lapA) return c.json({ error: `Lap ${id1} not found` }, 404);
     const lapB = await getLapById(id2);
     if (!lapB) return c.json({ error: `Lap ${id2} not found` }, 404);
+    const decisions = {
+      lapA: resolveEligibilityDecision(lapA, "corner-trace"),
+      lapB: resolveEligibilityDecision(lapB, "corner-trace"),
+    };
+    if (!isEligibilityUsable(decisions.lapA) || !isEligibilityUsable(decisions.lapB)) {
+      return c.json(
+        {
+          error: [decisions.lapA, decisions.lapB]
+            .filter((decision) => !isEligibilityUsable(decision))
+            .map(eligibilityDecisionText)
+            .join(" "),
+          decisions,
+        },
+        422,
+      );
+    }
     if (lapA.telemetry.length === 0 || lapB.telemetry.length === 0) return c.json({ error: "One or both laps have no telemetry data" }, 400);
 
     const cachedA = await getAnalysis(id1);
@@ -356,6 +403,8 @@ export const comparisonRoutes = new Hono()
     if (!cachedA || !cachedB) {
       return c.json({ error: "Both laps must be analysed before chatting. Run analysis on each lap first." }, 400);
     }
+    const identity = qualityCacheIdentityForComparison([lapA, lapB]);
+    if (!identity) return c.json({ error: "Lap quality is unavailable or stale" }, 422);
 
     const trackOrdinal = lapA.trackOrdinal ?? 0;
     let corners: Awaited<ReturnType<typeof getCorners>> = [];
@@ -377,6 +426,9 @@ export const comparisonRoutes = new Hono()
         carOrdinal: lapA.carOrdinal ?? undefined,
         trackOrdinal: lapA.trackOrdinal ?? undefined,
         gameId: lapA.gameId as GameId | undefined,
+        quality: lapA.quality,
+        eligibility: lapA.eligibility,
+        qualityGeneration: lapA.qualityGeneration,
       },
       {
         id: id2,
@@ -386,6 +438,9 @@ export const comparisonRoutes = new Hono()
         carOrdinal: lapB.carOrdinal ?? undefined,
         trackOrdinal: lapB.trackOrdinal ?? undefined,
         gameId: lapB.gameId as GameId | undefined,
+        quality: lapB.quality,
+        eligibility: lapB.eligibility,
+        qualityGeneration: lapB.qualityGeneration,
       },
       comparison,
       cachedA.analysis,
@@ -393,8 +448,8 @@ export const comparisonRoutes = new Hono()
       settings.unit,
       settings.temperatureUnit,
       settings.language,
-      buildCompareInsightsBlock("Lap A", lapA.telemetry, lapA.gameId as GameId | undefined) +
-        buildCompareInsightsBlock("Lap B", lapB.telemetry, lapB.gameId as GameId | undefined),
+      buildCompareInsightsBlock("Lap A", lapA.telemetry, lapA.gameId as GameId | undefined, lapA.quality) +
+        buildCompareInsightsBlock("Lap B", lapB.telemetry, lapB.gameId as GameId | undefined, lapB.quality),
     );
 
     const chatProvider = settings.chatProvider;
@@ -416,26 +471,18 @@ export const comparisonRoutes = new Hono()
       process.env.OPENAI_BASE_URL = settings.localEndpoint || "http://localhost:1234/v1";
     }
 
-    const chatModelLabel = settings.chatModel
-      || (chatProvider === "openai"
-        ? "gpt-4o-mini"
-        : chatProvider === "local"
-          ? "local-model"
-          : "gemini-flash-latest");
+    const chatModelLabel = settings.chatModel || (chatProvider === "openai" ? "gpt-4o-mini" : chatProvider === "local" ? "local-model" : "gemini-flash-latest");
 
-    const threadId = await resolveActiveThread(compareChatThreadId(id1, id2));
+    const threadId = await resolveActiveThread(compareChatThreadId(id1, id2, `${identity.policyVersion}:${identity.generation}`));
     const turnStartedAt = Date.now();
     try {
-      const stream = await compareChatAgent.stream(
-        [{ role: "system", content: systemPrompt }, ...messages],
-        {
-          memory: { thread: threadId, resource: CHAT_RESOURCE_ID },
-          providerOptions: {
-            openai: { reasoningEffort: "medium" },
-            google: buildGoogleReasoningProviderOptions(chatModelLabel, settings.chatThinkingBudget) as never,
-          },
+      const stream = await compareChatAgent.stream([{ role: "system", content: systemPrompt }, ...messages], {
+        memory: { thread: threadId, resource: CHAT_RESOURCE_ID },
+        providerOptions: {
+          openai: { reasoningEffort: "medium" },
+          google: buildGoogleReasoningProviderOptions(chatModelLabel, settings.chatThinkingBudget) as never,
         },
-      );
+      });
 
       return streamAgentTurnResponse({
         agentStream: stream,
@@ -454,7 +501,9 @@ export const comparisonRoutes = new Hono()
     const { id1, id2 } = c.req.valid("param");
     try {
       const memory = getChatMemory();
-      const base = compareChatThreadId(id1, id2);
+      const identity = await getCompareQualityIdentity(id1, id2);
+      if (!identity) return c.json({ ok: true });
+      const base = compareChatThreadId(id1, id2, `${identity.policyVersion}:${identity.generation}`);
       const gens = await listThreadGenerations(base);
       const ids = new Set(gens.map((g) => g.threadId));
       ids.add(base);

--- a/server/session-capture/import-pipeline.ts
+++ b/server/session-capture/import-pipeline.ts
@@ -1,15 +1,19 @@
 import { existsSync, unlinkSync } from "node:fs";
 import type { GameId } from "../../shared/games/ids";
+import type { LapClassification } from "../../shared/racing/laps/classification";
 import type { LapMeta, SessionOwnership } from "../../shared/racing/sessions/types";
 import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
+import type { EligibilityDecisionSet, EvidenceSourceKind, LapQualitySummary, RecordingQualitySummary, SourceChannelProfile } from "../../shared/racing/quality/contracts";
+import type { PersistLapInput } from "../db/lap-mutation-queries";
 import { deleteSession } from "../db/session-queries";
 import { getServerGame } from "../games/registry";
 import { LiveTelemetryPipeline } from "../telemetry/live-pipeline";
 import { NullWsAdapter, RealDbAdapter, type DbAdapter } from "../telemetry/pipeline-ports";
 import { reconcileSessionResult } from "../race-results/reconcile";
+import { finalizeLapQualityGeneration } from "../lap-analysis/quality-generation";
 
 
-export interface ImportedLap {
+export interface ImportedLap extends LapClassification {
   lapId: number;
   sessionId: number;
   lapNumber: number;
@@ -17,24 +21,22 @@ export interface ImportedLap {
   isValid: boolean;
   carOrdinal: number;
   trackOrdinal: number;
+  quality: LapQualitySummary;
+  eligibility: EligibilityDecisionSet;
 }
 
 /**
- * Delegates to RealDbAdapter but captures the returned lap IDs + session
- * metadata so an import caller can tell the UI what got inserted and build
- * deep links into the analyse page.
+ * metadata so import callers can report inserted rows and build deep links.
  */
 export class ImportCaptureAdapter implements DbAdapter {
-  private readonly _inner: RealDbAdapter;
+  private readonly _inner: DbAdapter;
   readonly laps: ImportedLap[] = [];
   readonly sessionIds = new Set<number>();
   readonly rawFiles = new Set<string>();
   private readonly _pendingLapWrites = new Set<Promise<number>>();
   private _lapWriteFailure: unknown;
-  private readonly _sessionMeta = new Map<
-    number,
-    { carOrdinal: number; trackOrdinal: number }
-  >();
+  private readonly _lapIdentity = new Map<number, { lapNumber: number; rawByteOffset: number | null; rawFrameCount: number }>();
+  private readonly _sessionMeta = new Map<number, { carOrdinal: number; trackOrdinal: number }>();
 
   constructor(options: { notifyDriverProfile?: boolean; ownership?: SessionOwnership } = {}) {
     this._inner = new RealDbAdapter(options);
@@ -46,46 +48,35 @@ export class ImportCaptureAdapter implements DbAdapter {
     gameId: GameId,
     sessionType?: string,
     versionIdentity?: TelemetryVersionIdentity,
+    sourceKind?: EvidenceSourceKind,
+    sourceChannelProfile?: SourceChannelProfile,
     ownership?: SessionOwnership,
   ): Promise<number> {
-    const id = await this._inner.insertSession(
-      carOrdinal,
-      trackOrdinal,
-      gameId,
-      sessionType,
-      versionIdentity,
-      ownership,
-    );
+    const id = await this._inner.insertSession(carOrdinal, trackOrdinal, gameId, sessionType, versionIdentity, sourceKind, sourceChannelProfile, ownership);
     this.sessionIds.add(id);
     this._sessionMeta.set(id, { carOrdinal, trackOrdinal });
     return id;
   }
 
-  insertLap(
-    sessionId: number,
-    lapNumber: number,
-    lapTime: number,
-    isValid: boolean,
-    rawByteOffset: number | null,
-    rawFrameCount: number,
-    profileId: number | null,
-    tuneId: number | null,
-    invalidReason: string | null,
-    sectors: number[] | null,
-    versionIdentity?: TelemetryVersionIdentity,
-  ): Promise<number> {
-    const pending = this._inner.insertLap(
-      sessionId, lapNumber, lapTime, isValid, rawByteOffset, rawFrameCount, profileId, tuneId, invalidReason, sectors, versionIdentity
-    ).then((id) => {
-      const meta = this._sessionMeta.get(sessionId);
+  insertLap(input: PersistLapInput): Promise<number> {
+    const pending = this._inner.insertLap(input).then((id) => {
+      const meta = this._sessionMeta.get(input.sessionId);
       this.laps.push({
         lapId: id,
-        sessionId,
-        lapNumber,
-        lapTime,
-        isValid,
+        sessionId: input.sessionId,
+        lapNumber: input.lapNumber,
+        lapTime: input.lapTime,
+        isValid: input.isValid,
+        ...input.classification,
+        quality: input.quality!,
+        eligibility: input.eligibility!,
         carOrdinal: meta?.carOrdinal ?? 0,
         trackOrdinal: meta?.trackOrdinal ?? 0,
+      });
+      this._lapIdentity.set(id, {
+        lapNumber: input.lapNumber,
+        rawByteOffset: input.rawByteOffset,
+        rawFrameCount: input.rawFrameCount,
       });
       return id;
     });
@@ -98,6 +89,20 @@ export class ImportCaptureAdapter implements DbAdapter {
       },
     );
     return pending;
+  }
+
+  async updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+    await this.waitForPendingLapWrites();
+    const finalized = await this._inner.updateSessionQuality(sessionId, quality);
+    for (const lap of this.laps) {
+      if (lap.sessionId !== sessionId) continue;
+      const identity = this._lapIdentity.get(lap.lapId);
+      if (!identity) continue;
+      const generated = finalizeLapQualityGeneration(lap.quality, finalized.provenance.sourceGeneration, identity);
+      lap.quality = generated.quality;
+      lap.eligibility = generated.eligibility;
+    }
+    return finalized;
   }
 
   setLapMetrics(lapId: number, fuelPerLap: number | null, tyreWear: number | null): Promise<void> {

--- a/server/session-capture/reprocess.ts
+++ b/server/session-capture/reprocess.ts
@@ -111,16 +111,23 @@ export async function reprocessSession(sessionId: number): Promise<ReprocessResu
       const existing = existingByLapNum.get(detected.lapNumber);
       if (!existing) continue;
       const sectors = detected.sectors ? [...detected.sectors] : null;
-      await updateLapRawIndex(
-        existing.id,
-        detected.rawByteOffset,
-        detected.rawFrameCount,
-        detected.lapTime,
-        detected.isValid,
-        detected.invalidReason,
+      await updateLapRawIndex({
+        lapId: existing.id,
+        rawByteOffset: detected.rawByteOffset,
+        rawFrameCount: detected.rawFrameCount,
+        lapTime: detected.lapTime,
+        isValid: detected.isValid,
+        invalidReason: detected.invalidReason,
         sectors,
+        classification: {
+          phase: detected.phase,
+          conditions: detected.conditions,
+          paceEligibility: detected.paceEligibility,
+        },
+        quality: detected.quality!,
+        eligibility: detected.eligibility!,
         versionIdentity,
-      );
+      });
       lapsUpdated++;
     }
   } else {
@@ -153,19 +160,26 @@ export async function reprocessSession(sessionId: number): Promise<ReprocessResu
     await deleteLapsForSession(sessionId);
     for (const { detected, preserved } of replacements) {
       const sectors = detected.sectors ? [...detected.sectors] : null;
-      await insertReprocessedLap(
+      await insertReprocessedLap({
         sessionId,
-        detected.lapNumber,
-        detected.lapTime,
-        detected.isValid,
-        detected.rawByteOffset,
-        detected.rawFrameCount,
-        preserved?.tuneId ?? null,
-        preserved?.notes ?? null,
-        detected.invalidReason,
+        lapNumber: detected.lapNumber,
+        lapTime: detected.lapTime,
+        isValid: detected.isValid,
+        rawByteOffset: detected.rawByteOffset,
+        rawFrameCount: detected.rawFrameCount,
+        tuneId: preserved?.tuneId ?? null,
+        notes: preserved?.notes ?? null,
+        invalidReason: detected.invalidReason,
         sectors,
+        classification: {
+          phase: detected.phase,
+          conditions: detected.conditions,
+          paceEligibility: detected.paceEligibility,
+        },
+        quality: detected.quality!,
+        eligibility: detected.eligibility!,
         versionIdentity,
-      );
+      });
       lapsUpdated++;
     }
   }

--- a/server/telemetry/pipeline-ports.ts
+++ b/server/telemetry/pipeline-ports.ts
@@ -1,11 +1,12 @@
 import { resolve } from "node:path";
+import type { LapClassification } from "../../shared/racing/laps/classification";
 import { mkdirSync } from "node:fs";
 import type { GameId } from "../../shared/games/ids";
 import type { LapMeta, SessionOwnership } from "../../shared/racing/sessions/types";
 import type { LivePitData, LiveSectorData } from "../../shared/racing/live/types";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
-import type { LapClassification } from "../../shared/racing/laps/classification";
+import type { ArchiveVerification, EligibilityDecisionSet, EvidenceSourceKind, LapQualitySummary, RecordingQualitySummary, SourceChannelProfile } from "../../shared/racing/quality/contracts";
 import type { TuneIssue } from "../../shared/racing/tuning/issues";
 import type { LiveProjection } from "./live-projector";
 import {
@@ -14,18 +15,16 @@ import {
   TELEMETRY_CATALOG_VERSION,
 } from "../../shared/telemetry/catalog/data";
 import { TELEMETRY_DERIVATION_VERSION } from "../../shared/telemetry/derivations/builtins";
-import {
-  TELEMETRY_PARSER_VERSIONS,
-  TELEMETRY_RESOLVER_VERSION,
-} from "../../shared/telemetry/resolver/versions";
-import { insertSession, updateSessionRawFile, updateSessionCarTrack } from "../db/session-queries";
-import { insertLap, setLapMetrics } from "../db/lap-mutation-queries";
+import { TELEMETRY_PARSER_VERSIONS, TELEMETRY_RESOLVER_VERSION } from "../../shared/telemetry/resolver/versions";
+import { insertSession, updateSessionQuality, updateSessionRawFile, updateSessionCarTrack } from "../db/session-queries";
+import { insertLap, setLapMetrics, type PersistLapInput } from "../db/lap-mutation-queries";
 import { getLaps } from "../db/lap-read-queries";
 import { getLapsForExclusionScope, setLapAutoExclusion, getLapExperimentScope } from "../db/experiment-lap-queries";
 import { notifyDriverProfileLap } from "../driver-profile/runner";
 import type { ExclusionScopeLap } from "../experiments/auto-exclude";
 import { getTuneAssignment } from "../db/tune-queries";
 import { SessionRecorder } from "../session-capture/recorder";
+import { finalizeRecordingQualityGeneration } from "../lap-analysis/quality-generation";
 import { resolveDataDir } from "../runtime/config/data-dir";
 
 export function currentTelemetryVersionIdentity(gameId: GameId): TelemetryVersionIdentity {
@@ -45,9 +44,12 @@ export interface CapturedSession {
   gameId: GameId;
   sessionType?: string;
   versionIdentity?: TelemetryVersionIdentity;
+  sourceKind?: EvidenceSourceKind;
+  sourceChannelProfile?: SourceChannelProfile;
   ownership?: SessionOwnership;
 }
-export interface CapturedLap extends Partial<LapClassification> {
+
+export interface CapturedLap extends LapClassification {
   sessionId: number;
   lapNumber: number;
   lapTime: number;
@@ -61,6 +63,8 @@ export interface CapturedLap extends Partial<LapClassification> {
   /** Populated by parseDump helpers for test assertions only — not present in production. */
   packets?: TelemetryPacket[];
   versionIdentity?: TelemetryVersionIdentity;
+  quality: LapQualitySummary | null;
+  eligibility: EligibilityDecisionSet | null;
 }
 
 export interface DbAdapter {
@@ -70,22 +74,12 @@ export interface DbAdapter {
     gameId: GameId,
     sessionType?: string,
     versionIdentity?: TelemetryVersionIdentity,
+    sourceKind?: EvidenceSourceKind,
+    sourceChannelProfile?: SourceChannelProfile,
     ownership?: SessionOwnership,
   ): Promise<number>;
-  insertLap(
-    sessionId: number,
-    lapNumber: number,
-    lapTime: number,
-    isValid: boolean,
-    rawByteOffset: number | null,
-    rawFrameCount: number,
-    profileId: number | null,
-    tuneId: number | null,
-    invalidReason: string | null,
-    sectors: number[] | null,
-    versionIdentity?: TelemetryVersionIdentity,
-    classification?: LapClassification,
-  ): Promise<number>;
+  insertLap(input: PersistLapInput): Promise<number>;
+  updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary>;
   /** Persist precomputed per-lap fuel/tyre metrics (migration v32 columns).
    *  Called right after insertLap so /lap-metrics is a pure column read and
    *  never has to decode telemetry on first open. */
@@ -93,11 +87,7 @@ export interface DbAdapter {
   getLaps(gameId: GameId, limit: number): Promise<LapMeta[]>;
   updateSessionRawFile(sessionId: number, rawFile: string, lapDetectorVersion: string): Promise<void>;
   updateSessionCarTrack(sessionId: number, carOrdinal: number, trackOrdinal: number): Promise<void>;
-  getTuneAssignment(
-    gameId: GameId,
-    carOrdinal: number,
-    trackOrdinal: number
-  ): Promise<{ carOrdinal: number; trackOrdinal: number; tuneId: number; tuneName: string } | null>;
+  getTuneAssignment(gameId: GameId, carOrdinal: number, trackOrdinal: number): Promise<{ carOrdinal: number; trackOrdinal: number; tuneId: number; tuneName: string } | null>;
   /** Auto-exclude fastest-5 curation (server/experiments/auto-exclude.ts). */
   getLapsForExclusionScope(experimentId: number, tuneId: number): Promise<ExclusionScopeLap[]>;
   setLapAutoExclusion(lapId: number, excluded: boolean): Promise<void>;
@@ -123,7 +113,7 @@ export interface SessionRecorderAdapter {
   writeRecord(buf: Buffer): void;
   getCurrentByteOffset(): number;
   flush(): void;
-  stop(): Promise<void>;
+  stop(): Promise<ArchiveVerification>;
 }
 
 export interface LiveTelemetryPublication {
@@ -133,6 +123,7 @@ export interface LiveTelemetryPublication {
   liveIssues?: TuneIssue[];
   projection?: LiveProjection;
 }
+
 
 export interface WsAdapter {
   /** Legacy packet capture hook retained for callers/tests. */
@@ -146,33 +137,51 @@ export interface WsAdapter {
 
 /** Delegates to the real query functions. Used in production. */
 export class RealDbAdapter implements DbAdapter {
-  private readonly sessionScopes = new Map<number, {
-    gameId: GameId;
-    carOrdinal: number;
-    trackOrdinal: number;
-    versionIdentity: TelemetryVersionIdentity;
-  }>();
+  private readonly sessionScopes = new Map<
+    number,
+    {
+      gameId: GameId;
+      carOrdinal: number;
+      trackOrdinal: number;
+      versionIdentity: TelemetryVersionIdentity;
+    }
+  >();
   private readonly options: { notifyDriverProfile?: boolean; ownership?: SessionOwnership };
 
   constructor(options: { notifyDriverProfile?: boolean; ownership?: SessionOwnership } = {}) {
     this.options = options;
   }
 
-  async insertSession(carOrdinal: number, trackOrdinal: number, gameId: GameId, sessionType?: string, versionIdentity?: TelemetryVersionIdentity, ownership?: SessionOwnership): Promise<number> {
+  async insertSession(
+    carOrdinal: number,
+    trackOrdinal: number,
+    gameId: GameId,
+    sessionType?: string,
+    versionIdentity?: TelemetryVersionIdentity,
+    sourceKind: EvidenceSourceKind = "native-live",
+    sourceChannelProfile?: SourceChannelProfile,
+    ownership?: SessionOwnership,
+  ): Promise<number> {
     const identity = versionIdentity ?? currentTelemetryVersionIdentity(gameId);
-    const sessionId = await insertSession(carOrdinal, trackOrdinal, gameId, sessionType, identity, ownership ?? this.options.ownership);
+    const sessionId = await insertSession(carOrdinal, trackOrdinal, gameId, sessionType, identity, ownership ?? this.options.ownership, sourceKind, sourceChannelProfile);
     this.sessionScopes.set(sessionId, { gameId, carOrdinal, trackOrdinal, versionIdentity: identity });
     return sessionId;
   }
 
-  async insertLap(sessionId: number, lapNumber: number, lapTime: number, isValid: boolean, rawByteOffset: number | null, rawFrameCount: number, profileId: number | null, tuneId: number | null, invalidReason: string | null, sectors: number[] | null, versionIdentity?: TelemetryVersionIdentity, classification?: LapClassification): Promise<number> {
-    const scope = this.sessionScopes.get(sessionId);
-    const lapId = await insertLap(sessionId, lapNumber, lapTime, isValid, rawByteOffset, rawFrameCount, profileId, tuneId, invalidReason, sectors, versionIdentity ?? scope?.versionIdentity, classification);
+  async insertLap(input: PersistLapInput): Promise<number> {
+    const scope = this.sessionScopes.get(input.sessionId);
+    const lapId = await insertLap({
+      ...input,
+      versionIdentity: input.versionIdentity ?? scope?.versionIdentity,
+    });
     if (scope && this.options.notifyDriverProfile !== false) notifyDriverProfileLap(scope.gameId);
     return lapId;
   }
   setLapMetrics(lapId: number, fuelPerLap: number | null, tyreWear: number | null): Promise<void> {
     return setLapMetrics(lapId, fuelPerLap, tyreWear);
+  }
+  updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+    return updateSessionQuality(sessionId, quality);
   }
   getLaps(gameId: GameId, limit: number): Promise<LapMeta[]> {
     return getLaps(gameId, limit);
@@ -206,17 +215,37 @@ export class CapturingDbAdapter implements DbAdapter {
   private _sessionId = 0;
   private _lapId = 0;
 
-  insertSession(carOrdinal: number, trackOrdinal: number, gameId: GameId, sessionType?: string, versionIdentity?: TelemetryVersionIdentity, ownership?: SessionOwnership): Promise<number> {
-    this.sessions.push({ carOrdinal, trackOrdinal, gameId, sessionType, versionIdentity, ownership });
+  insertSession(
+    carOrdinal: number,
+    trackOrdinal: number,
+    gameId: GameId,
+    sessionType?: string,
+    versionIdentity?: TelemetryVersionIdentity,
+    sourceKind: EvidenceSourceKind = "native-live",
+    sourceChannelProfile?: SourceChannelProfile,
+    ownership?: SessionOwnership,
+  ): Promise<number> {
+    this.sessions.push({ carOrdinal, trackOrdinal, gameId, sessionType, versionIdentity, sourceKind, sourceChannelProfile, ownership });
     return Promise.resolve(++this._sessionId);
   }
 
-  insertLap(sessionId: number, lapNumber: number, lapTime: number, isValid: boolean, rawByteOffset: number | null, rawFrameCount: number, profileId: number | null, tuneId: number | null, invalidReason: string | null, sectors: number[] | null, versionIdentity?: TelemetryVersionIdentity, classification?: LapClassification): Promise<number> {
-    this.laps.push({ sessionId, lapNumber, lapTime, isValid, rawByteOffset, rawFrameCount, profileId, tuneId, invalidReason, sectors, versionIdentity, ...classification });
+  insertLap(input: PersistLapInput): Promise<number> {
+    const { classification, ...captured } = input;
+    this.laps.push({ ...captured, ...classification });
     return Promise.resolve(++this._lapId);
   }
 
-  readonly lapMetrics: { lapId: number; fuelPerLap: number | null; tyreWear: number | null }[] = [];
+  readonly sessionQuality = new Map<number, RecordingQualitySummary>();
+  updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+    const finalized = finalizeRecordingQualityGeneration(quality);
+    this.sessionQuality.set(sessionId, finalized);
+    return Promise.resolve(finalized);
+  }
+  readonly lapMetrics: {
+    lapId: number;
+    fuelPerLap: number | null;
+    tyreWear: number | null;
+  }[] = [];
   setLapMetrics(lapId: number, fuelPerLap: number | null, tyreWear: number | null): Promise<void> {
     this.lapMetrics.push({ lapId, fuelPerLap, tyreWear });
     return Promise.resolve();
@@ -269,10 +298,19 @@ export class NullWsAdapter implements WsAdapter {
 
 /** No-op database adapter. Used in benchmarks and tests that don't need DB output. */
 export class NullDbAdapter implements DbAdapter {
-  insertSession(_carOrdinal: number, _trackOrdinal: number, _gameId: GameId, _sessionType?: string, _versionIdentity?: TelemetryVersionIdentity, _ownership?: SessionOwnership): Promise<number> {
+  insertSession(
+    _carOrdinal: number,
+    _trackOrdinal: number,
+    _gameId: GameId,
+    _sessionType?: string,
+    _versionIdentity?: TelemetryVersionIdentity,
+    _sourceKind?: EvidenceSourceKind,
+    _sourceChannelProfile?: SourceChannelProfile,
+    _ownership?: SessionOwnership,
+  ): Promise<number> {
     return Promise.resolve(1);
   }
-  insertLap(_sessionId: number, _lapNumber: number, _lapTime: number, _isValid: boolean, _rawByteOffset: number | null, _rawFrameCount: number, _profileId: number | null, _tuneId: number | null, _invalidReason: string | null, _sectors: number[] | null, _versionIdentity?: TelemetryVersionIdentity, _classification?: LapClassification): Promise<number> {
+  insertLap(_input: PersistLapInput): Promise<number> {
     return Promise.resolve(1);
   }
   setLapMetrics(_lapId: number, _fuelPerLap: number | null, _tyreWear: number | null): Promise<void> {
@@ -286,6 +324,9 @@ export class NullDbAdapter implements DbAdapter {
   }
   updateSessionCarTrack(_sessionId: number, _carOrdinal: number, _trackOrdinal: number): Promise<void> {
     return Promise.resolve();
+  }
+  updateSessionQuality(_sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+    return Promise.resolve(finalizeRecordingQualityGeneration(quality));
   }
   getTuneAssignment(_gameId: GameId, _carOrdinal: number, _trackOrdinal: number): Promise<{ carOrdinal: number; trackOrdinal: number; tuneId: number; tuneName: string } | null> {
     return Promise.resolve(null);
@@ -306,9 +347,15 @@ export class RealSessionRecorderAdapter implements SessionRecorderAdapter {
   private _inner: SessionRecorder | null = null;
   private _epoch = 0;
 
-  get active(): boolean { return this._inner?.recording ?? false; }
-  get path(): string | null { return this._inner?.path ?? null; }
-  get epoch(): number { return this._epoch; }
+  get active(): boolean {
+    return this._inner?.recording ?? false;
+  }
+  get path(): string | null {
+    return this._inner?.path ?? null;
+  }
+  get epoch(): number {
+    return this._epoch;
+  }
 
   start(gameId: GameId): void {
     const dataDir = resolveDataDir();
@@ -321,28 +368,47 @@ export class RealSessionRecorderAdapter implements SessionRecorderAdapter {
     this._epoch++;
   }
 
-  writeMetaFrame(): void { this._inner?.writeMetaFrame(); }
-  writeRecord(buf: Buffer): void { this._inner?.writeRecord(buf); }
-  getCurrentByteOffset(): number { return this._inner?.getCurrentByteOffset() ?? 0; }
-  flush(): void { this._inner?.flush(); }
-  async stop(): Promise<void> {
+  writeMetaFrame(): void {
+    this._inner?.writeMetaFrame();
+  }
+  writeRecord(buf: Buffer): void {
+    this._inner?.writeRecord(buf);
+  }
+  getCurrentByteOffset(): number {
+    return this._inner?.getCurrentByteOffset() ?? 0;
+  }
+  flush(): void {
+    this._inner?.flush();
+  }
+  async stop(): Promise<ArchiveVerification> {
     const inner = this._inner;
     this._inner = null;
-    if (inner) await inner.stop();
+    if (!inner) return { state: "unavailable", sourceGeneration: null, details: "Recorder was not active" };
+    return (await inner.stop()) ?? { state: "unavailable", sourceGeneration: null, details: "Recorder did not provide archive verification" };
   }
 }
 
 /** No-op session recorder — used in tests/benchmarks that re-feed recorded dumps. */
 export class NullSessionRecorderAdapter implements SessionRecorderAdapter {
-  get active(): boolean { return false; }
-  get path(): string | null { return null; }
-  get epoch(): number { return 0; }
+  get active(): boolean {
+    return false;
+  }
+  get path(): string | null {
+    return null;
+  }
+  get epoch(): number {
+    return 0;
+  }
   start(_gameId: GameId): void {}
   writeMetaFrame(): void {}
   writeRecord(_buf: Buffer): void {}
-  getCurrentByteOffset(): number { return 0; }
+  getCurrentByteOffset(): number {
+    return 0;
+  }
   flush(): void {}
-  async stop(): Promise<void> {}
+  async stop(): Promise<ArchiveVerification> {
+    return { state: "unavailable", sourceGeneration: null, details: "Recording disabled" };
+  }
 }
 /** Capturing WebSocket adapter that records all events. Used in tests. */
 export class CapturingWsAdapter implements WsAdapter {

--- a/shared/racing/results/types.ts
+++ b/shared/racing/results/types.ts
@@ -1,4 +1,5 @@
 import type { GameId } from "@shared/games/ids";
+import type { EligibilityDecision } from "@shared/racing/quality/contracts";
 
 export type RaceResultSourceStatus = "direct" | "derived" | "simplified" | "unavailable";
 export type RaceResultOutcomeStatus = "confirmed" | "provisional" | "unavailable";
@@ -150,6 +151,14 @@ export interface RaceResultEvidence {
   };
   conflicts: string[];
   decisions?: Record<string, RaceResultAuthorityDecision>;
+}
+
+export interface RaceResultLapQualityEvidence {
+  lapId: number;
+  lapNumber: number;
+  qualityGeneration: string | null;
+  officialTiming: EligibilityDecision;
+  normalPace: EligibilityDecision;
 }
 
 export interface RaceResult {

--- a/test/ai/tools/generate-lap-analysis.test.ts
+++ b/test/ai/tools/generate-lap-analysis.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { TelemetryPacket } from "../../../shared/telemetry/types";
-
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type LapQualitySummary,
+} from "../../../shared/racing/quality/contracts";
+import type { QualityCacheIdentity } from "../../../server/db/analysis-queries";
 import {
   generateLapAnalysis,
   type GenerateLapAnalysisDeps,
@@ -15,12 +21,41 @@ const validAnalysis = JSON.stringify({
   setup: [],
 });
 
+const QUALITY_GENERATION = "sha256:prompt-quality";
+
+function currentQuality(generation: string): LapQualitySummary {
+  return {
+    provenance: {
+      schemaVersion: QUALITY_SCHEMA_VERSION,
+      policyVersion: ELIGIBILITY_POLICY_VERSION,
+      configurationVersion: QUALITY_CONFIG_VERSION,
+      sourceGeneration: "sha256:prompt-source",
+      outputGeneration: generation,
+    },
+  } as LapQualitySummary;
+}
+
 const lap = {
   id: 7,
   lapTime: 91.2,
   gameId: "fm-2023" as const,
   trackOrdinal: 1,
   telemetry: [{ DistanceTraveled: 0 }, { DistanceTraveled: 100 }],
+  qualityGeneration: QUALITY_GENERATION,
+  qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+  qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+  qualityConfigVersion: QUALITY_CONFIG_VERSION,
+  quality: currentQuality(QUALITY_GENERATION),
+  eligibility: {
+    "corner-trace": {
+      status: "eligible" as const,
+      policyId: "corner-trace" as const,
+      policyVersion: ELIGIBILITY_POLICY_VERSION,
+      confidence: { level: "high" as const, score: 1 },
+      reasons: [],
+      evidenceIds: [],
+    },
+  },
 };
 
 function makeDeps(
@@ -28,11 +63,13 @@ function makeDeps(
     cached?: string;
     generated?: string;
     generateError?: Error;
-    onSave?: (analysis: string) => void;
+    onGenerate?: () => void;
+    onSave?: (analysis: string, identity: QualityCacheIdentity) => void;
   } = {},
-): GenerateLapAnalysisDeps & { generateCalls: number; saves: string[] } {
+): GenerateLapAnalysisDeps & { generateCalls: number; saves: string[]; saveIdentities: QualityCacheIdentity[] } {
   let generateCalls = 0;
   const saves: string[] = [];
+  const saveIdentities: QualityCacheIdentity[] = [];
   let cached = options.cached
     ? {
         analysis: options.cached,
@@ -46,16 +83,19 @@ function makeDeps(
   const deps: GenerateLapAnalysisDeps & {
     generateCalls: number;
     saves: string[];
+    saveIdentities: QualityCacheIdentity[];
   } = {
     generateCalls,
     saves,
+    saveIdentities,
     getLapById: async () => lap as never,
     getCorners: async () => [],
     detectCorners: () => [],
     getAnalysis: async () => cached,
-    saveAnalysis: async (_lapId, analysis) => {
+    saveAnalysis: async (_lapId, analysis, _usage, identity) => {
       saves.push(analysis);
-      options.onSave?.(analysis);
+      saveIdentities.push(identity);
+      options.onSave?.(analysis, identity);
       cached = {
         analysis,
         inputTokens: 1,
@@ -64,6 +104,7 @@ function makeDeps(
         durationMs: 3,
         model: "test-model",
       };
+      return true;
     },
     loadSettings: () =>
       ({
@@ -90,6 +131,7 @@ function makeDeps(
     }),
     runAiStructured: async () => {
       generateCalls++;
+      options.onGenerate?.();
       if (options.generateError) throw options.generateError;
       return {
         analysis: options.generated ?? validAnalysis,
@@ -200,6 +242,40 @@ describe("generateLapAnalysis", () => {
     expect(JSON.parse(result.analysis!).verdict).toBe("Regenerated");
     expect(deps.generateCalls).toBe(1);
     expect(deps.saves).toHaveLength(1);
+  });
+
+  test("passes prompt-load quality identity to save after model generation", async () => {
+    const loadedLap = {
+      ...lap,
+      quality: currentQuality(lap.qualityGeneration),
+    };
+    const deps = makeDeps({
+      onGenerate: () => {
+        loadedLap.qualityGeneration = "sha256:changed-during-model";
+        loadedLap.quality.provenance.policyVersion = "changed-policy";
+      },
+    });
+    deps.getLapById = async () => loadedLap as never;
+
+    const result = await generateLapAnalysis(7, { regenerate: true }, deps);
+
+    expect(result.error).toBeUndefined();
+    expect(deps.saveIdentities).toEqual([
+      {
+        generation: "sha256:prompt-quality",
+        policyVersion: "1",
+      },
+    ]);
+  });
+
+  test("rejects model output when save reports a stale prompt identity", async () => {
+    const deps = makeDeps();
+    deps.saveAnalysis = async () => false;
+
+    const result = await generateLapAnalysis(7, { regenerate: true }, deps);
+
+    expect(result.analysis).toBeNull();
+    expect(result.error).toBe("Lap quality changed during analysis generation. Analysis not cached.");
   });
 
   test("failed regeneration leaves prior valid cache untouched", async () => {

--- a/test/db/analysis-quality-generation.test.ts
+++ b/test/db/analysis-quality-generation.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { and, eq, inArray } from "drizzle-orm";
+
+import { ELIGIBILITY_POLICY_VERSION, QUALITY_CONFIG_VERSION, QUALITY_SCHEMA_VERSION, type LapQualitySummary } from "../../shared/racing/quality/contracts";
+import {
+  getAnalysis,
+  getCompareAnalysis,
+  qualityCacheIdentityForComparison,
+  qualityCacheIdentityForLap,
+  saveAnalysis,
+  saveCompareAnalysis,
+  type AnalysisUsage,
+} from "../../server/db/analysis-queries";
+import { db } from "../../server/db";
+import { compareAnalyses, lapAnalyses, laps, sessions } from "../../server/db/schema";
+
+const createdSessionIds: number[] = [];
+const createdLapIds: number[] = [];
+
+const usage: AnalysisUsage = {
+  inputTokens: 10,
+  outputTokens: 20,
+  costUsd: 0,
+  durationMs: 30,
+  model: "race-test-model",
+};
+
+function currentQuality(generation: string): LapQualitySummary {
+  return {
+    provenance: {
+      schemaVersion: QUALITY_SCHEMA_VERSION,
+      policyVersion: ELIGIBILITY_POLICY_VERSION,
+      configurationVersion: QUALITY_CONFIG_VERSION,
+      sourceGeneration: "sha256:test-source",
+      outputGeneration: generation,
+    },
+  } as LapQualitySummary;
+}
+
+async function createLaps(generations: readonly string[]): Promise<number[]> {
+  const sessionId = (
+    await db
+      .insert(sessions)
+      .values({
+        carOrdinal: 9_231_001,
+        trackOrdinal: 9_231_002,
+        gameId: "iracing",
+        source: "native-live",
+      })
+      .returning({ id: sessions.id })
+      .get()
+  ).id;
+  createdSessionIds.push(sessionId);
+
+  const ids: number[] = [];
+  for (const [index, generation] of generations.entries()) {
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: index + 1,
+          lapTime: 90 + index,
+          isValid: true,
+          qualityGeneration: generation,
+          qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+          quality: currentQuality(generation),
+          qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+          qualityConfigVersion: QUALITY_CONFIG_VERSION,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+    ids.push(lapId);
+    createdLapIds.push(lapId);
+  }
+  return ids;
+}
+
+async function finishModelWork(changeIdentity: () => Promise<void>, output: string): Promise<string> {
+  await changeIdentity();
+  return output;
+}
+
+afterEach(async () => {
+  if (createdLapIds.length > 0) {
+    await db.delete(compareAnalyses).where(inArray(compareAnalyses.lapAId, createdLapIds)).run();
+    await db.delete(compareAnalyses).where(inArray(compareAnalyses.lapBId, createdLapIds)).run();
+  }
+  for (const sessionId of createdSessionIds) {
+    await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
+  }
+  createdLapIds.length = 0;
+  createdSessionIds.length = 0;
+});
+
+describe("AI analysis quality generation races", () => {
+  test("single-lap output generated from stale quality is neither cached nor stamped current", async () => {
+    const originalGeneration = "sha256:single-prompt";
+    const currentGeneration = "sha256:single-current";
+    const [lapId] = await createLaps([originalGeneration]);
+    const expectedIdentity = qualityCacheIdentityForLap({
+      qualityGeneration: originalGeneration,
+      quality: currentQuality(originalGeneration),
+    });
+    if (!expectedIdentity) throw new Error("Expected single-lap quality identity");
+    expect(await saveAnalysis(lapId!, "existing analysis", usage, expectedIdentity)).toBe(true);
+
+    const staleOutput = await finishModelWork(async () => {
+      await db.update(laps).set({ qualityGeneration: currentGeneration }).where(eq(laps.id, lapId!)).run();
+    }, "stale model output");
+    const saved = await saveAnalysis(lapId!, staleOutput, usage, expectedIdentity);
+
+    expect(saved).toBe(false);
+    expect(await getAnalysis(lapId!)).toBeNull();
+    const stored = await db
+      .select({ analysis: lapAnalyses.analysis, qualityGeneration: lapAnalyses.qualityGeneration })
+      .from(lapAnalyses)
+      .where(eq(lapAnalyses.lapId, lapId!))
+      .get();
+    expect(stored).toEqual({
+      analysis: "existing analysis",
+      qualityGeneration: originalGeneration,
+    });
+  });
+
+  test("comparison output generated from stale quality is neither cached nor stamped current", async () => {
+    const originalGenerations = ["sha256:compare-a", "sha256:compare-b"] as const;
+    const [lapAId, lapBId] = await createLaps(originalGenerations);
+    const expectedIdentity = qualityCacheIdentityForComparison([
+      {
+        qualityGeneration: originalGenerations[0],
+        quality: currentQuality(originalGenerations[0]),
+      },
+      {
+        qualityGeneration: originalGenerations[1],
+        quality: currentQuality(originalGenerations[1]),
+      },
+    ]);
+    if (!expectedIdentity) throw new Error("Expected comparison quality identity");
+    expect(await saveCompareAnalysis(lapAId!, lapBId!, "existing comparison", usage, expectedIdentity, "inputs")).toBe(true);
+
+    const staleOutput = await finishModelWork(async () => {
+      await db.update(laps).set({ qualityGeneration: "sha256:compare-a-current" }).where(eq(laps.id, lapAId!)).run();
+    }, "stale comparison output");
+    const saved = await saveCompareAnalysis(lapAId!, lapBId!, staleOutput, usage, expectedIdentity, "inputs");
+
+    expect(saved).toBe(false);
+    expect(await getCompareAnalysis(lapAId!, lapBId!, "inputs")).toBeNull();
+    const [lo, hi] = [lapAId!, lapBId!].sort((left, right) => left - right);
+    const stored = await db
+      .select({ analysis: compareAnalyses.analysis, qualityGeneration: compareAnalyses.qualityGeneration })
+      .from(compareAnalyses)
+      .where(
+        and(
+          eq(compareAnalyses.lapAId, lo!),
+          eq(compareAnalyses.lapBId, hi!),
+          eq(compareAnalyses.kind, "inputs"),
+        ),
+      )
+      .get();
+    expect(stored).toEqual({
+      analysis: "existing comparison",
+      qualityGeneration: expectedIdentity.generation,
+    });
+  });
+
+  test("cache reads reject stale quality metadata even when cache generation still matches", async () => {
+    const generations = ["sha256:stale-cache-a", "sha256:stale-cache-b"] as const;
+    const [lapAId, lapBId] = await createLaps(generations);
+    const lapIdentity = qualityCacheIdentityForLap({
+      qualityGeneration: generations[0],
+      quality: currentQuality(generations[0]),
+    });
+    const comparisonIdentity = qualityCacheIdentityForComparison([
+      { qualityGeneration: generations[0], quality: currentQuality(generations[0]) },
+      { qualityGeneration: generations[1], quality: currentQuality(generations[1]) },
+    ]);
+    if (!lapIdentity || !comparisonIdentity) throw new Error("Expected current quality identities");
+    expect(await saveAnalysis(lapAId!, "stale single analysis", usage, lapIdentity)).toBe(true);
+    expect(await saveCompareAnalysis(lapAId!, lapBId!, "stale comparison", usage, comparisonIdentity, "inputs")).toBe(true);
+
+    await db.update(laps).set({ qualityConfigVersion: "stale-config" }).where(eq(laps.id, lapAId!)).run();
+
+    expect(await getAnalysis(lapAId!)).toBeNull();
+    expect(await getCompareAnalysis(lapAId!, lapBId!, "inputs")).toBeNull();
+  });
+});

--- a/test/db/lap-eligibility.test.ts
+++ b/test/db/lap-eligibility.test.ts
@@ -1,0 +1,398 @@
+import { afterEach, expect, test } from "bun:test";
+import { and, eq, gt, inArray } from "drizzle-orm";
+import { db } from "../../server/db";
+import { getLapCountsByTest } from "../../server/db/experiment-version-queries";
+import { analysisEligibility } from "../../server/db/lap-eligibility";
+import { getSessionRecapData, getSessions } from "../../server/db/session-queries";
+import { computeRecap } from "../../server/lap-analysis/recap";
+import { experimentVersions, experiments, laps, sessions } from "../../server/db/schema";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecisionSet,
+  type EligibilityStatus,
+  type LapQualitySummary,
+} from "../../shared/racing/quality/contracts";
+
+const createdSessionIds: number[] = [];
+const createdExperimentIds: number[] = [];
+
+afterEach(async () => {
+  if (createdSessionIds.length > 0) {
+    await db.delete(laps).where(inArray(laps.sessionId, createdSessionIds)).run();
+    await db.delete(sessions).where(inArray(sessions.id, createdSessionIds)).run();
+    createdSessionIds.length = 0;
+  }
+  if (createdExperimentIds.length > 0) {
+    await db.delete(experimentVersions).where(inArray(experimentVersions.experimentId, createdExperimentIds)).run();
+    await db.delete(experiments).where(inArray(experiments.id, createdExperimentIds)).run();
+    createdExperimentIds.length = 0;
+  }
+});
+function normalPace(status: EligibilityStatus): EligibilityDecisionSet {
+  return {
+    "normal-pace": {
+      status,
+      policyId: "normal-pace",
+      policyVersion: "1",
+      confidence: { level: "high", score: 1 },
+      reasons: [],
+      evidenceIds: [],
+    },
+    "corner-trace": {
+      status,
+      policyId: "corner-trace",
+      policyVersion: "1",
+      confidence: { level: "high", score: 1 },
+      reasons: [],
+      evidenceIds: [],
+    },
+    "setup-analysis": {
+      status,
+      policyId: "setup-analysis",
+      policyVersion: "1",
+      confidence: { level: "high", score: 1 },
+      reasons: [],
+      evidenceIds: [],
+    },
+  } as unknown as EligibilityDecisionSet;
+}
+
+function currentQualityEvidence(generation = "sha256:session-query-quality") {
+  return {
+    quality: {
+      provenance: {
+        schemaVersion: QUALITY_SCHEMA_VERSION,
+        policyVersion: ELIGIBILITY_POLICY_VERSION,
+        configurationVersion: QUALITY_CONFIG_VERSION,
+        sourceGeneration: "sha256:session-query-source",
+        outputGeneration: generation,
+      },
+    } as unknown as LapQualitySummary,
+    qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+    qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+    qualityConfigVersion: QUALITY_CONFIG_VERSION,
+    qualityGeneration: generation,
+  };
+}
+
+test("analysisEligibility filters the normal-pace policy decision", async () => {
+  const sessionId = (await db.insert(sessions).values({ carOrdinal: 992_229, trackOrdinal: 993_229, gameId: "iracing" }).returning({ id: sessions.id }).get()).id;
+  createdSessionIds.push(sessionId);
+  const experimentId = (await db.insert(experiments).values({ gameId: "iracing", name: "pace eligibility test" }).returning({ id: experiments.id }).get()).id;
+  createdExperimentIds.push(experimentId);
+  const experimentVersionId = (await db.insert(experimentVersions).values({ experimentId, version: 1, label: "base" }).returning({ id: experimentVersions.id }).get()).id;
+  const versionLink = { experimentId, experimentVersionId };
+
+  const inserted = await db
+    .insert(laps)
+    .values([
+      { ...versionLink, sessionId, lapNumber: 1, lapTime: 90_000, isValid: true, paceEligibility: "eligible", eligibility: normalPace("eligible") },
+      { ...versionLink, sessionId, lapNumber: 2, lapTime: 89_000, isValid: true, phase: "out", paceEligibility: "excluded", eligibility: normalPace("ineligible") },
+      { ...versionLink, sessionId, lapNumber: 3, lapTime: 88_000, isValid: true, conditions: ["caution"], paceEligibility: "excluded", eligibility: normalPace("ineligible") },
+      { ...versionLink, sessionId, lapNumber: 4, lapTime: 87_000, isValid: false, paceEligibility: "eligible", eligibility: normalPace("eligible") },
+      { ...versionLink, sessionId, lapNumber: 5, lapTime: 0, isValid: true, paceEligibility: "eligible", eligibility: normalPace("eligible") },
+    ])
+    .returning({ id: laps.id, lapNumber: laps.lapNumber })
+    .all();
+  const idByLapNumber = new Map(inserted.map((lap) => [lap.lapNumber, lap.id]));
+  const eligibilityMatches = await db
+    .select({ id: laps.id })
+    .from(laps)
+    .where(and(eq(laps.sessionId, sessionId), analysisEligibility(laps, "normal-pace")))
+    .orderBy(laps.lapNumber)
+    .all();
+  expect(eligibilityMatches.map((lap) => lap.id)).toEqual([idByLapNumber.get(1)!, idByLapNumber.get(4)!, idByLapNumber.get(5)!]);
+
+  const fullyEligible = await db
+    .select({ id: laps.id })
+    .from(laps)
+    .where(and(eq(laps.sessionId, sessionId), analysisEligibility(laps, "normal-pace"), eq(laps.isValid, true), gt(laps.lapTime, 0)))
+    .all();
+  expect(fullyEligible.map((lap) => lap.id)).toEqual([idByLapNumber.get(1)!]);
+
+  expect((await getLapCountsByTest(experimentId)).get(experimentVersionId)).toEqual({
+    lapCount: 5,
+    bestLapMs: null,
+  });
+});
+
+test("experiment test best lap requires a setup-eligible group", async () => {
+  const sessionId = (await db.insert(sessions).values({ carOrdinal: 996_229, trackOrdinal: 997_229, gameId: "iracing" }).returning({ id: sessions.id }).get()).id;
+  createdSessionIds.push(sessionId);
+  const experimentId = (await db.insert(experiments).values({ gameId: "iracing", name: "setup group eligibility test" }).returning({ id: experiments.id }).get()).id;
+  createdExperimentIds.push(experimentId);
+  const experimentVersionId = (await db.insert(experimentVersions).values({ experimentId, version: 1, label: "base" }).returning({ id: experimentVersions.id }).get()).id;
+  const eligibility = normalPace("eligible");
+
+  await db.insert(laps).values(
+    [90_000, 90_500, 89_500].map((lapTime, index) => ({
+      experimentId,
+      experimentVersionId,
+      sessionId,
+      lapNumber: index + 1,
+      lapTime,
+      isValid: true,
+      ...currentQualityEvidence(),
+      eligibility,
+    })),
+  );
+
+  expect((await getLapCountsByTest(experimentId)).get(experimentVersionId)).toEqual({
+    lapCount: 3,
+    bestLapMs: 89_500,
+  });
+});
+
+test("session recap keeps validity and positive-time filters caller-owned", async () => {
+  const currentSessionId = (await db.insert(sessions).values({ carOrdinal: 994_229, trackOrdinal: 995_229, gameId: "iracing" }).returning({ id: sessions.id }).get()).id;
+  const comparisonSessionId = (await db.insert(sessions).values({ carOrdinal: 994_229, trackOrdinal: 995_229, gameId: "iracing" }).returning({ id: sessions.id }).get()).id;
+  createdSessionIds.push(currentSessionId, comparisonSessionId);
+
+  await db.insert(laps).values([
+    {
+      ...currentQualityEvidence(),
+      sessionId: currentSessionId,
+      lapNumber: 1,
+      lapTime: 91_000,
+      isValid: true,
+      paceEligibility: "eligible",
+      sectorTimes: [45_500, 45_500],
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence(),
+      sessionId: comparisonSessionId,
+      lapNumber: 1,
+      lapTime: 90_000,
+      isValid: true,
+      paceEligibility: "eligible",
+      sectorTimes: [45_000, 45_000],
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence(),
+      sessionId: comparisonSessionId,
+      lapNumber: 2,
+      lapTime: 70_000,
+      isValid: true,
+      phase: "out",
+      paceEligibility: "excluded",
+      sectorTimes: [35_000, 35_000],
+      eligibility: normalPace("ineligible"),
+    },
+    {
+      ...currentQualityEvidence(),
+      sessionId: comparisonSessionId,
+      lapNumber: 3,
+      lapTime: 71_000,
+      isValid: true,
+      conditions: ["caution"],
+      paceEligibility: "excluded",
+      sectorTimes: [35_500, 35_500],
+      eligibility: normalPace("ineligible"),
+    },
+    {
+      ...currentQualityEvidence(),
+      sessionId: comparisonSessionId,
+      lapNumber: 4,
+      lapTime: 72_000,
+      isValid: false,
+      paceEligibility: "eligible",
+      sectorTimes: [36_000, 36_000],
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence(),
+      sessionId: comparisonSessionId,
+      lapNumber: 5,
+      lapTime: 0,
+      isValid: true,
+      paceEligibility: "eligible",
+      sectorTimes: [1, 1],
+      eligibility: normalPace("eligible"),
+    },
+  ]);
+
+  const recap = await getSessionRecapData(currentSessionId, "iracing");
+  expect(recap?.allTimeBestSec).toBe(90_000);
+  expect(recap?.allTimeBestSectors).toEqual([45_000, 45_000]);
+});
+
+test("session recap excludes stale and legacy eligibility from cross-session pace", async () => {
+  const currentSessionId = (
+    await db.insert(sessions).values({ carOrdinal: 991_229, trackOrdinal: 990_229, gameId: "iracing" }).returning({ id: sessions.id }).get()
+  ).id;
+  const comparisonSessionId = (
+    await db.insert(sessions).values({ carOrdinal: 991_229, trackOrdinal: 990_229, gameId: "iracing" }).returning({ id: sessions.id }).get()
+  ).id;
+  createdSessionIds.push(currentSessionId, comparisonSessionId);
+
+  const staleColumnEvidence = [
+    { ...currentQualityEvidence("sha256:cross-session-stale-output"), qualityGeneration: "sha256:cross-session-stale-column" },
+    { ...currentQualityEvidence("sha256:cross-session-stale-schema"), qualitySchemaVersion: "legacy-schema" },
+    { ...currentQualityEvidence("sha256:cross-session-stale-policy"), qualityPolicyVersion: "legacy-policy" },
+    { ...currentQualityEvidence("sha256:cross-session-stale-config"), qualityConfigVersion: "legacy-config" },
+  ];
+  const staleProvenanceEvidence = (["schemaVersion", "policyVersion", "configurationVersion"] as const).map((field) => {
+    const evidence = currentQualityEvidence(`sha256:cross-session-stale-provenance-${field}`);
+    return {
+      ...evidence,
+      quality: {
+        ...evidence.quality,
+        provenance: { ...evidence.quality.provenance, [field]: `legacy-${field}` },
+      } as LapQualitySummary,
+    };
+  });
+  const staleRows = [...staleColumnEvidence, ...staleProvenanceEvidence].map((evidence, index) => ({
+    ...evidence,
+    sessionId: comparisonSessionId,
+    lapNumber: index + 2,
+    lapTime: 80_000 - index * 1_000,
+    isValid: true,
+    sectorTimes: [40_000 - index * 500, 40_000 - index * 500],
+    eligibility: normalPace("eligible"),
+  }));
+
+  await db.insert(laps).values([
+    {
+      ...currentQualityEvidence("sha256:cross-session-anchor"),
+      sessionId: currentSessionId,
+      lapNumber: 1,
+      lapTime: 91_000,
+      isValid: true,
+      sectorTimes: [45_500, 45_500],
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence("sha256:cross-session-current"),
+      sessionId: comparisonSessionId,
+      lapNumber: 1,
+      lapTime: 90_000,
+      isValid: true,
+      sectorTimes: [45_000, 45_000],
+      eligibility: normalPace("eligible"),
+    },
+    ...staleRows,
+    {
+      sessionId: comparisonSessionId,
+      lapNumber: staleRows.length + 2,
+      lapTime: 70_000,
+      isValid: true,
+      sectorTimes: [35_000, 35_000],
+      eligibility: normalPace("eligible"),
+    },
+  ]);
+
+  const recap = await getSessionRecapData(currentSessionId, "iracing");
+  expect(recap?.allTimeBestSec).toBe(90_000);
+  expect(recap?.allTimeBestSectors).toEqual([45_000, 45_000]);
+});
+
+test("session query projections preserve current pace evidence and reject stale, missing, non-pace, and legacy rows", async () => {
+  const sessionId = (
+    await db.insert(sessions).values({ carOrdinal: 998_229, trackOrdinal: 999_229, gameId: "iracing" }).returning({ id: sessions.id }).get()
+  ).id;
+  createdSessionIds.push(sessionId);
+
+  await db.insert(laps).values([
+    {
+      ...currentQualityEvidence("sha256:session-query-current"),
+      sessionId,
+      lapNumber: 1,
+      lapTime: 95_000,
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence("sha256:session-query-stale-output"),
+      qualityGeneration: "sha256:session-query-stale-column",
+      sessionId,
+      lapNumber: 2,
+      lapTime: 90_000,
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence("sha256:session-query-stale-version"),
+      qualityPolicyVersion: "legacy-policy",
+      sessionId,
+      lapNumber: 3,
+      lapTime: 89_000,
+      eligibility: normalPace("eligible"),
+    },
+    {
+      sessionId,
+      lapNumber: 4,
+      lapTime: 88_000,
+      eligibility: normalPace("eligible"),
+    },
+    {
+      ...currentQualityEvidence("sha256:session-query-non-pace"),
+      sessionId,
+      lapNumber: 5,
+      lapTime: 87_000,
+      paceEligibility: "excluded",
+      eligibility: normalPace("ineligible"),
+    },
+    {
+      sessionId,
+      lapNumber: 6,
+      lapTime: 86_000,
+      paceEligibility: "eligible",
+    },
+  ]);
+
+  const session = (await getSessions("iracing")).find((row) => row.id === sessionId);
+  expect(session?.bestLapTime).toBe(95_000);
+
+  const recapData = await getSessionRecapData(sessionId, "iracing");
+  if (!recapData) throw new Error("Expected recap query data");
+  const currentLap = recapData.laps.find((lap) => lap.lapNumber === 1);
+  if (!currentLap) throw new Error("Expected current lap projection");
+  expect(currentLap).toMatchObject({
+    qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+    qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+    qualityConfigVersion: QUALITY_CONFIG_VERSION,
+    qualityGeneration: "sha256:session-query-current",
+    quality: {
+      provenance: {
+        schemaVersion: QUALITY_SCHEMA_VERSION,
+        policyVersion: ELIGIBILITY_POLICY_VERSION,
+        configurationVersion: QUALITY_CONFIG_VERSION,
+        outputGeneration: "sha256:session-query-current",
+      },
+    },
+  });
+
+  const recap = computeRecap({
+    ...recapData,
+    carName: "Query test car",
+    trackName: "Query test track",
+  });
+  expect(recap.sparkline.find((lap) => lap.lapNumber === 1)).toMatchObject({
+    qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+    qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+    qualityConfigVersion: QUALITY_CONFIG_VERSION,
+    qualityGeneration: "sha256:session-query-current",
+    quality: {
+      provenance: {
+        schemaVersion: QUALITY_SCHEMA_VERSION,
+        policyVersion: ELIGIBILITY_POLICY_VERSION,
+        configurationVersion: QUALITY_CONFIG_VERSION,
+        outputGeneration: "sha256:session-query-current",
+      },
+    },
+  });
+  expect(recap.sparkline.find((lap) => lap.lapNumber === 2)?.qualityGeneration).toBe("sha256:session-query-stale-column");
+  expect(recap.sparkline.find((lap) => lap.lapNumber === 4)).toMatchObject({
+    quality: null,
+    qualityGeneration: null,
+    qualitySchemaVersion: null,
+    qualityPolicyVersion: null,
+    qualityConfigVersion: null,
+  });
+  expect(recap.lapsValid).toBe(1);
+  expect(recap.bestLapSec).toBe(95_000);
+  expect(recap.bestLapId).toBe(currentLap.id);
+  expect(recap.timeOnTrackSec).toBe(95_000);
+});

--- a/test/db/lap-ownership.test.ts
+++ b/test/db/lap-ownership.test.ts
@@ -9,6 +9,27 @@ import { sessions } from "../../server/db/schema";
 
 const sessionIds: number[] = [];
 const testGameId = "lap-ownership-test" as GameId;
+async function insertTestLap(sessionId: number, lapNumber: number, lapTime: number): Promise<number> {
+  return insertLap({
+    sessionId,
+    lapNumber,
+    lapTime,
+    isValid: true,
+    rawByteOffset: null,
+    rawFrameCount: 0,
+    profileId: null,
+    tuneId: null,
+    invalidReason: null,
+    sectors: null,
+    classification: {
+      phase: "flying",
+      conditions: [],
+      paceEligibility: "eligible",
+    },
+    quality: null,
+    eligibility: null,
+  });
+}
 afterEach(async () => {
   for (const id of sessionIds.splice(0)) await deleteSession(id);
 });
@@ -17,8 +38,8 @@ test("owned stats and profile pool exclude others while general reads preserve o
   const mine = await insertSession(1, 2, testGameId, "race", undefined, "mine");
   const others = await insertSession(1, 2, testGameId, "race", undefined, "others");
   sessionIds.push(mine, others);
-  await insertLap(mine, 1, 90_000, true, null, 0);
-  await insertLap(others, 1, 80_000, true, null, 0);
+  await insertTestLap(mine, 1, 90_000);
+  await insertTestLap(others, 1, 80_000);
 
   const stats = await getLapStats(testGameId);
   expect(stats.totalLaps).toBe(1);
@@ -37,7 +58,7 @@ test("legacy null ownership normalizes to mine at read boundary", async () => {
   const id = await insertSession(3, 4, testGameId);
   sessionIds.push(id);
   await db.update(sessions).set({ ownership: sql`'legacy'` }).where(eq(sessions.id, id)).run();
-  await insertLap(id, 1, 100_000, true, null, 0);
+  await insertTestLap(id, 1, 100_000);
   expect((await getSessions(testGameId)).find((session) => session.id === id)?.ownership).toBe("mine");
   expect((await getLaps(testGameId)).find((lap) => lap.sessionId === id)?.ownership).toBe("mine");
 });

--- a/test/db/migrations/migration-regression.test.ts
+++ b/test/db/migrations/migration-regression.test.ts
@@ -1,13 +1,7 @@
 import { describe, test, expect } from "bun:test";
-import {
-  bootstrap,
-  newClient,
-  runMigrations,
-} from "../../support/db/migrations";
+import { bootstrap, newClient, runMigrations } from "../../support/db/migrations";
 
 describe("migration regressions", () => {
-
-
   test("v45 keeps native car ordinals unique without treating names as identity", async () => {
     const client = newClient();
     await bootstrap(client);
@@ -69,19 +63,9 @@ describe("migration regressions", () => {
 
     await runMigrations(client);
 
-    const rows = await client.execute(
-      "SELECT sector_times FROM laps ORDER BY session_id, lap_number",
-    );
-    expect(rows.rows.map((row) => JSON.parse(String(row.sector_times)))).toEqual([
-      [30, 30],
-      [30, 31, 29],
-      null,
-      null,
-      [30, 31, 29],
-    ]);
-    const sessionVersions = await client.execute(
-      "SELECT id, lap_detector_version FROM sessions ORDER BY id",
-    );
+    const rows = await client.execute("SELECT sector_times FROM laps ORDER BY session_id, lap_number");
+    expect(rows.rows.map((row) => JSON.parse(String(row.sector_times)))).toEqual([[30, 30], [30, 31, 29], null, null, [30, 31, 29]]);
+    const sessionVersions = await client.execute("SELECT id, lap_detector_version FROM sessions ORDER BY id");
     expect(
       sessionVersions.rows.map((row) => ({
         id: Number(row.id),
@@ -183,7 +167,110 @@ describe("migration regressions", () => {
     client.close();
   });
 
+  test("v60 preserves explicit sources and backfills legacy live provenance", async () => {
+    const client = newClient();
+    await bootstrap(client);
+    await runMigrations(client, 59);
+    await client.execute(
+      `INSERT INTO sessions (id, car_ordinal, track_ordinal, game_id, source)
+       VALUES (1, 10, 20, 'iracing', 'motec'),
+              (2, 11, 21, 'acc', NULL)`,
+    );
+    await client.execute(
+      `INSERT INTO laps (session_id, lap_number, lap_time, is_valid, phase, conditions, pace_eligibility)
+       VALUES (1, 1, 100, 1, 'flying', '[]', 'eligible'),
+              (1, 2, 75, 1, 'pit', '[]', 'excluded'),
+              (2, 1, 90, 1, 'flying', '[]', 'eligible')`,
+    );
 
+    await runMigrations(client);
+
+    const sessionRows = await client.execute(
+      "SELECT id, source, recording_quality, quality_generation FROM sessions ORDER BY id",
+    );
+    const migratedSessions = sessionRows.rows.map((row) => ({
+      id: Number(row.id),
+      source: String(row.source),
+      quality: JSON.parse(String(row.recording_quality)),
+      generation: String(row.quality_generation),
+    }));
+    expect(migratedSessions.map(({ id, source, quality }) => ({ id, source, sourceKind: quality.sourceKind }))).toEqual([
+      { id: 1, source: "motec", sourceKind: "motec" },
+      { id: 2, source: "native-live", sourceKind: "native-live" },
+    ]);
+    expect(migratedSessions.every(({ quality }) => quality.lifecycleState === "unavailable")).toBe(true);
+    expect(migratedSessions.every(({ quality }) => quality.facts.some(({ code }: { code: string }) => code === "quality_not_rebuilt"))).toBe(true);
+    expect(migratedSessions.every(({ generation }) => generation === "legacy")).toBe(true);
+
+    const rows = await client.execute("SELECT session_id, lap_number, quality, eligibility, quality_generation FROM laps ORDER BY session_id, lap_number");
+    const migrated = rows.rows.map((row) => ({
+      sessionId: Number(row.session_id),
+      lapNumber: Number(row.lap_number),
+      quality: JSON.parse(String(row.quality)),
+      eligibility: JSON.parse(String(row.eligibility)),
+      generation: String(row.quality_generation),
+    }));
+    expect(migrated[0]?.quality.timing).toMatchObject({ source: "simulator-history", confirmed: true });
+    expect(migrated[0]?.eligibility["official-timing"].status).toBe("eligible_with_warning");
+    expect(migrated[0]?.eligibility["normal-pace"].status).toBe("eligible_with_warning");
+    expect(migrated[0]?.eligibility["corner-trace"].status).toBe("unknown");
+    expect(migrated[0]?.eligibility["corner-trace"].reasons[0].code).toBe("quality_not_rebuilt");
+    expect(migrated[1]?.eligibility["normal-pace"].status).toBe("ineligible");
+    expect(migrated[1]?.eligibility["normal-pace"].reasons[0].code).toBe("non_pace_classification");
+    expect(migrated.every(({ generation }) => generation === "legacy")).toBe(true);
+    expect(migrated[2]?.quality.sourceKind).toBe("native-live");
+    client.close();
+  });
+
+  test("v61 adds nullable source channel profiles without inventing legacy fidelity", async () => {
+    const client = newClient();
+    await bootstrap(client);
+    await runMigrations(client, 60);
+    await client.execute("INSERT INTO sessions (id, car_ordinal, track_ordinal, game_id, source) VALUES (1, 10, 20, 'ac-evo', 'motec')");
+
+    await runMigrations(client);
+
+    const row = (await client.execute("SELECT source_channel_profile FROM sessions WHERE id = 1")).rows[0]!;
+    expect(row.source_channel_profile).toBeNull();
+    const profile = JSON.stringify({
+      schemaVersion: "1",
+      sourceKind: "motec",
+      channels: {
+        "inputs.steer": {
+          treatment: "assumed",
+          mappingStatus: "simplified",
+          sourceChannels: [{ name: "STEERANGLE", declaredHz: 60, effectiveHz: 60 }],
+          limitations: ["Steering normalized using assumed 240 degree full lock."],
+          evidenceId: "source-channel-profile:1:motec:inputs.steer",
+        },
+      },
+    });
+    await client.execute({ sql: "UPDATE sessions SET source_channel_profile = ? WHERE id = 1", args: [profile] });
+    const persisted = (await client.execute("SELECT source_channel_profile FROM sessions WHERE id = 1")).rows[0]!;
+    expect(JSON.parse(String(persisted.source_channel_profile))).toEqual(JSON.parse(profile));
+    client.close();
+  });
+
+  test("v62 versions lap metrics without inventing generations for existing rows", async () => {
+    const client = newClient();
+    await bootstrap(client);
+    await runMigrations(client, 61);
+    await client.execute("INSERT INTO sessions (id, car_ordinal, track_ordinal, game_id) VALUES (1, 10, 20, 'f1-2025')");
+    await client.execute("INSERT INTO laps (id, session_id, lap_number, lap_time) VALUES (1, 1, 1, 100)");
+    await client.execute(
+      `INSERT INTO lap_metrics (lap_id, algo_version, insights, segment_stats, computed_at)
+       VALUES (1, 2, '[]', '[]', '2026-01-01T00:00:00.000Z')`,
+    );
+
+    await runMigrations(client);
+
+    const columns = await client.execute("PRAGMA table_info(lap_metrics)");
+    expect(columns.rows.map((row) => String(row.name))).toContain("quality_generation");
+    const row = (await client.execute("SELECT quality_generation, computed_at FROM lap_metrics WHERE lap_id = 1")).rows[0]!;
+    expect(row.quality_generation).toBeNull();
+    expect(row.computed_at).toBe("2026-01-01T00:00:00.000Z");
+    client.close();
+  });
   test("v58 normalizes pre-existing null and invalid ownership values", async () => {
     const client = newClient();
     await bootstrap(client);
@@ -227,6 +314,5 @@ describe("migration regressions", () => {
     expect(rows.rows[0]?.ownership).toBe("mine");
     client.close();
   });
-
 
 });

--- a/test/db/opponent-quality-persistence.test.ts
+++ b/test/db/opponent-quality-persistence.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "../../server/db";
+import { laps, sessions } from "../../server/db/schema";
+import { finalizeLapQualityGeneration } from "../../server/lap-analysis/quality-generation";
+import { qualityPackets, summarize } from "../support/lap-analysis/quality-model";
+
+const createdSessionIds: number[] = [];
+
+const opponent = {
+  kind: "opponent" as const,
+  sourceId: "car-7",
+  stableId: "driver:opponent-7",
+  identityState: "stable" as const,
+};
+
+const playerOnlySemanticIds = [
+  "inputs.accel",
+  "inputs.brake",
+  "inputs.steer",
+  "fuel.fuel",
+  "tire.temperature.average",
+  "tires.tire-wear",
+  "tires.tire-pressure",
+  "tires.tire-slip-ratio",
+  "tires.tire-slip-angle",
+  "tires.wheel-rotation-speed",
+  "suspension.norm-suspension-travel",
+] as const;
+
+afterEach(async () => {
+  for (const sessionId of createdSessionIds) {
+    await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
+  }
+  createdSessionIds.length = 0;
+});
+
+describe("opponent lap quality JSON persistence", () => {
+  test("roundtrips unavailable player-only channels and reason evidence without zero substitution", async () => {
+    const packets = qualityPackets(500, [248, 249]);
+    const measured = summarize(packets, {
+      participant: opponent,
+      eventIds: ["evt:opponent-gap"],
+    });
+    const generated = finalizeLapQualityGeneration(measured, "sha256:opponent-session", {
+      lapNumber: 8,
+      rawByteOffset: 256,
+      rawFrameCount: packets.length,
+    });
+
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({
+          carOrdinal: 9_236_701,
+          trackOrdinal: 9_236_702,
+          gameId: "iracing",
+          source: "native-live",
+        })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: 8,
+          lapTime: 10,
+          isValid: true,
+          quality: generated.quality,
+          eligibility: generated.eligibility,
+          qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+          qualityPolicyVersion: generated.quality.provenance.policyVersion,
+          qualityConfigVersion: generated.quality.provenance.configurationVersion,
+          qualityGeneration: generated.quality.provenance.outputGeneration,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+
+    const stored = await db.select({ quality: laps.quality, eligibility: laps.eligibility }).from(laps).where(eq(laps.id, lapId)).get();
+
+    expect(stored?.quality?.participant).toEqual(opponent);
+
+    const unavailable = stored?.quality?.channelQuality.filter(({ semanticId }) => playerOnlySemanticIds.includes(semanticId as (typeof playerOnlySemanticIds)[number]));
+    expect(unavailable).toHaveLength(playerOnlySemanticIds.length);
+    for (const channel of unavailable ?? []) {
+      expect(channel.mappingStatus).toBe("unavailable");
+      expect(channel.coverage).toBeNull();
+      expect(channel.confidenceMean).toBeNull();
+      expect(channel.observedCadenceMs).toBeNull();
+      expect(channel.boundaryCoverage.first500Ms).toBeNull();
+      expect(channel.boundaryCoverage.last500Ms).toBeNull();
+      expect(channel.coverage).not.toBe(0);
+      expect(channel.confidenceMean).not.toBe(0);
+    }
+
+    const generatedGapReason = generated.eligibility["normal-pace"].reasons.find(({ code }) => code === "telemetry_gap_minor");
+    const storedGapReason = stored?.eligibility?.["normal-pace"].reasons.find(({ code }) => code === "telemetry_gap_minor");
+    expect(generatedGapReason).toBeDefined();
+    expect(generatedGapReason!.evidenceIds.length).toBeGreaterThan(0);
+    expect(storedGapReason).toBeDefined();
+    expect(storedGapReason!.evidenceIds).toEqual(generatedGapReason!.evidenceIds);
+
+    const generatedOpponentReason = generated.eligibility["ml-training"].reasons.find(({ code }) => code === "opponent_channel_unavailable");
+    const storedOpponentReason = stored?.eligibility?.["ml-training"].reasons.find(({ code }) => code === "opponent_channel_unavailable");
+    expect(generatedOpponentReason).toBeDefined();
+    expect(generatedOpponentReason!.evidenceIds.length).toBeGreaterThan(0);
+    expect(storedOpponentReason).toBeDefined();
+    expect(storedOpponentReason!.evidenceIds).toEqual(generatedOpponentReason!.evidenceIds);
+  });
+});

--- a/test/db/quality-event-linkage.test.ts
+++ b/test/db/quality-event-linkage.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { eq, sql } from "drizzle-orm";
+import { finalizeLapQualityGeneration, finalizeRecordingQualityGeneration } from "../../server/lap-analysis/quality-generation";
+import { db } from "../../server/db";
+import { linkSessionQualityEvents } from "../../server/db/quality-event-queries";
+import { updateSessionQuality } from "../../server/db/session-queries";
+import { laps, pitEvents, sessionResults, sessions } from "../../server/db/schema";
+import { LOCAL_PLAYER_EVIDENCE } from "../../shared/racing/quality/contracts";
+import { RecordingQualityAccumulator } from "../../shared/racing/quality/measure";
+import { evaluateAllEligibility } from "../../shared/racing/quality/policies";
+import { qualityPackets, summarize, TEST_VERSION_IDENTITY } from "../support/lap-analysis/quality-model";
+
+const createdSessionIds: number[] = [];
+
+afterEach(async () => {
+  for (const sessionId of createdSessionIds) await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
+  createdSessionIds.length = 0;
+});
+
+describe("durable quality event linkage", () => {
+  test("links only events matching lap and time range, then stays idempotent", async () => {
+    const packets = qualityPackets(100, [20]);
+    const recordingAccumulator = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of packets) recordingAccumulator.observe(packet);
+    const recordingQuality = finalizeRecordingQualityGeneration(
+      recordingAccumulator.finalize("complete", {
+        state: "verified",
+        sourceGeneration: "sha256:event-source",
+      }),
+    );
+    const measured = summarize(packets, { eventIds: ["pit:ephemeral"] });
+    const generated = finalizeLapQualityGeneration(measured, recordingQuality.provenance.sourceGeneration, {
+      lapNumber: 1,
+      rawByteOffset: 12,
+      rawFrameCount: packets.length,
+    });
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({
+          carOrdinal: 991_237,
+          trackOrdinal: 992_237,
+          gameId: "iracing",
+          source: "native-live",
+          recordingQuality,
+          qualitySchemaVersion: recordingQuality.provenance.schemaVersion,
+          qualityPolicyVersion: recordingQuality.provenance.policyVersion,
+          qualityConfigVersion: recordingQuality.provenance.configurationVersion,
+          qualityGeneration: recordingQuality.provenance.outputGeneration,
+        })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: 1,
+          lapTime: 10,
+          isValid: true,
+          quality: generated.quality,
+          eligibility: evaluateAllEligibility(generated.quality),
+          qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+          qualityPolicyVersion: generated.quality.provenance.policyVersion,
+          qualityConfigVersion: generated.quality.provenance.configurationVersion,
+          qualityGeneration: generated.quality.provenance.outputGeneration,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+    const resultId = (await db.insert(sessionResults).values({ sessionId }).returning({ id: sessionResults.id }).get()).id;
+    const gap = generated.quality.facts.find(({ code }) => code === "telemetry_gap_minor")!;
+    const eventTime = ((gap.timeRange?.startMs ?? 0) + (gap.timeRange?.endMs ?? 0)) / 2_000;
+    const matchingEvent = (
+      await db.insert(pitEvents).values({ resultId, sequence: 1, eventType: "pit", lapNumber: 1, elapsedSeconds: eventTime, durationSeconds: 0.01 }).returning({ id: pitEvents.id }).get()
+    ).id;
+    await db
+      .insert(pitEvents)
+      .values([
+        { resultId, sequence: 2, eventType: "pit", lapNumber: 2, elapsedSeconds: eventTime, durationSeconds: 0.01 },
+        { resultId, sequence: 3, eventType: "position-change", lapNumber: 1, elapsedSeconds: eventTime + 20, durationSeconds: 0.01 },
+      ])
+      .run();
+
+    expect(await linkSessionQualityEvents(sessionId)).toBe(1);
+    const stored = await db.select({ quality: laps.quality }).from(laps).where(eq(laps.id, lapId)).get();
+    const linkedGap = stored?.quality?.facts.find(({ code }) => code === "telemetry_gap_minor");
+    expect(linkedGap?.eventIds).toEqual([`pit-event:${matchingEvent}`]);
+    expect(await linkSessionQualityEvents(sessionId)).toBe(0);
+  });
+
+  test("falls back to lap linkage when event and quality clocks are incomparable", async () => {
+    const packets = qualityPackets(100, [20]);
+    const recordingAccumulator = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of packets) recordingAccumulator.observe(packet);
+    const recordingQuality = finalizeRecordingQualityGeneration(
+      recordingAccumulator.finalize("complete", {
+        state: "verified",
+        sourceGeneration: "sha256:incompatible-clock-source",
+      }),
+    );
+    const generated = finalizeLapQualityGeneration(summarize(packets), recordingQuality.provenance.sourceGeneration, {
+      lapNumber: 7,
+      rawByteOffset: 12,
+      rawFrameCount: packets.length,
+    });
+
+    for (const [index, gameId] of (["acc", "ac-evo", "fm-2023"] as const).entries()) {
+      const sessionId = (
+        await db
+          .insert(sessions)
+          .values({
+            carOrdinal: 991_240 + index,
+            trackOrdinal: 992_240 + index,
+            gameId,
+            source: "native-live",
+            recordingQuality,
+            qualitySchemaVersion: recordingQuality.provenance.schemaVersion,
+            qualityPolicyVersion: recordingQuality.provenance.policyVersion,
+            qualityConfigVersion: recordingQuality.provenance.configurationVersion,
+            qualityGeneration: recordingQuality.provenance.outputGeneration,
+          })
+          .returning({ id: sessions.id })
+          .get()
+      ).id;
+      createdSessionIds.push(sessionId);
+      const lapId = (
+        await db
+          .insert(laps)
+          .values({
+            sessionId,
+            lapNumber: 7,
+            lapTime: 10,
+            isValid: true,
+            quality: generated.quality,
+            eligibility: evaluateAllEligibility(generated.quality),
+            qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+            qualityPolicyVersion: generated.quality.provenance.policyVersion,
+            qualityConfigVersion: generated.quality.provenance.configurationVersion,
+            qualityGeneration: generated.quality.provenance.outputGeneration,
+          })
+          .returning({ id: laps.id })
+          .get()
+      ).id;
+      const resultId = (await db.insert(sessionResults).values({ sessionId }).returning({ id: sessionResults.id }).get()).id;
+      const matchingEvent = (
+        await db.insert(pitEvents).values({ resultId, sequence: 1, eventType: "pit", lapNumber: 7, elapsedSeconds: 100_000, durationSeconds: 0.01 }).returning({ id: pitEvents.id }).get()
+      ).id;
+      await db.insert(pitEvents).values({ resultId, sequence: 2, eventType: "pit", lapNumber: 8, elapsedSeconds: 1, durationSeconds: 10 }).run();
+
+      expect(await linkSessionQualityEvents(sessionId)).toBe(1);
+      const stored = await db.select({ quality: laps.quality }).from(laps).where(eq(laps.id, lapId)).get();
+      const linkedGap = stored?.quality?.facts.find(({ code }) => code === "telemetry_gap_minor");
+      expect(linkedGap?.eventIds).toEqual([`pit-event:${matchingEvent}`]);
+    }
+  });
+
+  test("projects lifecycle evidence only onto overlapping laps", async () => {
+    const firstPackets = qualityPackets(20);
+    const secondPackets = qualityPackets(20).map((packet, index) => ({
+      ...packet,
+      TimestampMS: packet.TimestampMS + 10_000,
+      iracing: packet.iracing ? { ...packet.iracing, sessionTick: index + firstPackets.length } : undefined,
+    }));
+    const recordingAccumulator = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of [...firstPackets, ...secondPackets.slice(0, 5)]) recordingAccumulator.observe(packet);
+    recordingAccumulator.noteSourceLifecycle({ kind: "reconnect", timestampMs: Date.now(), eventId: "lifecycle:reconnect" });
+    for (const packet of secondPackets.slice(5)) recordingAccumulator.observe(packet);
+    const recordingQuality = recordingAccumulator.finalize("complete", {
+      state: "verified",
+      sourceGeneration: "sha256:localized-source",
+    });
+
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({
+          carOrdinal: 991_238,
+          trackOrdinal: 992_238,
+          gameId: "iracing",
+          source: "native-live",
+        })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    for (const [index, packets] of [firstPackets, secondPackets].entries()) {
+      const quality = summarize(packets);
+      await db.insert(laps).values({
+        sessionId,
+        lapNumber: index + 1,
+        lapTime: 10,
+        isValid: true,
+        quality,
+        eligibility: evaluateAllEligibility(quality),
+        qualitySchemaVersion: quality.provenance.schemaVersion,
+        qualityPolicyVersion: quality.provenance.policyVersion,
+        qualityConfigVersion: quality.provenance.configurationVersion,
+        qualityGeneration: quality.provenance.outputGeneration,
+      });
+    }
+
+    await updateSessionQuality(sessionId, recordingQuality);
+    const stored = await db.select({ lapNumber: laps.lapNumber, quality: laps.quality, eligibility: laps.eligibility }).from(laps).where(eq(laps.sessionId, sessionId)).all();
+    const first = stored.find(({ lapNumber }) => lapNumber === 1)!;
+    const second = stored.find(({ lapNumber }) => lapNumber === 2)!;
+
+    expect(first.quality?.facts.some(({ code }) => code === "source_reconnect")).toBe(false);
+    expect(first.quality?.lifecycleState).toBe("exact");
+    expect(second.quality?.facts.find(({ code }) => code === "source_reconnect")?.eventIds).toEqual(["lifecycle:reconnect"]);
+    expect(second.quality?.lifecycleState).toBe("degraded");
+    expect(second.eligibility?.["lap-comparison"].status).toBe("eligible_with_warning");
+    expect(second.eligibility?.["transient-event"].status).toBe("ineligible");
+
+    const cleanRecording = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of [...firstPackets, ...secondPackets]) cleanRecording.observe(packet);
+    await updateSessionQuality(
+      sessionId,
+      cleanRecording.finalize("complete", {
+        state: "verified",
+        sourceGeneration: "sha256:clean-source",
+      }),
+    );
+    const rebuilt = await db.select({ quality: laps.quality }).from(laps).where(eq(laps.sessionId, sessionId)).all();
+    expect(rebuilt.map(({ quality }) => quality?.lifecycleState)).toEqual(["exact", "exact"]);
+    expect(rebuilt.every(({ quality }) => quality?.facts.every(({ id }) => !id.startsWith("session:")))).toBe(true);
+  });
+
+  test("keeps measured ordering faults local without duplicate session facts", async () => {
+    const firstPackets = qualityPackets(20);
+    const secondPackets = qualityPackets(20).map((packet, index) => ({
+      ...packet,
+      TimestampMS: packet.TimestampMS + 10_000,
+      iracing: packet.iracing
+        ? {
+            ...packet.iracing,
+            sessionTick: index === 10 ? firstPackets.length + 2 : index + firstPackets.length,
+          }
+        : undefined,
+    }));
+    const recordingAccumulator = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of [...firstPackets, ...secondPackets]) recordingAccumulator.observe(packet);
+    const recordingQuality = recordingAccumulator.finalize("complete", {
+      state: "verified",
+      sourceGeneration: "sha256:ordering-source",
+    });
+
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({
+          carOrdinal: 991_239,
+          trackOrdinal: 992_239,
+          gameId: "iracing",
+          source: "native-live",
+        })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    for (const [index, packets] of [firstPackets, secondPackets].entries()) {
+      const quality = summarize(packets);
+      await db.insert(laps).values({
+        sessionId,
+        lapNumber: index + 1,
+        lapTime: 10,
+        isValid: true,
+        quality,
+        eligibility: evaluateAllEligibility(quality),
+        qualitySchemaVersion: quality.provenance.schemaVersion,
+        qualityPolicyVersion: quality.provenance.policyVersion,
+        qualityConfigVersion: quality.provenance.configurationVersion,
+        qualityGeneration: quality.provenance.outputGeneration,
+      });
+    }
+
+    await updateSessionQuality(sessionId, recordingQuality);
+    const stored = await db.select({ lapNumber: laps.lapNumber, quality: laps.quality }).from(laps).where(eq(laps.sessionId, sessionId)).all();
+    const first = stored.find(({ lapNumber }) => lapNumber === 1)!;
+    const second = stored.find(({ lapNumber }) => lapNumber === 2)!;
+    const orderingFacts = second.quality?.facts.filter(({ code }) => code === "out_of_order_observations") ?? [];
+
+    expect(first.quality?.facts.some(({ code }) => code === "out_of_order_observations")).toBe(false);
+    expect(first.quality?.lifecycleState).toBe("exact");
+    expect(orderingFacts).toHaveLength(1);
+    expect(orderingFacts[0]?.id.startsWith("session:")).toBe(false);
+    expect(orderingFacts[0]?.timeRange).toEqual({
+      startMs: secondPackets[9]!.TimestampMS,
+      endMs: secondPackets[10]!.TimestampMS,
+    });
+  });
+
+  test("rolls back lap quality changes when session quality persistence fails", async () => {
+    const packets = qualityPackets(20);
+    const initialQuality = summarize(packets);
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({
+          carOrdinal: 991_241,
+          trackOrdinal: 992_241,
+          gameId: "iracing",
+          source: "native-live",
+        })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: 1,
+          lapTime: 10,
+          isValid: true,
+          quality: initialQuality,
+          eligibility: evaluateAllEligibility(initialQuality),
+          qualitySchemaVersion: initialQuality.provenance.schemaVersion,
+          qualityPolicyVersion: initialQuality.provenance.policyVersion,
+          qualityConfigVersion: initialQuality.provenance.configurationVersion,
+          qualityGeneration: initialQuality.provenance.outputGeneration,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+    const recording = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of packets) recording.observe(packet);
+    const recordingQuality = recording.finalize("complete", {
+      state: "verified",
+      sourceGeneration: "sha256:atomic-quality-source",
+    });
+    const triggerName = `reject_session_quality_${sessionId}`;
+    await db.run(sql.raw(`CREATE TEMP TRIGGER ${triggerName} BEFORE UPDATE OF quality_generation ON sessions WHEN NEW.id = ${sessionId} BEGIN SELECT RAISE(ABORT, 'forced quality failure'); END`));
+
+    try {
+      await expect(updateSessionQuality(sessionId, recordingQuality)).rejects.toThrow();
+    } finally {
+      await db.run(sql.raw(`DROP TRIGGER IF EXISTS ${triggerName}`));
+    }
+
+    const storedLap = await db.select({ qualityGeneration: laps.qualityGeneration }).from(laps).where(eq(laps.id, lapId)).get();
+    const storedSession = await db.select({ qualityGeneration: sessions.qualityGeneration }).from(sessions).where(eq(sessions.id, sessionId)).get();
+    expect(storedLap?.qualityGeneration).toBe(initialQuality.provenance.outputGeneration);
+    expect(storedSession?.qualityGeneration).toBeNull();
+  });
+});

--- a/test/db/telemetry-version-identity.test.ts
+++ b/test/db/telemetry-version-identity.test.ts
@@ -1,25 +1,14 @@
 import { expect, test } from "bun:test";
-import {
-  TELEMETRY_CATALOG_HASH,
-  TELEMETRY_CATALOG_SCHEMA_VERSION,
-  TELEMETRY_CATALOG_VERSION,
-} from "../../shared/telemetry/catalog/data";
+import { TELEMETRY_CATALOG_HASH, TELEMETRY_CATALOG_SCHEMA_VERSION, TELEMETRY_CATALOG_VERSION } from "../../shared/telemetry/catalog/data";
 import { TELEMETRY_DERIVATION_VERSION } from "../../shared/telemetry/derivations/builtins";
-import {
-  TELEMETRY_PARSER_VERSIONS,
-  TELEMETRY_RESOLVER_VERSION,
-} from "../../shared/telemetry/resolver/versions";
-import { deleteSession, getSessions, } from "../../server/db/session-queries";
-import { getLapById } from "../../server/db/lap-read-queries";
+import { TELEMETRY_PARSER_VERSIONS, TELEMETRY_RESOLVER_VERSION } from "../../shared/telemetry/resolver/versions";
+import { deleteSession, getSessions } from "../../server/db/session-queries";
+import { getLapById, getLaps } from "../../server/db/lap-read-queries";
 import { initServerGameAdapters } from "../../server/games/init";
-import { RealDbAdapter } from "../../server/telemetry/pipeline-ports"
+import { RealDbAdapter } from "../../server/telemetry/pipeline-ports";
 import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
+import { DEFAULT_LAP_CLASSIFICATION } from "../../shared/racing/laps/classification";
 initServerGameAdapters();
-
-
-
-
-
 
 test("production adapter stamps current runtime identity on sessions and laps", async () => {
   const adapter = new RealDbAdapter();
@@ -33,20 +22,26 @@ test("production adapter stamps current runtime identity on sessions and laps", 
   };
   const sessionId = await adapter.insertSession(990_205, 991_205, "iracing");
   try {
-    const lapId = await adapter.insertLap(
+    const lapId = await adapter.insertLap({
       sessionId,
-      1,
-      88.5,
-      true,
-      null,
-      0,
-      null,
-      null,
-      null,
-      null,
-    );
+      lapNumber: 1,
+      lapTime: 88.5,
+      isValid: true,
+      rawByteOffset: null,
+      rawFrameCount: 0,
+      profileId: null,
+      tuneId: null,
+      invalidReason: null,
+      sectors: null,
+      classification: DEFAULT_LAP_CLASSIFICATION,
+      quality: null,
+      eligibility: null,
+    });
 
     expect(await getLapById(lapId)).toMatchObject(expected);
+    const metadata = (await getLaps("iracing")).find((row) => row.id === lapId);
+    expect(metadata).toMatchObject({ ...expected, rawFrameCount: 0 });
+    expect(metadata).not.toHaveProperty("telemetry");
     const session = (await getSessions("iracing")).find((row) => row.id === sessionId);
     expect(session).toMatchObject(expected);
   } finally {

--- a/test/experiments/arms/lap-link.test.ts
+++ b/test/experiments/arms/lap-link.test.ts
@@ -6,7 +6,27 @@ import { getLapsForExperiment } from "../../../server/db/experiment-lap-queries"
 import { insertLap } from "../../../server/db/lap-mutation-queries";
 import { insertSession } from "../../../server/db/session-queries";
 import { createExperiment } from "../../../server/db/experiment-queries";
-import { getActiveExperiment, setActiveExperiment } from "../../../server/experiments/active"
+import { getActiveExperiment, setActiveExperiment } from "../../../server/experiments/active";
+import { DEFAULT_LAP_CLASSIFICATION } from "../../../shared/racing/laps/classification";
+import type { PersistLapInput } from "../../../server/db/lap-mutation-queries";
+
+function testLap(sessionId: number, lapNumber: number, lapTime: number): PersistLapInput {
+  return {
+    sessionId,
+    lapNumber,
+    lapTime,
+    isValid: true,
+    rawByteOffset: null,
+    rawFrameCount: 0,
+    profileId: null,
+    tuneId: null,
+    invalidReason: null,
+    sectors: null,
+    classification: DEFAULT_LAP_CLASSIFICATION,
+    quality: null,
+    eligibility: null,
+  };
+}
 
 /**
  * Explicit lap ↔ experiment link (migration v25). Tests the DB layer +
@@ -43,20 +63,20 @@ describe("lap ↔ experiment explicit link", () => {
     // Race session A. First lap recorded with NO active tuning session → unlinked.
     const raceA = await insertSession(1, 2, "acc");
     createdSessionIds.push(raceA);
-    const unlinkedLap = await insertLap(raceA, 1, 90000, true, null, 0);
+    const unlinkedLap = await insertLap(testLap(raceA, 1, 90000));
 
     // Activate, then record laps across TWO different race sessions.
     setActiveExperiment(tsId);
     expect(getActiveExperiment()).toBe(tsId);
-    const linkedA = await insertLap(raceA, 2, 89000, true, null, 0);
+    const linkedA = await insertLap(testLap(raceA, 2, 89000));
 
     const raceB = await insertSession(1, 2, "acc");
     createdSessionIds.push(raceB);
-    const linkedB = await insertLap(raceB, 1, 88000, true, null, 0);
+    const linkedB = await insertLap(testLap(raceB, 1, 88000));
 
     // Deactivate → subsequent laps are unlinked again.
     setActiveExperiment(null);
-    const afterLap = await insertLap(raceB, 2, 91000, true, null, 0);
+    const afterLap = await insertLap(testLap(raceB, 2, 91000));
 
     const linked = await getLapsForExperiment(tsId);
     const ids = linked.map((l) => l.id).sort((a, b) => a - b);

--- a/test/games/shared/semantic-replay-native.test.ts
+++ b/test/games/shared/semantic-replay-native.test.ts
@@ -11,6 +11,7 @@ import { META_FRAME_MAGIC } from "../../../server/session-capture/framing";
 import { iterateIRacingNativeFramesForTest, queryLapTelemetryBySemanticId } from "../../../server/telemetry/replay";
 import { initGameAdapters } from "../../../shared/games/init";
 import { canonicalizeTelemetryScalar } from "../../../shared/telemetry/replay/canonicalize";
+import { DEFAULT_LAP_CLASSIFICATION } from "../../../shared/racing/laps/classification";
 
 initGameAdapters();
 initServerGameAdapters();
@@ -115,7 +116,21 @@ test("semantic replay aligns native session frames and hashes decompressed captu
   const sessionId = await insertSession(42, 99, "iracing");
   try {
     await updateSessionRawFile(sessionId, rawFile, "test-detector");
-    const lapId = await insertLap(sessionId, 1, 1, true, rawByteOffset, 2);
+    const lapId = await insertLap({
+      sessionId,
+      lapNumber: 1,
+      lapTime: 1,
+      isValid: true,
+      rawByteOffset,
+      rawFrameCount: 2,
+      profileId: null,
+      tuneId: null,
+      invalidReason: null,
+      sectors: null,
+      classification: DEFAULT_LAP_CLASSIFICATION,
+      quality: null,
+      eligibility: null,
+    });
 
     const replay = await queryLapTelemetryBySemanticId(lapId, ["session.session-state", "motion.speed"]);
     expect(replay?.envelopes).toHaveLength(2);

--- a/test/lap-analysis/persist-lap-metrics.test.ts
+++ b/test/lap-analysis/persist-lap-metrics.test.ts
@@ -4,10 +4,29 @@
  * first-open telemetry decode). Verifies derivation + that nothing is written
  * when no channel is usable.
  */
-import { describe, test, expect } from "bun:test";
-import { persistLapMetrics } from "../../server/lap-analysis/metrics-store";
+import { afterEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "../../server/db";
+import { lapMetrics, laps, sessions } from "../../server/db/schema";
+import { _telemetryCacheForTest } from "../../server/db/telemetry-replay-storage";
+import { initServerGameAdapters } from "../../server/games/init";
+import { finalizeLapQualityGeneration } from "../../server/lap-analysis/quality-generation";
+import { getOrComputeLapMetrics, getOrComputeLapMetricsBatch, persistLapMetrics } from "../../server/lap-analysis/metrics-store";
+import { LAP_METRICS_ALGO_VERSION } from "../../server/lap-analysis/metrics";
 import { CapturingDbAdapter } from "../../server/telemetry/pipeline-ports";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
+import { qualityPackets, summarize } from "../support/lap-analysis/quality-model";
+initServerGameAdapters();
+
+const createdSessionIds: number[] = [];
+
+afterEach(async () => {
+  for (const sessionId of createdSessionIds) {
+    await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
+  }
+  createdSessionIds.length = 0;
+  _telemetryCacheForTest.clear();
+});
 
 
 function mkPackets(opts: { fuelPerLap?: number; tyreWear?: number[]; fuel?: [number, number] }): TelemetryPacket[] {
@@ -41,5 +60,139 @@ describe("persistLapMetrics", () => {
     const db = new CapturingDbAdapter();
     await persistLapMetrics(db, 9, mkPackets({}));
     expect(db.lapMetrics).toHaveLength(0);
+  });
+});
+
+describe("quality-versioned lap metrics cache", () => {
+  test("recomputes one cached row after lap quality generation changes", async () => {
+    const packets = qualityPackets(100);
+    const generated = finalizeLapQualityGeneration(summarize(packets), "legacy", {
+      lapNumber: 1,
+      rawByteOffset: 1_000,
+      rawFrameCount: packets.length,
+    });
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({ carOrdinal: 301, trackOrdinal: 401, gameId: "f1-2025" })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: 1,
+          lapTime: 100,
+          rawByteOffset: 1_000,
+          rawFrameCount: packets.length,
+          quality: generated.quality,
+          eligibility: generated.eligibility,
+          qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+          qualityPolicyVersion: generated.quality.provenance.policyVersion,
+          qualityConfigVersion: generated.quality.provenance.configurationVersion,
+          qualityGeneration: generated.quality.provenance.outputGeneration,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+    _telemetryCacheForTest.set(lapId, packets);
+    await db.insert(lapMetrics).values({
+      lapId,
+      algoVersion: LAP_METRICS_ALGO_VERSION,
+      qualityGeneration: "sha256:stale-quality",
+      insights: "[]",
+      segmentStats: "[]",
+      computedAt: "stale",
+    });
+
+    const metrics = await getOrComputeLapMetrics(lapId);
+
+    expect(metrics?.computedAt).not.toBe("stale");
+    const stored = await db
+      .select({ qualityGeneration: lapMetrics.qualityGeneration, computedAt: lapMetrics.computedAt })
+      .from(lapMetrics)
+      .where(eq(lapMetrics.lapId, lapId))
+      .get();
+    expect(stored).toEqual({
+      qualityGeneration: generated.quality.provenance.outputGeneration,
+      computedAt: metrics!.computedAt,
+    });
+  });
+
+  test("batch recomputes only rows with stale quality generations", async () => {
+    const packets = qualityPackets(100);
+    const generatedByLap = [1, 2].map((lapNumber) =>
+      finalizeLapQualityGeneration(summarize(packets), "legacy", {
+        lapNumber,
+        rawByteOffset: lapNumber * 1_000,
+        rawFrameCount: packets.length,
+      }),
+    );
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({ carOrdinal: 302, trackOrdinal: 402, gameId: "f1-2025" })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    const insertedLaps = await db
+      .insert(laps)
+      .values(
+        generatedByLap.map((generated, index) => ({
+          sessionId,
+          lapNumber: index + 1,
+          lapTime: 100 + index,
+          rawByteOffset: (index + 1) * 1_000,
+          rawFrameCount: packets.length,
+          quality: generated.quality,
+          eligibility: generated.eligibility,
+          qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+          qualityPolicyVersion: generated.quality.provenance.policyVersion,
+          qualityConfigVersion: generated.quality.provenance.configurationVersion,
+          qualityGeneration: generated.quality.provenance.outputGeneration,
+        })),
+      )
+      .returning({ id: laps.id, qualityGeneration: laps.qualityGeneration })
+      .all();
+    const [staleLap, currentLap] = insertedLaps;
+    _telemetryCacheForTest.set(staleLap!.id, packets);
+    _telemetryCacheForTest.set(currentLap!.id, packets);
+    await db.insert(lapMetrics).values([
+      {
+        lapId: staleLap!.id,
+        algoVersion: LAP_METRICS_ALGO_VERSION,
+        qualityGeneration: "sha256:stale-quality",
+        insights: "[]",
+        segmentStats: "[]",
+        computedAt: "stale",
+      },
+      {
+        lapId: currentLap!.id,
+        algoVersion: LAP_METRICS_ALGO_VERSION,
+        qualityGeneration: currentLap!.qualityGeneration,
+        insights: "[]",
+        segmentStats: "[]",
+        computedAt: "cached-current",
+      },
+    ]);
+
+    const metrics = await getOrComputeLapMetricsBatch(insertedLaps.map(({ id }) => id));
+
+    expect(metrics.get(staleLap!.id)?.computedAt).not.toBe("stale");
+    expect(metrics.get(currentLap!.id)?.computedAt).toBe("cached-current");
+    const stored = await db
+      .select({ lapId: lapMetrics.lapId, qualityGeneration: lapMetrics.qualityGeneration, computedAt: lapMetrics.computedAt })
+      .from(lapMetrics)
+      .where(eq(lapMetrics.lapId, staleLap!.id))
+      .get();
+    expect(stored).toEqual({
+      lapId: staleLap!.id,
+      qualityGeneration: staleLap!.qualityGeneration,
+      computedAt: metrics.get(staleLap!.id)!.computedAt,
+    });
   });
 });

--- a/test/lap-analysis/quality-source-parity.test.ts
+++ b/test/lap-analysis/quality-source-parity.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LOCAL_PLAYER_EVIDENCE,
+  type EligibilityDecision,
+  type EligibilityDecisionSet,
+  type EligibilityPolicyId,
+  type SourceChannelProfile,
+} from "../../shared/racing/quality/contracts";
+import { finalizeLapQualityGeneration } from "../../server/lap-analysis/quality-generation";
+import { evaluateAllEligibility } from "../../shared/racing/quality/policies";
+import { RecordingQualityAccumulator } from "../../shared/racing/quality/measure";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+import { qualityPackets, summarize, TEST_VERSION_IDENTITY } from "../support/lap-analysis/quality-model";
+
+function stripNativeSequence(packets: readonly TelemetryPacket[]): TelemetryPacket[] {
+  return packets.map((packet) => ({
+    ...packet,
+    iracing: undefined,
+  }));
+}
+
+function normalizeEligibilityReasons(decisions: EligibilityDecisionSet): Record<string, { status: EligibilityDecision["status"]; reasons: string[] }> {
+  return Object.fromEntries(
+    Object.entries(decisions).map(([policyId, decision]) => [
+      policyId as EligibilityPolicyId,
+      {
+        status: decision.status,
+        reasons: decision.reasons
+          .filter(({ code }) => code !== "imported_source")
+          .map(({ code }) => code)
+          .sort(),
+      },
+    ]),
+  ) as Record<string, { status: EligibilityDecision["status"]; reasons: string[] }>;
+}
+
+describe("remote source packet-loss evidence", () => {
+  const skippedPackets = [248, 249];
+  const eventIds = ["evt:remote-loss"];
+  const packets = qualityPackets(500, skippedPackets);
+  const nativeSequencePackets = packets;
+  const timestampOnlyPackets = stripNativeSequence(packets);
+
+  test("flags remote_packet_loss only when native sequence proves packet loss", () => {
+    const native = summarize(nativeSequencePackets, {
+      sourceKind: "remote-collector",
+      eventIds,
+    });
+
+    const recorder = new RecordingQualityAccumulator("remote-collector", LOCAL_PLAYER_EVIDENCE, TEST_VERSION_IDENTITY);
+    for (const packet of nativeSequencePackets) recorder.observe(packet);
+    const finalized = recorder.finalize("complete", { state: "verified", sourceGeneration: "sha256:remote-source" });
+
+    expect(finalized.gapSummary.countMethod).toBe("native-sequence");
+    expect(finalized.gapSummary.totalMissingCount).toBe(2);
+    expect(native.gapSummary.countMethod).toBe("native-sequence");
+    expect(native.gapSummary.totalMissingCount).toBe(2);
+
+    const remoteLoss = native.facts.find((fact) => fact.code === "remote_packet_loss");
+    const gap = native.facts.find((fact) => fact.code === "telemetry_gap_minor");
+    expect(remoteLoss).toBeDefined();
+    expect(gap).toBeDefined();
+    expect(remoteLoss!.details).toMatchObject({
+      count: native.gapSummary.totalMissingCount,
+    });
+    expect(remoteLoss!.timeRange).toEqual(gap!.timeRange);
+    expect(remoteLoss!.distanceRange).toEqual(gap!.distanceRange);
+    expect(remoteLoss!.eventIds).toEqual(eventIds);
+
+    expect(gap!.details?.inferredMissingCount).toBe(2);
+    expect(gap!.eventIds).toEqual(eventIds);
+    expect(gap!.timeRange).not.toBeNull();
+    expect(gap!.distanceRange).not.toBeNull();
+
+    const byTimestampOnly = summarize(timestampOnlyPackets, {
+      sourceKind: "remote-collector",
+      eventIds,
+    });
+    expect(timestampOnlyPackets[0]!.TimestampMS).toBe(nativeSequencePackets[0]!.TimestampMS);
+    expect(timestampOnlyPackets[timestampOnlyPackets.length - 1]!.TimestampMS).toBe(nativeSequencePackets[nativeSequencePackets.length - 1]!.TimestampMS);
+    expect(byTimestampOnly.gapSummary.countMethod).toBe("timestamp-estimate");
+    expect(byTimestampOnly.facts.some((fact) => fact.code === "remote_packet_loss")).toBe(false);
+  });
+
+  test("local collection must not be mislabeled as remote loss", () => {
+    const native = summarize(nativeSequencePackets, { sourceKind: "native-live" });
+    expect(native.facts.some((fact) => fact.code === "remote_packet_loss")).toBe(false);
+  });
+});
+
+describe("cross-source policy parity", () => {
+  const skipped = [120, 121];
+  const sourceKinds = ["native-live", "raceiq-raw", "raceiq-archive", "iracing-ibt"] as const;
+  const packets = qualityPackets(240, skipped);
+  const evidence = sourceKinds.map((sourceKind) => {
+    const measured = summarize(packets, {
+      sourceKind,
+      eventIds: ["evt:source-parity"],
+      versionIdentity: TEST_VERSION_IDENTITY,
+    });
+
+    return {
+      sourceKind,
+      measured,
+      finalized: finalizeLapQualityGeneration(measured, "sha256:cross-source-session", {
+        lapNumber: 1,
+        rawByteOffset: null,
+        rawFrameCount: packets.length,
+      }),
+    };
+  });
+
+  test("preserves policy status and reason codes after removing provenance-only reasons", () => {
+    const native = evidence.find(({ sourceKind }) => sourceKind === "native-live")!;
+    const baseline = normalizeEligibilityReasons(native.finalized.eligibility);
+
+    for (const sample of evidence) {
+      expect(normalizeEligibilityReasons(sample.finalized.eligibility)).toEqual(baseline);
+      expect(normalizeEligibilityReasons(evaluateAllEligibility(sample.finalized.quality))).toEqual(baseline);
+    }
+  });
+
+  test("keeps provenance generations source-specific and non-null", () => {
+    const provenance = evidence.map(({ sourceKind, finalized }) => ({
+      sourceKind,
+      provenance: finalized.quality.provenance,
+      outputGeneration: finalized.quality.provenance.outputGeneration,
+    }));
+
+    const sourceGeneration = new Set(provenance.map((entry) => entry.provenance.sourceGeneration));
+    const outputGeneration = new Set(provenance.map((entry) => entry.outputGeneration));
+    expect(sourceGeneration.size).toBe(sourceKinds.length);
+    expect(outputGeneration.size).toBe(sourceKinds.length);
+
+    for (const { provenance: resolved } of provenance) {
+      expect(resolved.sourceGeneration).toMatch(/^sha256:/);
+      expect(resolved.outputGeneration).toMatch(/^sha256:/);
+      expect(resolved.schemaVersion).toBeTruthy();
+      expect(resolved.policyVersion).toBeTruthy();
+      expect(resolved.configurationVersion).toBeTruthy();
+    }
+  });
+});
+
+describe("source profile quality generation", () => {
+  const packets = qualityPackets(40);
+  const profile = (treatment: "held" | "resampled", effectiveHz: number, evidenceId: string): SourceChannelProfile => ({
+    schemaVersion: "1",
+    sourceKind: "motec",
+    channels: {
+      "inputs.steer": {
+        treatment,
+        mappingStatus: "simplified",
+        sourceChannels: [{ name: "STEERANGLE", declaredHz: 60, effectiveHz }],
+        limitations: ["Source-authored steering fidelity."],
+        evidenceId,
+      },
+    },
+  });
+  const variants = [
+    profile("held", 10, "source-profile:steer:a"),
+    profile("resampled", 10, "source-profile:steer:a"),
+    profile("held", 20, "source-profile:steer:a"),
+    profile("held", 10, "source-profile:steer:b"),
+  ].map((sourceChannelProfile) => {
+    const measured = summarize(packets, { sourceKind: "motec", sourceChannelProfile });
+    return finalizeLapQualityGeneration(measured, "sha256:same-session-source", {
+      lapNumber: 1,
+      rawByteOffset: null,
+      rawFrameCount: packets.length,
+    });
+  });
+
+  test("preserves typed source treatment, cadence, and evidence identity in persisted quality", () => {
+    const sourceEvidence = variants.map(({ quality }) => quality.channelQuality.find(({ semanticId }) => semanticId === "inputs.steer")?.sourceProfile);
+
+    expect(sourceEvidence).toEqual([
+      {
+        schemaVersion: "1",
+        sourceKind: "motec",
+        treatment: "held",
+        sourceChannels: [{ name: "STEERANGLE", declaredHz: 60, effectiveHz: 10 }],
+        evidenceId: "source-profile:steer:a",
+      },
+      {
+        schemaVersion: "1",
+        sourceKind: "motec",
+        treatment: "resampled",
+        sourceChannels: [{ name: "STEERANGLE", declaredHz: 60, effectiveHz: 10 }],
+        evidenceId: "source-profile:steer:a",
+      },
+      {
+        schemaVersion: "1",
+        sourceKind: "motec",
+        treatment: "held",
+        sourceChannels: [{ name: "STEERANGLE", declaredHz: 60, effectiveHz: 20 }],
+        evidenceId: "source-profile:steer:a",
+      },
+      {
+        schemaVersion: "1",
+        sourceKind: "motec",
+        treatment: "held",
+        sourceChannels: [{ name: "STEERANGLE", declaredHz: 60, effectiveHz: 10 }],
+        evidenceId: "source-profile:steer:b",
+      },
+    ]);
+    expect(new Set(variants.map(({ quality }) => quality.provenance.sourceGeneration)).size).toBe(1);
+    expect(new Set(variants.map(({ quality }) => quality.provenance.outputGeneration)).size).toBe(variants.length);
+  });
+
+  test("links source-authored facts to typed profile evidence without parsing limitations", () => {
+    for (const { quality } of variants) {
+      const steering = quality.channelQuality.find(({ semanticId }) => semanticId === "inputs.steer")!;
+      const fact = quality.facts.find(({ code, semanticIds }) => code === "channel_simplified" && semanticIds.includes("inputs.steer"));
+
+      expect(fact?.eventIds).toEqual([steering.sourceProfile!.evidenceId]);
+      expect(fact?.details).toMatchObject({
+        sourceProfileEvidenceId: steering.sourceProfile!.evidenceId,
+        sourceProfileVersion: steering.sourceProfile!.schemaVersion,
+        sourceKind: "motec",
+        sourceTreatment: steering.sourceProfile!.treatment,
+        sourceChannelCount: 1,
+      });
+    }
+    expect(variants[1]!.quality.facts.some(({ code }) => code === "interpolated_channel")).toBe(true);
+    expect(variants[0]!.quality.facts.some(({ code }) => code === "interpolated_channel")).toBe(false);
+  });
+});

--- a/test/support/lap-analysis/recap.ts
+++ b/test/support/lap-analysis/recap.ts
@@ -1,4 +1,12 @@
 import { computeRecap, type RecapLapInput, type RecapSessionInput } from "../../../server/lap-analysis/recap";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecisionSet,
+  type EligibilityStatus,
+  type LapQualitySummary,
+} from "../../../shared/racing/quality/contracts";
 
 export const baseSession: RecapSessionInput = {
   id: 1,
@@ -8,11 +16,52 @@ export const baseSession: RecapSessionInput = {
   createdAt: "2026-07-15T12:00:00.000Z",
 };
 
+export function normalPaceEligibility(status: EligibilityStatus): EligibilityDecisionSet {
+  return {
+    "normal-pace": {
+      policyId: "normal-pace",
+      policyVersion: "1",
+      status,
+      confidence: { level: status === "unknown" ? "unknown" : "high", score: status === "unknown" ? null : 1 },
+      reasons: [],
+      evidenceIds: [],
+    },
+  } as unknown as EligibilityDecisionSet;
+}
+export function currentQualityEvidence(generation = "sha256:recap-quality"): Pick<
+  RecapLapInput,
+  "quality" | "qualityGeneration" | "qualitySchemaVersion" | "qualityPolicyVersion" | "qualityConfigVersion"
+> {
+  return {
+    quality: {
+      provenance: {
+        schemaVersion: QUALITY_SCHEMA_VERSION,
+        policyVersion: ELIGIBILITY_POLICY_VERSION,
+        configurationVersion: QUALITY_CONFIG_VERSION,
+        sourceGeneration: "sha256:recap-source",
+        outputGeneration: generation,
+      },
+    } as unknown as LapQualitySummary,
+    qualityGeneration: generation,
+    qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+    qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+    qualityConfigVersion: QUALITY_CONFIG_VERSION,
+  };
+}
+
 export function lap(overrides: Partial<RecapLapInput>): RecapLapInput {
+  const isValid = overrides.isValid ?? true;
+  const paceEligibility = overrides.paceEligibility ?? "eligible";
+  const eligibility = overrides.eligibility ?? normalPaceEligibility(isValid && paceEligibility === "eligible" ? "eligible" : "ineligible");
   const merged = {
     lapNumber: 1,
     lapTime: 100,
-    isValid: true,
+    isValid,
+    phase: "flying" as const,
+    conditions: [],
+    paceEligibility,
+    eligibility,
+    ...currentQualityEvidence(),
     sectorTimes: null,
     ...overrides,
   };

--- a/test/telemetry/dynamic-sector-persistence.test.ts
+++ b/test/telemetry/dynamic-sector-persistence.test.ts
@@ -2,23 +2,27 @@ import { expect, test } from "bun:test";
 import { deleteSession, insertSession } from "../../server/db/session-queries";
 import { getLapById, getLaps } from "../../server/db/lap-read-queries";
 import { insertLap } from "../../server/db/lap-mutation-queries";
+import { DEFAULT_LAP_CLASSIFICATION } from "../../shared/racing/laps/classification";
 
 test("ordered six-sector times round-trip without a three-sector projection", async () => {
   const sessionId = await insertSession(990_134, 991_134, "iracing");
   try {
     const sectorTimes = [8.125, 10.25, 11.375, 12.5, 9.625, 10.75];
-    const lapId = await insertLap(
+    const lapId = await insertLap({
       sessionId,
-      1,
-      sectorTimes.reduce((sum, time) => sum + time, 0),
-      true,
-      null,
-      0,
-      null,
-      null,
-      null,
-      sectorTimes,
-    );
+      lapNumber: 1,
+      lapTime: sectorTimes.reduce((sum, time) => sum + time, 0),
+      isValid: true,
+      rawByteOffset: null,
+      rawFrameCount: 0,
+      profileId: null,
+      tuneId: null,
+      invalidReason: null,
+      sectors: sectorTimes,
+      classification: DEFAULT_LAP_CLASSIFICATION,
+      quality: null,
+      eligibility: null,
+    });
 
     const stored = (await getLaps("iracing")).find((lap) => lap.id === lapId);
     expect(stored?.sectorTimes).toEqual(sectorTimes);

--- a/test/telemetry/pipeline-adapters.test.ts
+++ b/test/telemetry/pipeline-adapters.test.ts
@@ -1,7 +1,28 @@
 import { describe, test, expect, spyOn } from "bun:test";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
-import { RealDbAdapter, CapturingDbAdapter, NullWsAdapter } from "../../server/telemetry/pipeline-ports"
+import { DEFAULT_LAP_CLASSIFICATION } from "../../shared/racing/laps/classification";
+import { RealDbAdapter, CapturingDbAdapter, NullWsAdapter } from "../../server/telemetry/pipeline-ports";
 import * as DriverProfileRunner from "../../server/driver-profile/runner";
+import type { PersistLapInput } from "../../server/db/lap-mutation-queries";
+
+function lapInput(sessionId: number, lapNumber = 1, overrides: Partial<PersistLapInput> = {}): PersistLapInput {
+  return {
+    sessionId,
+    lapNumber,
+    lapTime: 90000,
+    isValid: true,
+    rawByteOffset: null,
+    rawFrameCount: 0,
+    profileId: null,
+    tuneId: null,
+    invalidReason: null,
+    sectors: null,
+    classification: DEFAULT_LAP_CLASSIFICATION,
+    quality: null,
+    eligibility: null,
+    ...overrides,
+  };
+}
 
 describe("CapturingDbAdapter", () => {
   test("insertSession captures data and returns incrementing IDs", async () => {
@@ -22,7 +43,7 @@ describe("CapturingDbAdapter", () => {
   test("insertLap captures data and returns incrementing IDs", async () => {
     const db = new CapturingDbAdapter();
     await db.insertSession(1, 1, "f1-2025");
-    const id = await db.insertLap(1, 1, 90000, true, null, 0, null, null, null, null);
+    const id = await db.insertLap(lapInput(1));
     expect(id).toBe(1);
     expect(db.laps).toHaveLength(1);
     expect(db.laps[0]).toMatchObject({
@@ -30,13 +51,16 @@ describe("CapturingDbAdapter", () => {
       lapNumber: 1,
       lapTime: 90000,
       isValid: true,
+      phase: "flying",
+      conditions: [],
+      paceEligibility: "eligible",
     });
   });
 
   test("insertLap captures sectors", async () => {
     const db = new CapturingDbAdapter();
     await db.insertSession(1, 1, "f1-2025");
-    await db.insertLap(1, 1, 90000, true, null, 0, null, null, null, [30000, 30000, 30000]);
+    await db.insertLap(lapInput(1, 1, { sectors: [30000, 30000, 30000] }));
     expect(db.laps[0].sectors).toEqual([30000, 30000, 30000]);
   });
 
@@ -56,8 +80,14 @@ test("RealDbAdapter notifies global profile after valid and dirty persisted laps
   try {
     const db = new RealDbAdapter();
     const sessionId = await db.insertSession(1, 1, "f1-2025");
-    await db.insertLap(sessionId, 1, 90000, true, null, 0, null, null, null, null);
-    await db.insertLap(sessionId, 2, 91000, false, null, 0, null, null, "dirty", null);
+    await db.insertLap(lapInput(sessionId));
+    await db.insertLap(
+      lapInput(sessionId, 2, {
+        lapTime: 91000,
+        isValid: false,
+        invalidReason: "dirty",
+      }),
+    );
     expect(notify).toHaveBeenNthCalledWith(1, "f1-2025");
     expect(notify).toHaveBeenNthCalledWith(2, "f1-2025");
   } finally {
@@ -70,7 +100,7 @@ test("RealDbAdapter can suppress profile notifications for imports", async () =>
   try {
     const db = new RealDbAdapter({ notifyDriverProfile: false });
     const sessionId = await db.insertSession(1, 1, "f1-2025");
-    await db.insertLap(sessionId, 1, 90000, true, null, 0, null, null, null, null);
+    await db.insertLap(lapInput(sessionId));
     expect(notify).not.toHaveBeenCalled();
   } finally {
     notify.mockRestore();


### PR DESCRIPTION
Replacement for closed #269 after reviewer remediation.

Part 3 of 8 for #231

Parent: #268. Base: `issue-229/02-quality-policy`.

## Behavior
- Persist lap and session quality with schema, policy, configuration, and generation identity.
- Reject stale quality snapshots and version quality-dependent metrics and analysis caches atomically.

## Focused verification
- `Focused persistence, migration, eligibility projection, telemetry identity, ownership, and quality generation suites.`
- `bun run typecheck`