### PR TITLE
feat(telemetry): finalize live capture provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@
 - Carry imported channel fidelity into eligibility reasons and confidence so strict analyses reject held, resampled, reconstructed, or assumed evidence
 - Measure lap coverage from native progress or track length without penalizing later laps whose distance counter is cumulative
 - Keep packet ordering faults confined to affected laps and telemetry ranges instead of limiting unrelated analysis
+- Record reconnect and timeout quality warnings only for accepted telemetry from same game and session, preventing stale UDP traffic from degrading another recording
+- Replace provisional live lap evidence with finalized quality in current and newly connected clients
+- Keep live and replay telemetry gap measurements aligned across native packet IDs and timestamp-only sources
+- Clear stale degraded lap-quality states after a clean recording rebuild
 - Make stale-session reprocessing recoverable with retry and dismissal actions, accessible progress states, and clear failure feedback
 - Skip unavailable raw captures during stale-session reprocessing instead of failing the entire maintenance run
 - Keep newly started session captures from being removed by concurrent storage cleanup

--- a/server/lap-detection/types.ts
+++ b/server/lap-detection/types.ts
@@ -65,6 +65,8 @@ export interface ILapDetector {
    * stuck at null.
    */
   setCurrentLapByteOffset?(offset: number): void;
+  /** Wait until every accepted lap and its persistence follow-ups settle. */
+  waitForPendingLapWrites?(): Promise<void>;
   /** Return implementation-specific debug state for the dev panel. */
   getDebugState?(): Record<string, unknown>;
 }

--- a/server/live-strategy/pit-tracker.ts
+++ b/server/live-strategy/pit-tracker.ts
@@ -2,17 +2,13 @@ import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { GameId } from "../../shared/games/ids";
 import type { LivePitData } from "../../shared/racing/live/types";
 import type { LapMeta } from "../../shared/racing/sessions/types";
+import type { EligibilityDecisionSet } from "../../shared/racing/quality/contracts";
+import { isEligibilityUsable, isTimedLapEligibilityUsable } from "../../shared/racing/quality/policies";
 import { getLaps, getLapById } from "../db/lap-read-queries";
 import type { ServerGameRuntimePolicy } from "../games/types";
-import {
-  appendWithCap,
-  interpolateGrid,
-  lapsUntilThreshold,
-  linearInterpolate,
-  rollingAverage,
-} from "./tracker-math";
+import { appendWithCap, interpolateGrid, lapsUntilThreshold, linearInterpolate, rollingAverage } from "./tracker-math";
 
-const CRITICAL_HEALTH_THRESHOLD = 0.20;
+const CRITICAL_HEALTH_THRESHOLD = 0.2;
 
 /**
  * Server-side pit strategy tracker.
@@ -54,9 +50,10 @@ export class PitTracker {
   private lapTimeHistory: number[] = [];
   private lastCurrentLap = 0;
   private sessionLapCount = 0;
+  private completedLapEligibility: EligibilityDecisionSet | null = null;
 
   // Health thresholds supplied by the active adapter.
-  private badHealthThreshold = 0.40;
+  private badHealthThreshold = 0.4;
 
   reset(): void {
     this.fuelHistory = [];
@@ -70,6 +67,7 @@ export class PitTracker {
     this.lapTimeHistory = [];
     this.lastCurrentLap = 0;
     this.sessionLapCount = 0;
+    this.completedLapEligibility = null;
   }
 
   setTireThresholds(yellow: number): void {
@@ -80,27 +78,31 @@ export class PitTracker {
    * Seed enabled fuel and tire histories from previous sessions.
    * The active adapter decides which historical signals are comparable.
    */
-  async seedFromHistory(
-    trackOrdinal: number,
-    carOrdinal: number,
-    pi: number,
-    gameId: GameId,
-    policy: ServerGameRuntimePolicy["pit"],
-  ): Promise<void> {
+  async seedFromHistory(trackOrdinal: number, carOrdinal: number, pi: number, gameId: GameId, policy: ServerGameRuntimePolicy["pit"]): Promise<void> {
     const seedFuel = policy.seedFuelFromHistory;
     const seedTires = policy.seedTireWearFromHistory;
     try {
       const allLaps = await getLaps(gameId, 200);
       const matching = allLaps
-        .filter((l: LapMeta) => l.trackOrdinal === trackOrdinal && l.carOrdinal === carOrdinal && l.pi === pi && l.isValid && l.lapTime > 10)
-        .sort((a: LapMeta, b: LapMeta) => b.id - a.id) // newest first
-        .slice(0, 5);
+        .filter(
+          (lap: LapMeta) =>
+            lap.trackOrdinal === trackOrdinal &&
+            lap.carOrdinal === carOrdinal &&
+            lap.pi === pi &&
+            lap.lapTime > 10,
+        )
+        .sort((a: LapMeta, b: LapMeta) => b.id - a.id); // newest first
 
       const fuelRates: number[] = [];
       const wearRates: { fl: number; fr: number; rl: number; rr: number }[] = [];
 
       for (const lapMeta of matching) {
-        if ((!seedFuel || fuelRates.length >= 2) && (!seedTires || wearRates.length >= 1)) break;
+        const needsFuel = seedFuel && fuelRates.length < 2;
+        const needsTires = seedTires && wearRates.length < 1;
+        if (!needsFuel && !needsTires) break;
+        const fuelEligible = needsFuel && isTimedLapEligibilityUsable(lapMeta, "fuel-burn");
+        const tireEligible = needsTires && isTimedLapEligibilityUsable(lapMeta, "tire-analysis");
+        if (!fuelEligible && !tireEligible) continue;
         const lap = await getLapById(lapMeta.id);
         if (!lap?.telemetry || lap.telemetry.length < 50) continue;
 
@@ -109,12 +111,12 @@ export class PitTracker {
 
         // Fuel
         const fuelUsed = first.Fuel - last.Fuel;
-        if (fuelUsed > 0 && fuelRates.length < 2) {
+        if (fuelEligible && fuelUsed > 0 && fuelRates.length < 2) {
           fuelRates.push(fuelUsed);
         }
 
         // Tire wear is only read when the adapter marks history comparable.
-        if (seedTires && wearRates.length < 1) {
+        if (tireEligible && wearRates.length < 1) {
           const worn = {
             fl: Math.max(0, last.TireWearFL - first.TireWearFL),
             fr: Math.max(0, last.TireWearFR - first.TireWearFR),
@@ -137,6 +139,9 @@ export class PitTracker {
       console.warn("[Pit] Failed to seed from history:", err);
     }
   }
+  acceptCompletedLap(eligibility: EligibilityDecisionSet): void {
+    this.completedLapEligibility = eligibility;
+  }
 
   /** Check if a lap's data should be excluded (formation lap, pit lap, etc.) */
   private isOutlier(fuelUsed: number, lapTime: number): boolean {
@@ -155,20 +160,24 @@ export class PitTracker {
   feed(packet: TelemetryPacket, trackLength: number, lapDistStart: number = 0): LivePitData {
     // Detect lap boundary
     if (this.lastLap >= 0 && packet.LapNumber > this.lastLap) {
+      const fuelUsable = isEligibilityUsable(this.completedLapEligibility?.["fuel-burn"]);
+      const tireUsable = isEligibilityUsable(this.completedLapEligibility?.["tire-analysis"]);
+      const normalPaceUsable = isEligibilityUsable(this.completedLapEligibility?.["normal-pace"]);
+      this.completedLapEligibility = null;
       const lapTime = this.lastCurrentLap; // CurrentLap at end of previous lap
 
       // Fuel
       const fuelUsed = this.fuelAtLapStart >= 0 ? this.fuelAtLapStart - packet.Fuel : 0;
       const outlier = this.isOutlier(fuelUsed, lapTime);
 
-      if (!outlier && fuelUsed > 0) {
+      if (fuelUsable && !outlier && fuelUsed > 0) {
         appendWithCap(this.fuelHistory, fuelUsed, 50);
         this.sessionLapCount++;
       }
       this.fuelAtLapStart = packet.Fuel;
 
       // Per-tire wear
-      if (!outlier && this.wearAtLapStart.fl >= 0) {
+      if (tireUsable && !outlier && this.wearAtLapStart.fl >= 0) {
         const worn = {
           fl: packet.TireWearFL - this.wearAtLapStart.fl,
           fr: packet.TireWearFR - this.wearAtLapStart.fr,
@@ -181,14 +190,16 @@ export class PitTracker {
         }
       }
       this.wearAtLapStart = {
-        fl: packet.TireWearFL, fr: packet.TireWearFR,
-        rl: packet.TireWearRL, rr: packet.TireWearRR,
+        fl: packet.TireWearFL,
+        fr: packet.TireWearFR,
+        rl: packet.TireWearRL,
+        rr: packet.TireWearRR,
       };
       // Snapshot for live curve-based delta
       this.liveWearAtLapStart = { ...this.wearAtLapStart };
 
       // Track lap times for outlier detection
-      if (lapTime > 10) {
+      if (normalPaceUsable && lapTime > 10) {
         appendWithCap(this.lapTimeHistory, lapTime, 20);
       }
     }
@@ -197,8 +208,10 @@ export class PitTracker {
       if (this.fuelAtLapStart < 0) this.fuelAtLapStart = packet.Fuel;
       if (this.wearAtLapStart.fl < 0) {
         this.wearAtLapStart = {
-          fl: packet.TireWearFL, fr: packet.TireWearFR,
-          rl: packet.TireWearRL, rr: packet.TireWearRR,
+          fl: packet.TireWearFL,
+          fr: packet.TireWearFR,
+          rl: packet.TireWearRL,
+          rr: packet.TireWearRR,
         };
         this.liveWearAtLapStart = { ...this.wearAtLapStart };
       }
@@ -227,7 +240,7 @@ export class PitTracker {
         const refWear = interpolateGrid(this.refWearCurve.wears[i], lapDist);
         if (refWear >= 0) {
           const actualWearDelta = wears[i] - liveStartArr[i]; // actual wear so far this lap
-          const wearDeviation = actualWearDelta - refWear;     // ahead/behind reference
+          const wearDeviation = actualWearDelta - refWear; // ahead/behind reference
           projectedWearPerLap[i] = Math.max(0, this.refWearCurve.totalWear[i] + wearDeviation);
         }
       }
@@ -257,31 +270,15 @@ export class PitTracker {
     // Per-tire estimates
     for (let i = 0; i < 4; i++) {
       const health = 1 - wears[i];
-      toCliff[i] = lapsUntilThreshold(
-        health,
-        this.badHealthThreshold,
-        projectedWearPerLap[i],
-      );
-      toDead[i] = lapsUntilThreshold(
-        health,
-        CRITICAL_HEALTH_THRESHOLD,
-        projectedWearPerLap[i],
-      );
+      toCliff[i] = lapsUntilThreshold(health, this.badHealthThreshold, projectedWearPerLap[i]);
+      toDead[i] = lapsUntilThreshold(health, CRITICAL_HEALTH_THRESHOLD, projectedWearPerLap[i]);
     }
 
     // Worst-tire summary
     const worstWear = Math.max(...wears);
     const health = 1 - worstWear;
-    const tireLapsToBad = lapsUntilThreshold(
-      health,
-      this.badHealthThreshold,
-      worstWearPerLap,
-    );
-    const tireLapsToCritical = lapsUntilThreshold(
-      health,
-      CRITICAL_HEALTH_THRESHOLD,
-      worstWearPerLap,
-    );
+    const tireLapsToBad = lapsUntilThreshold(health, this.badHealthThreshold, worstWearPerLap);
+    const tireLapsToCritical = lapsUntilThreshold(health, CRITICAL_HEALTH_THRESHOLD, worstWearPerLap);
 
     const tireLapsRemaining = tireLapsToBad;
 
@@ -301,9 +298,7 @@ export class PitTracker {
     }
 
     const hasEstimates = fuelPerLap > 0 || worstWearPerLap > 0;
-    const estimateSource: "history" | "session" | null = !hasEstimates
-      ? null
-      : this.sessionLapCount > 0 ? "session" : "history";
+    const estimateSource: "history" | "session" | null = !hasEstimates ? null : this.sessionLapCount > 0 ? "session" : "history";
 
     return {
       fuelPerLap,
@@ -347,10 +342,7 @@ export class PitTracker {
     const startWear = [packets[0].TireWearFL, packets[0].TireWearFR, packets[0].TireWearRL, packets[0].TireWearRR];
 
     // Resample onto 1-meter grid via linear interpolation
-    const wears: [Float64Array, Float64Array, Float64Array, Float64Array] = [
-      new Float64Array(trackLen), new Float64Array(trackLen),
-      new Float64Array(trackLen), new Float64Array(trackLen),
-    ];
+    const wears: [Float64Array, Float64Array, Float64Array, Float64Array] = [new Float64Array(trackLen), new Float64Array(trackLen), new Float64Array(trackLen), new Float64Array(trackLen)];
 
     let pi = 0; // packet index cursor
     for (let m = 0; m < trackLen; m++) {
@@ -373,10 +365,7 @@ export class PitTracker {
       }
     }
 
-    const totalWear: [number, number, number, number] = [
-      wears[0][trackLen - 1], wears[1][trackLen - 1],
-      wears[2][trackLen - 1], wears[3][trackLen - 1],
-    ];
+    const totalWear: [number, number, number, number] = [wears[0][trackLen - 1], wears[1][trackLen - 1], wears[2][trackLen - 1], wears[3][trackLen - 1]];
 
     const curve: ResampledWearCurve = { wears, totalWear, length: trackLen };
     appendWithCap(this.recentWearCurves, curve, 3);
@@ -389,13 +378,10 @@ export class PitTracker {
   private averageWearCurves(): ResampledWearCurve | null {
     const curves = this.recentWearCurves;
     if (curves.length === 0) return null;
-    const len = Math.min(...curves.map(c => c.length));
+    const len = Math.min(...curves.map((c) => c.length));
     if (len < 100) return null;
 
-    const wears: [Float64Array, Float64Array, Float64Array, Float64Array] = [
-      new Float64Array(len), new Float64Array(len),
-      new Float64Array(len), new Float64Array(len),
-    ];
+    const wears: [Float64Array, Float64Array, Float64Array, Float64Array] = [new Float64Array(len), new Float64Array(len), new Float64Array(len), new Float64Array(len)];
     const totalWear: [number, number, number, number] = [0, 0, 0, 0];
     const n = curves.length;
 
@@ -427,7 +413,7 @@ export class PitTracker {
       tireWearHistoryLength: this.tireWearHistory.length,
       wearAtLapStart: this.wearAtLapStart,
       recentWearCurvesLength: this.recentWearCurves.length,
-      refWearCurveLength: this.refWearCurve ? this.refWearCurve.wears[0]?.length ?? 0 : 0,
+      refWearCurveLength: this.refWearCurve ? (this.refWearCurve.wears[0]?.length ?? 0) : 0,
       liveWearAtLapStart: this.liveWearAtLapStart,
       lapTimeHistoryLength: this.lapTimeHistory.length,
       lastCurrentLap: this.lastCurrentLap,

--- a/server/runtime/README.md
+++ b/server/runtime/README.md
@@ -19,7 +19,7 @@
 - Boot ordering is intentional: adapters and database state initialize before listeners; HTTP starts before UDP and background jobs; native sources and desktop integration start before maintenance jobs; the ready message is last.
 - HTTP port precedence is explicit option, then `SERVER_PORT`, then `3117`. UDP port precedence is explicit option, persisted setting, then `UDP_PORT`, then `5301`. `DATA_DIR` overrides the derived user-data path, while tests refuse an implicit real user-data path.
 - HTTP paths remain partitioned: `/ws` is the WebSocket upgrade, `/api` and `/studio-api` dispatch to Hono, production serves bundled assets with SPA fallback, and development may serve public files.
-- UDP binds IPv4 on `0.0.0.0` by default, preserves raw recording frames before parsing, and owns its one-second status/flush interval across restarts.
+- UDP binds IPv4 on `0.0.0.0` by default, records length-valid raw UDP datagrams before parsing—including parser-skipped packets—and owns its one-second status/flush interval across restarts. Timeout and reconnect evidence is emitted only for accepted telemetry from the matching UDP source.
 - Native process detection is Windows-only and polls every two seconds. Reader references are cleared before asynchronous stops so one source instance has clear ownership.
 - Shutdown stops the compressor first, then settles recorder flush, native-source stop, and recording-mode source stops before exiting. Signal registration and task ordering must not move casually.
 - Runtime orchestrates game, database, telemetry, session-capture, tune-sync, route, and shared-data domains; those domains retain their own parsing, persistence, and policy. Cross-domain moves or new shared layers require a separate dependency-cycle pass.

--- a/server/runtime/udp-listener.ts
+++ b/server/runtime/udp-listener.ts
@@ -13,7 +13,7 @@
 import { resolve } from "node:path";
 import { parsePacket } from "../games/packet-dispatch";
 import { wsManager } from "./websocket-manager";
-import { processPacket, flushSessionRecorderBuffer, lapDetector } from "../telemetry/live-pipeline";
+import { processPacket, flushSessionRecorderBuffer, lapDetector, noteSourceLifecycle } from "../telemetry/live-pipeline";
 import { getRunningGame } from "../games/registry";
 import { SessionRecorder } from "../session-capture/recorder";
 import type { GameId } from "../../shared/games/ids";
@@ -21,7 +21,19 @@ import type { GameId } from "../../shared/games/ids";
 const MIN_PACKET_LENGTH = 29; // Minimum: F1 header size
 const PACKETS_PER_SEC_WINDOW = 1000; // 1-second sliding window for rate display
 
-class UdpListener {
+export interface UdpListenerDependencies {
+  parsePacket: typeof parsePacket;
+  processPacket: typeof processPacket;
+  noteSourceLifecycle: typeof noteSourceLifecycle;
+}
+
+const DEFAULT_DEPENDENCIES: UdpListenerDependencies = {
+  parsePacket,
+  processPacket,
+  noteSourceLifecycle,
+};
+
+export class UdpListener {
   private _droppedPackets = 0;
   private _totalPackets = 0;
   private _receiving = false;
@@ -37,6 +49,16 @@ class UdpListener {
   private _lastWsPacketCount = 0;
   private _lastStatusAt = performance.now();
   private _statusTimer: ReturnType<typeof setInterval> | null = null;
+  private _timedOut = false;
+  private _activeSourceGame: GameId | null = null;
+  private _timedOutSourceGame: GameId | null = null;
+  private _activeSourceSessionId: number | null = null;
+  private _timedOutSourceSessionId: number | null = null;
+  private readonly dependencies: UdpListenerDependencies;
+
+  constructor(dependencies: UdpListenerDependencies = DEFAULT_DEPENDENCIES) {
+    this.dependencies = dependencies;
+  }
 
   get droppedPackets(): number {
     return this._droppedPackets;
@@ -98,6 +120,11 @@ class UdpListener {
     this._socket = { stop: () => sock.close() };
 
     console.log(`[UDP] Listening on ${hostname}:${port}`);
+    this.dependencies.noteSourceLifecycle({
+      kind: "start",
+      timestampMs: Date.now(),
+      eventId: `udp-start:${hostname}:${port}`,
+    });
 
     // Update packets/sec every second. Own the handle so restart replaces,
     // rather than stacks, status/flush loops.
@@ -117,9 +144,28 @@ class UdpListener {
       // telemetry disappears from the analyse view.
       flushSessionRecorderBuffer();
 
-      // Mark as not receiving if no packets in last second
-      if (this._packetsPerSec === 0 && this._receiving) {
+      // Only accepted UDP telemetry owns this timeout. Raw invalid/menu traffic
+      // cannot keep a previously active source alive.
+      if (
+        this._packetsPerSec === 0 &&
+        this._receiving &&
+        this._activeSourceGame &&
+        this._activeSourceSessionId !== null
+      ) {
+        const gameId = this._activeSourceGame;
+        const sessionId = this._activeSourceSessionId;
         this._receiving = false;
+        this._timedOut = true;
+        this._timedOutSourceGame = gameId;
+        this._timedOutSourceSessionId = sessionId;
+        this.dependencies.noteSourceLifecycle(
+          {
+            kind: "timeout",
+            timestampMs: Date.now(),
+            eventId: `udp-timeout:${Date.now()}`,
+          },
+          { kind: "udp", gameId, sessionId },
+        );
       }
 
       // Stream-wide activity: count packets handed to wsManager from any
@@ -162,12 +208,8 @@ class UdpListener {
         isRaceOn: raceOn,
         droppedPackets: this._droppedPackets,
         udpPort: this._port,
-        detectedGame: runningGame
-          ? { id: runningGame.id, name: runningGame.shortName }
-          : null,
-        currentSession: session
-          ? { id: session.sessionId, carOrdinal: session.carOrdinal, trackOrdinal: session.trackOrdinal }
-          : null,
+        detectedGame: runningGame ? { id: runningGame.id, name: runningGame.shortName } : null,
+        currentSession: session ? { id: session.sessionId, carOrdinal: session.carOrdinal, trackOrdinal: session.trackOrdinal } : null,
       });
 
       if (this._packetsPerSec > 0) {
@@ -176,9 +218,8 @@ class UdpListener {
     }, PACKETS_PER_SEC_WINDOW);
   }
 
-  private async handlePacket(sourceFrame: Buffer): Promise<void> {
+  protected async handlePacket(sourceFrame: Buffer): Promise<void> {
     this._totalPackets++;
-    this._packetsInWindow++;
 
     if (sourceFrame.length < MIN_PACKET_LENGTH) {
       this._droppedPackets++;
@@ -190,16 +231,44 @@ class UdpListener {
     this._recorder?.writeRecord(sourceFrame);
 
     // Returns null when game is paused/in menus (IsRaceOn == 0)
-    const packet = parsePacket(sourceFrame);
+    const packet = this.dependencies.parsePacket(sourceFrame);
     if (!packet) {
       return;
     }
 
+    this._packetsInWindow++;
+    const gameId = packet.gameId;
+    if (this._timedOut) {
+      const timedOutGame = this._timedOutSourceGame;
+      const timedOutSessionId = this._timedOutSourceSessionId;
+      this._timedOut = false;
+      this._timedOutSourceGame = null;
+      this._timedOutSourceSessionId = null;
+      if (timedOutGame === gameId && timedOutSessionId !== null) {
+        this.dependencies.noteSourceLifecycle(
+          {
+            kind: "reconnect",
+            timestampMs: Date.now(),
+            eventId: `udp-reconnect:${this._totalPackets}`,
+          },
+          { kind: "udp", gameId, sessionId: timedOutSessionId },
+        );
+      }
+    }
+
+    this._activeSourceGame = gameId;
     this._receiving = true;
-    await processPacket(packet, sourceFrame);
+    await this.dependencies.processPacket(packet, sourceFrame);
+    const session = lapDetector.session;
+    this._activeSourceSessionId = session?.gameId === gameId ? session.sessionId : null;
   }
 
   async stop(): Promise<void> {
+    this.dependencies.noteSourceLifecycle({
+      kind: "stop",
+      timestampMs: Date.now(),
+      eventId: `udp-stop:${this._hostname}:${this._port}`,
+    });
     if (this._statusTimer) {
       clearInterval(this._statusTimer);
       this._statusTimer = null;
@@ -223,6 +292,11 @@ class UdpListener {
     this._droppedPackets = 0;
     this._totalPackets = 0;
     this._receiving = false;
+    this._timedOut = false;
+    this._activeSourceGame = null;
+    this._timedOutSourceGame = null;
+    this._activeSourceSessionId = null;
+    this._timedOutSourceSessionId = null;
     this._packetsInWindow = 0;
     this._packetsPerSec = 0;
     await this.start(port, hostname ?? this._hostname);

--- a/server/session-capture/framing.ts
+++ b/server/session-capture/framing.ts
@@ -5,6 +5,12 @@ import { promisify } from "node:util";
 export const META_FRAME_MAGIC = 0xffffffff;
 const META_FRAME_PAYLOAD_BYTES = 4;
 export const META_FRAME_BYTES = 8 + META_FRAME_PAYLOAD_BYTES;
+export class InvalidSessionFrameError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidSessionFrameError";
+  }
+}
 
 const gunzipAsync = promisify(gunzip);
 const gzipAsync = promisify(gzip);
@@ -26,19 +32,20 @@ export function encodeFrameLength(length: number): Buffer {
 
 /** Offset after an optional declared-length meta frame. */
 export function readFrameStreamStart(bytes: Uint8Array): number {
-  if (bytes.length < 8) return 0;
-  const view = Buffer.isBuffer(bytes)
-    ? bytes
-    : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  if (bytes.length < 4) return 0;
+  const view = Buffer.isBuffer(bytes) ? bytes : Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
   if (view.readUInt32LE(0) !== META_FRAME_MAGIC) return 0;
-  return 8 + view.readUInt32LE(4);
-}
-
-/** Legacy importer behavior: recorder magic always reserves the fixed 12-byte header. */
-function readRecorderFrameStreamStart(bytes: Buffer): number {
-  return bytes.length >= 4 && bytes.readUInt32LE(0) === META_FRAME_MAGIC
-    ? META_FRAME_BYTES
-    : 0;
+  if (view.length < 8) {
+    throw new InvalidSessionFrameError("Truncated recorder metadata header at byte 0");
+  }
+  const payloadLength = view.readUInt32LE(4);
+  if (payloadLength !== META_FRAME_PAYLOAD_BYTES) {
+    throw new InvalidSessionFrameError(`Invalid recorder metadata payload length ${payloadLength} at byte 0`);
+  }
+  if (view.length < 8 + payloadLength) {
+    throw new InvalidSessionFrameError("Truncated recorder metadata payload at byte 0");
+  }
+  return 8 + payloadLength;
 }
 
 interface SessionFrameRecord {
@@ -49,31 +56,41 @@ interface SessionFrameRecord {
 interface SessionFrameIterationOptions {
   skipMetaFrames?: boolean;
   allowEmptyFrames?: boolean;
+  strict?: boolean;
 }
-
 
 /**
  * Iterate complete length-prefixed records, stopping at a truncated tail.
  * Options retain reprocessor behavior; normal imports use strict framing.
  */
-export function* iterateSessionFrameRecords(
-  bytes: Buffer,
-  offset = readRecorderFrameStreamStart(bytes),
-  options?: SessionFrameIterationOptions,
-): Generator<SessionFrameRecord> {
+export function* iterateSessionFrameRecords(bytes: Buffer, offset?: number, options?: SessionFrameIterationOptions): Generator<SessionFrameRecord> {
+  offset ??= readFrameStreamStart(bytes);
   while (offset + 4 <= bytes.length) {
     const frameOffset = offset;
     const length = bytes.readUInt32LE(offset);
     if (options?.skipMetaFrames && length === META_FRAME_MAGIC) {
-      if (offset + 8 > bytes.length) break;
-      offset += 8 + bytes.readUInt32LE(offset + 4);
+      if (offset + 8 > bytes.length) {
+        if (options.strict) throw new InvalidSessionFrameError(`Truncated meta frame at byte ${offset}`);
+        break;
+      }
+      const payloadLength = bytes.readUInt32LE(offset + 4);
+      if (options.strict && payloadLength !== META_FRAME_PAYLOAD_BYTES) {
+        throw new InvalidSessionFrameError(`Invalid meta payload length ${payloadLength} at byte ${offset}`);
+      }
+      if (offset + 8 + payloadLength > bytes.length) {
+        if (options.strict) throw new InvalidSessionFrameError(`Truncated meta payload at byte ${offset}`);
+        break;
+      }
+      offset += 8 + payloadLength;
       continue;
     }
     offset += 4;
-    if (
-      (!options?.allowEmptyFrames && length === 0) ||
-      offset + length > bytes.length
-    ) {
+    if (!options?.allowEmptyFrames && length === 0) {
+      if (options?.strict) throw new InvalidSessionFrameError(`Empty frame at byte ${frameOffset}`);
+      break;
+    }
+    if (offset + length > bytes.length) {
+      if (options?.strict) throw new InvalidSessionFrameError(`Truncated frame payload at byte ${frameOffset}`);
       break;
     }
     yield {
@@ -82,19 +99,46 @@ export function* iterateSessionFrameRecords(
     };
     offset += length;
   }
+  if (options?.strict && offset !== bytes.length) {
+    throw new InvalidSessionFrameError(`Truncated frame length at byte ${offset}`);
+  }
 }
 
-/** Iterate complete length-prefixed telemetry frames, stopping at truncated tail. */
-export function* iterateSessionFrames(
-  bytes: Buffer,
-  offset = readRecorderFrameStreamStart(bytes),
-): Generator<Buffer> {
-  while (true) {
-    const frame = sessionFrameAt(bytes, offset);
-    if (!frame) break;
-    yield frame;
-    offset += 4 + frame.length;
+/** Iterate strict length-prefixed telemetry frames. Truncated or empty records are invalid. */
+export function* iterateSessionFrames(bytes: Buffer, offset?: number): Generator<Buffer> {
+  const validateDeclaredCount = offset === undefined;
+  offset ??= readFrameStreamStart(bytes);
+  const declaredFrameCount = validateDeclaredCount && offset === META_FRAME_BYTES
+    ? bytes.readUInt32LE(8)
+    : 0;
+  let actualFrameCount = 0;
+  while (offset < bytes.length) {
+    if (offset + 4 > bytes.length) {
+      throw new InvalidSessionFrameError(`Truncated frame length at byte ${offset}`);
+    }
+    const length = bytes.readUInt32LE(offset);
+    if (length === 0) {
+      throw new InvalidSessionFrameError(`Empty frame at byte ${offset}`);
+    }
+    if (offset + 4 + length > bytes.length) {
+      throw new InvalidSessionFrameError(`Truncated frame payload at byte ${offset}`);
+    }
+    actualFrameCount++;
+    yield bytes.subarray(offset + 4, offset + 4 + length);
+    offset += 4 + length;
   }
+  if (declaredFrameCount !== 0 && actualFrameCount !== declaredFrameCount) {
+    throw new InvalidSessionFrameError(
+      `Recorder metadata declares ${declaredFrameCount} frames, but capture contains ${actualFrameCount}`,
+    );
+  }
+}
+
+/** Count complete records, validating framing and any nonzero leading declaration. */
+export function countSessionFrames(bytes: Buffer, offset?: number): number {
+  let count = 0;
+  for (const _frame of iterateSessionFrames(bytes, offset)) count++;
+  return count;
 }
 
 export function sessionFrameAt(bytes: Buffer, offset: number): Buffer | null {
@@ -104,11 +148,7 @@ export function sessionFrameAt(bytes: Buffer, offset: number): Buffer | null {
   return bytes.subarray(offset + 4, offset + 4 + length);
 }
 
-export function advanceSessionFrames(
-  bytes: Buffer,
-  offset: number,
-  count: number,
-): number {
+export function advanceSessionFrames(bytes: Buffer, offset: number, count: number): number {
   let at = offset;
   for (let i = 0; i < count; i++) {
     const frame = sessionFrameAt(bytes, at);
@@ -141,4 +181,3 @@ export async function gunzipBuffer(bytes: Buffer): Promise<Buffer> {
 export function decompressIfGzipSync(bytes: Buffer): Buffer {
   return isGzip(bytes) ? gunzipBufferSync(bytes) : bytes;
 }
-

--- a/server/session-capture/identity.ts
+++ b/server/session-capture/identity.ts
@@ -15,6 +15,20 @@ export function sha256ContentHash(bytes: Uint8Array): string {
   return `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 }
 
+export function sha256SourceArtifacts(artifacts: readonly { name: string; bytes: Uint8Array }[]): string {
+  const hash = createHash("sha256");
+  const lengths = Buffer.allocUnsafe(12);
+  for (const artifact of artifacts) {
+    const name = Buffer.from(artifact.name);
+    lengths.writeUInt32LE(name.length, 0);
+    lengths.writeBigUInt64LE(BigInt(artifact.bytes.byteLength), 4);
+    hash.update(lengths);
+    hash.update(name);
+    hash.update(artifact.bytes);
+  }
+  return `sha256:${hash.digest("hex")}`;
+}
+
 export async function loadRawCaptureIdentity(path: string): Promise<RawCaptureIdentity | undefined> {
   const file = Bun.file(path);
   if (!(await file.exists())) return undefined;

--- a/server/session-capture/recorder.ts
+++ b/server/session-capture/recorder.ts
@@ -1,6 +1,8 @@
-import { existsSync, mkdirSync, openSync, writeSync, closeSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, writeSync } from "node:fs";
+import { createHash } from "node:crypto";
+import type { ArchiveVerification } from "../../shared/racing/quality/contracts";
 import { dirname } from "node:path";
-import { encodeFrameLength, encodeMetaFrame, META_FRAME_BYTES } from "./framing";
+import { encodeFrameLength, encodeMetaFrame, iterateSessionFrameRecords, META_FRAME_BYTES, META_FRAME_MAGIC } from "./framing";
 
 /**
  * Appends raw telemetry records to a binary dump file.
@@ -23,6 +25,7 @@ export class SessionRecorder {
   private _byteOffset = 0;
   private _metaPending = false;
   private _active = false;
+  private _hasher = createHash("sha256");
 
   get recording(): boolean {
     return this._active;
@@ -51,6 +54,7 @@ export class SessionRecorder {
     this._recordCount = 0;
     this._byteOffset = 0;
     this._metaPending = false;
+    this._hasher = createHash("sha256");
     this._active = true;
     return this._path;
   }
@@ -74,10 +78,13 @@ export class SessionRecorder {
     if (!this._active) return;
     if (!this._file) this._openAndWriteMeta();
     if (!this._file) return;
-    this._file.write(encodeFrameLength(buf.length));
+    const prefix = encodeFrameLength(buf.length);
+    this._file.write(prefix);
     this._file.write(buf);
+    this._hasher.update(prefix);
+    this._hasher.update(buf);
     this._recordCount++;
-    this._byteOffset += 4 + buf.length;
+    this._byteOffset += prefix.length + buf.length;
   }
 
   private _openAndWriteMeta(): void {
@@ -106,17 +113,35 @@ export class SessionRecorder {
     }
   }
 
-  /** Flush, patch total frame count into header, and close. No file is created if no records were written. */
-  async stop(): Promise<void> {
+  /** Flush, patch total frame count, close, and verify framing plus digest. */
+  async stop(): Promise<ArchiveVerification> {
     const path = this._path;
     const file = this._file;
     const count = this._recordCount;
+    const expectedBytes = this._byteOffset;
     const hadMeta = this._metaPending;
     this._file = null;
     this._metaPending = false;
     this._active = false;
-    if (!file || !path) return;
-    await file.end();
+    if (!file || !path) {
+      return { state: "unavailable", sourceGeneration: null, details: "No records were written" };
+    }
+
+    let closeFailure: unknown;
+    try {
+      await file.end();
+    } catch (error) {
+      closeFailure = error;
+    }
+    const sourceGeneration = `sha256:${this._hasher.digest("hex")}`;
+    if (closeFailure) {
+      return {
+        state: "corrupt",
+        sourceGeneration,
+        details: closeFailure instanceof Error ? closeFailure.message : String(closeFailure),
+      };
+    }
+
     if (hadMeta) {
       try {
         const countBuf = encodeFrameLength(count);
@@ -126,10 +151,58 @@ export class SessionRecorder {
         } finally {
           closeSync(fd);
         }
-      } catch {
-        // Non-fatal: header patch failing doesn't corrupt the record data
+      } catch (error) {
+        return {
+          state: "corrupt",
+          sourceGeneration,
+          details: error instanceof Error ? error.message : String(error),
+        };
       }
     }
+
+    let verification: ArchiveVerification;
+    try {
+      if (!existsSync(path)) {
+        verification = { state: "unavailable", sourceGeneration: null, details: "Recording file disappeared before verification" };
+      } else {
+        const bytes = readFileSync(path);
+        if (bytes.length < expectedBytes) {
+          verification = { state: "truncated", sourceGeneration, details: `Expected ${expectedBytes} bytes, found ${bytes.length}` };
+        } else if (bytes.length > expectedBytes) {
+          verification = { state: "corrupt", sourceGeneration, details: `Expected ${expectedBytes} bytes, found ${bytes.length}` };
+        } else if (
+          hadMeta &&
+          (bytes.length < META_FRAME_BYTES ||
+            bytes.readUInt32LE(0) !== META_FRAME_MAGIC ||
+            bytes.readUInt32LE(4) !== META_FRAME_BYTES - 8 ||
+            bytes.readUInt32LE(8) !== count)
+        ) {
+          verification = { state: "corrupt", sourceGeneration, details: "Recording metadata frame does not match written frame count" };
+        } else {
+          const actualHash = createHash("sha256");
+          let actualCount = 0;
+          for (const record of iterateSessionFrameRecords(bytes, hadMeta ? META_FRAME_BYTES : 0, { strict: true })) {
+            actualHash.update(bytes.subarray(record.offset, record.offset + 4 + record.frame.length));
+            actualCount++;
+          }
+          if (actualCount !== count) {
+            verification = { state: "corrupt", sourceGeneration, details: `Expected ${count} frames, found ${actualCount}` };
+          } else if (`sha256:${actualHash.digest("hex")}` !== sourceGeneration) {
+            verification = { state: "corrupt", sourceGeneration, details: "Recording digest does not match written frames" };
+          } else {
+            verification = { state: "verified", sourceGeneration };
+          }
+        }
+      }
+    } catch (error) {
+      const details = error instanceof Error ? error.message : String(error);
+      verification = {
+        state: /truncated/i.test(details) ? "truncated" : "corrupt",
+        sourceGeneration,
+        details,
+      };
+    }
     console.log(`[SessionRecorder] Stopped. ${count} records written to ${path}`);
+    return verification;
   }
 }

--- a/server/telemetry/README.md
+++ b/server/telemetry/README.md
@@ -6,16 +6,20 @@
 
 ## Structure
 
-- `live-pipeline.ts` owns live packet ordering, recorder rotation, lap callbacks, tracker feeds, and WebSocket publication.
+- `live-pipeline.ts` owns live packet ordering, recorder rotation, lap callbacks, tracker feeds, WebSocket publication, and recording-quality accumulation.
 - `normalization.ts` contains shared in-place packet normalization used by live and persisted decode paths.
 - `replay.ts` resolves persisted lap packets into canonical semantic envelopes with capture provenance.
-- `pipeline-ports.ts` defines database, recorder, and WebSocket boundaries plus database/recorder production implementations and capture/no-op test seams.
+- `pipeline-ports.ts` defines database, recorder, WebSocket, and source-lifecycle evidence boundaries plus production and test adapters.
 
 ## Boundaries and invariants
 
 Game adapters own parsing, detector construction, coordinate metadata, and game policy. Session capture owns binary framing, recorder implementation, and raw-capture identity. Database modules own persistence queries; runtime owns WebSocket delivery and process lifecycle.
 
 Live processing order is intentional: persist the source frame when a recorder is active, normalize the packet, feed the detector, repair a recorder rotation with the same source frame, feed sector and pit trackers, then publish telemetry and development state. Raw offsets must continue to identify the first byte of the corresponding recorded frame. Detector callbacks must keep session-start, lap-complete, and lap-saved order.
+
+Source lifecycle, packet ordering, gaps, reconnects, and writer drops become localized quality evidence for the affected lap or time range. They must not rewrite simulator structural validity or contaminate unrelated laps.
+
+Imported-source verification and canonical RaceIQ recorder integrity are independent evidence. A verified original source cannot hide a corrupt or truncated canonical capture. Session finalization drains pending lap persistence before writing session-level generations or publishing quality updates.
 
 Replay keeps persisted packet order and timestamps, advances native source frames in capture order, and emits canonical values detached from mutable decoder state. Replay must not expose local capture paths or reinterpret parser, catalog, resolver, or derivation versions.
 

--- a/server/telemetry/live-pipeline.ts
+++ b/server/telemetry/live-pipeline.ts
@@ -2,13 +2,19 @@ import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { GameId } from "../../shared/games/ids";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import type { TuneIssue } from "../../shared/racing/tuning/issues";
+import { isEligibilityUsable } from "../../shared/racing/quality/policies";
 import {
-  type DbAdapter,
-  type WsAdapter,
-  type SessionRecorderAdapter,
-  RealDbAdapter,
-  RealSessionRecorderAdapter,
-} from "./pipeline-ports";
+  LOCAL_PLAYER_EVIDENCE,
+  type ArchiveVerification,
+  type EligibilityDecision,
+  type EligibilityDecisionSet,
+  type EvidenceSourceKind,
+  type SourceChannelProfile,
+  type SourceLifecycleEvidence,
+} from "../../shared/racing/quality/contracts";
+import { RecordingQualityAccumulator } from "../../shared/racing/quality/measure";
+import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
+import { type DbAdapter, type WsAdapter, type SessionRecorderAdapter, currentTelemetryVersionIdentity, RealDbAdapter, RealSessionRecorderAdapter } from "./pipeline-ports";
 import { LiveTelemetryProjector } from "./live-projector";
 import type { ILapDetector, LapDetectorCallbacks } from "../lap-detection/types";
 import { SectorTracker } from "../live-strategy/sector-tracker";
@@ -18,7 +24,7 @@ import { getTrackOutlineByOrdinal } from "../../shared/racing/tracks/recording/o
 import { getServerGame } from "../games/registry";
 import { normalizeTelemetryPacket } from "./normalization";
 import { LAP_DETECTOR_ID } from "../lap-detection/detector";
-import { detectCorners } from "../lap-analysis/corners"
+import { detectCorners } from "../lap-analysis/corners";
 import { telemetryToSymptoms } from "../ai/tune-symptoms";
 import { symptomsToIssues, detectLiveIssues } from "../ai/tune-issues";
 import { reconcileSessionResult } from "../race-results/reconcile";
@@ -26,6 +32,29 @@ import { wsManager } from "../runtime/websocket-manager";
 import { withSessionCaptureMaintenanceLock } from "../session-capture/cleanup";
 
 const CURRENT_SESSION_LAP_SNAPSHOT_LIMIT = 500;
+export function resolveLapIssueEligibility(eligibility: EligibilityDecisionSet): EligibilityDecision {
+  return [eligibility["normal-pace"], eligibility["corner-trace"], eligibility["transient-event"]].find((decision) => !isEligibilityUsable(decision)) ?? eligibility["transient-event"];
+}
+
+export interface LiveSourceScope {
+  kind: "udp";
+  gameId: GameId;
+  sessionId: number;
+}
+
+interface RecordingSessionState {
+  sessionId: number;
+  gameId: GameId;
+  detector: ILapDetector;
+}
+
+interface ClosedRecordingSession {
+  session: RecordingSessionState;
+  qualityAccumulator: RecordingQualityAccumulator | null;
+  sourceVerification: ArchiveVerification;
+  transportVerification?: ArchiveVerification;
+  canonicalVerification?: ArchiveVerification;
+}
 
 export class LiveTelemetryPipeline {
   private sectorTracker = new SectorTracker();
@@ -39,6 +68,11 @@ export class LiveTelemetryPipeline {
   private _bypassPacketRateFilter: boolean;
   private _skipHistorySeeding: boolean;
   private _skipDevState: boolean;
+  private readonly _sourceKind: EvidenceSourceKind;
+  private readonly _versionIdentity?: TelemetryVersionIdentity;
+  private readonly _sourceChannelProfile?: SourceChannelProfile;
+  private readonly _sourceArchiveVerification?: ArchiveVerification;
+  private readonly _sourceTransportVerification?: ArchiveVerification;
   private projector = new LiveTelemetryProjector();
   private _sessionLaps: LapMeta[] = [];
   /** Live Tuning Dashboard: gates the per-packet transient issue detector.
@@ -47,7 +81,9 @@ export class LiveTelemetryPipeline {
   /** Issues computed in onLapComplete (has packets, no lapId yet), consumed in
    *  onLapSaved (has lapId/lapNumber, no packets) to build the "lap-issues" push. */
   private _pendingLapIssues: TuneIssue[] | null = null;
-  private _recordingSession: { sessionId: number; gameId: GameId } | null = null;
+  private _pendingLapIssueEligibility: EligibilityDecision | null = null;
+  private _recordingSession: RecordingSessionState | null = null;
+  private _recordingQuality: RecordingQualityAccumulator | null = null;
   private _onSessionFinalized?: (sessionId: number, gameId: GameId) => Promise<void>;
   private _finalizedResultSessions = new Set<number>();
   private _lapReconciliations = new Map<number, Promise<void>>();
@@ -66,6 +102,12 @@ export class LiveTelemetryPipeline {
   /** Toggled by `POST /api/live-analysis {enabled}`. */
   setLiveIssuesEnabled(enabled: boolean): void {
     this._liveIssuesEnabled = enabled;
+  }
+  noteSourceLifecycle(event: SourceLifecycleEvidence, source?: LiveSourceScope): void {
+    if ((event.kind === "timeout" || event.kind === "reconnect") && (!source || this._recordingSession?.gameId !== source.gameId || this._recordingSession?.sessionId !== source.sessionId)) {
+      return;
+    }
+    this._recordingQuality?.noteSourceLifecycle(event);
   }
 
   /** True while a session is being recorded (session recorder is open). */
@@ -87,6 +129,11 @@ export class LiveTelemetryPipeline {
       skipDevState?: boolean;
       recorder?: SessionRecorderAdapter;
       onSessionFinalized?: (sessionId: number, gameId: GameId) => Promise<void>;
+      sourceKind?: EvidenceSourceKind;
+      sourceArchiveVerification?: ArchiveVerification;
+      sourceTransportVerification?: ArchiveVerification;
+      versionIdentity?: TelemetryVersionIdentity;
+      sourceChannelProfile?: SourceChannelProfile;
     },
   ) {
     this.db = db;
@@ -96,6 +143,11 @@ export class LiveTelemetryPipeline {
     this._skipHistorySeeding = options?.skipHistorySeeding ?? false;
     this._skipDevState = options?.skipDevState ?? false;
     this._onSessionFinalized = options?.onSessionFinalized;
+    this._sourceKind = options?.sourceKind ?? "native-live";
+    this._versionIdentity = options?.versionIdentity;
+    this._sourceChannelProfile = options?.sourceChannelProfile;
+    this._sourceArchiveVerification = options?.sourceArchiveVerification;
+    this._sourceTransportVerification = options?.sourceTransportVerification;
   }
 
   private _scheduleLapReconciliation(sessionId: number, gameId: GameId): void {
@@ -121,9 +173,7 @@ export class LiveTelemetryPipeline {
     await this._lapReconciliations.get(sessionId);
   }
 
-  private _reconcileRecordedSession(
-    session: { sessionId: number; gameId: GameId },
-  ): Promise<void> {
+  private _reconcileRecordedSession(session: { sessionId: number; gameId: GameId }): Promise<void> {
     if (this._finalizedResultSessions.has(session.sessionId)) {
       return Promise.resolve();
     }
@@ -145,31 +195,87 @@ export class LiveTelemetryPipeline {
     return finalization;
   }
 
-  private async _finishRecordedSession(
-    session = this._recordingSession,
-  ): Promise<void> {
-    await withSessionCaptureMaintenanceLock(async () => {
-      if (session && this._recordingSession?.sessionId === session.sessionId) {
-        this._recordingSession = null;
+  private async _closeRecordedSession(session: RecordingSessionState): Promise<ClosedRecordingSession> {
+    const isCurrentSession = this._recordingSession?.sessionId === session.sessionId;
+    const qualityAccumulator = isCurrentSession ? this._recordingQuality : null;
+    if (isCurrentSession) {
+      this._recordingSession = null;
+      this._recordingQuality = null;
+    }
+
+    let canonicalVerification: ArchiveVerification;
+    try {
+      canonicalVerification = await this.recorder.stop();
+    } catch (error) {
+      qualityAccumulator?.noteWriterFailure(error);
+      canonicalVerification = {
+        state: "corrupt" as const,
+        sourceGeneration: null,
+        details: error instanceof Error ? error.message : String(error),
+      };
+    }
+    const hasOriginalSourceVerification = this._sourceArchiveVerification !== undefined;
+    return {
+      session,
+      qualityAccumulator,
+      sourceVerification: this._sourceArchiveVerification ?? canonicalVerification,
+      ...(this._sourceTransportVerification ? { transportVerification: this._sourceTransportVerification } : {}),
+      ...(hasOriginalSourceVerification ? { canonicalVerification } : {}),
+    };
+  }
+
+  private async _finalizeRecordedSession(closed: ClosedRecordingSession, endReason: string): Promise<void> {
+    await closed.session.detector.waitForPendingLapWrites?.();
+    if (closed.qualityAccumulator) {
+      const summary = closed.qualityAccumulator.finalize(endReason, closed.sourceVerification, {
+        transportVerification: closed.transportVerification,
+        canonicalVerification: closed.canonicalVerification,
+      });
+      const finalized = await this.db.updateSessionQuality(closed.session.sessionId, summary);
+      await this._refreshFinalizedSessionLaps(closed.session.sessionId, closed.session.gameId);
+      this.ws.broadcastNotification({
+        type: "quality-updated",
+        sessionId: closed.session.sessionId,
+        qualityGeneration: finalized.provenance.outputGeneration,
+      });
+    }
+    await this._reconcileRecordedSession(closed.session);
+  }
+
+  private async _finishRecordedSession(session = this._recordingSession, endReason = "session-ended"): Promise<void> {
+    const closed = await withSessionCaptureMaintenanceLock(async () => {
+      if (!session) {
+        await this.recorder.stop();
+        return null;
       }
-      await this.recorder.stop();
+      return this._closeRecordedSession(session);
     });
-    if (session) await this._reconcileRecordedSession(session);
+    if (closed) await this._finalizeRecordedSession(closed, endReason);
   }
 
   private _buildCallbacks(): LapDetectorCallbacks {
     return {
       onSessionStart: async (session) => {
-        const previousSession = this._recordingSession;
-        await withSessionCaptureMaintenanceLock(async () => {
-          this._recordingSession = null;
-          await this.recorder.stop();
+        const closedPrevious = await withSessionCaptureMaintenanceLock(async () => {
+          const previousSession = this._recordingSession;
+          const closed = previousSession
+            ? await this._closeRecordedSession(previousSession)
+            : (await this.recorder.stop(), null);
+
+          this._pendingLapIssues = null;
+          this._pendingLapIssueEligibility = null;
           this.recorder.start(session.gameId);
           this.recorder.writeMetaFrame();
           this._recordingSession = {
             sessionId: session.sessionId,
             gameId: session.gameId,
+            detector: this._lapDetector!,
           };
+          this._recordingQuality = new RecordingQualityAccumulator(
+            this._sourceKind,
+            LOCAL_PLAYER_EVIDENCE,
+            this._versionIdentity ?? currentTelemetryVersionIdentity(session.gameId),
+          );
           if (this.recorder.path) {
             await this.db.updateSessionRawFile(
               session.sessionId,
@@ -177,48 +283,41 @@ export class LiveTelemetryPipeline {
               this._lapDetector?.detectorId ?? LAP_DETECTOR_ID,
             );
           }
+          return closed;
         });
-        if (previousSession) {
-          void this._reconcileRecordedSession(previousSession).catch((error) => {
-            console.error(
-              `[Race Results] Failed to reconcile session ${previousSession.sessionId}:`,
-              error,
-            );
-          });
-        }
 
         await this.sectorTracker.reset(session.trackOrdinal, session.gameId, session.carOrdinal);
         this.pitTracker.reset();
         const adapter = getServerGame(session.gameId);
         this.pitTracker.setTireThresholds(adapter.tireHealthThresholds.yellow);
         if (!this._skipHistorySeeding) {
-          await this.pitTracker.seedFromHistory(
-            session.trackOrdinal,
-            session.carOrdinal,
-            session.carPI,
-            session.gameId,
-            adapter.runtime.pit,
-          );
+          await this.pitTracker.seedFromHistory(session.trackOrdinal, session.carOrdinal, session.carPI, session.gameId, adapter.runtime.pit);
           await this._seedSessionLaps(session.sessionId, session.trackOrdinal, session.carOrdinal, session.gameId);
         } else {
           this._sessionLaps = [];
         }
         this._broadcastSessionLaps();
+
+        if (closedPrevious) {
+          await this._finalizeRecordedSession(closedPrevious, "session-rotated");
+        }
       },
 
       onLapComplete: (event) => {
-        if (event.isValid) {
+        this.pitTracker.acceptCompletedLap(event.eligibility);
+        const issueEligibility = resolveLapIssueEligibility(event.eligibility);
+        this._pendingLapIssueEligibility = issueEligibility;
+        const normalPaceUsable = isEligibilityUsable(event.eligibility["normal-pace"]);
+        if (normalPaceUsable) {
           this.sectorTracker.updateRefLap(event.packets, event.lapTime, event.sectors);
-          // Update distance-based wear curves when enabled by the adapter.
-          const session = this._lapDetector?.session ?? null;
-          if (session && getServerGame(session.gameId).runtime.pit.useDistanceBasedWearCurves) {
-            this.pitTracker.updateWearCurves(event.packets, event.lapDistStart);
-          }
+        }
 
-          // Live Tuning Dashboard per-lap issue feed. Computed here (packets are
-          // available) but pushed from onLapSaved (lapId/lapNumber are available
-          // there) — onLapComplete always fires synchronously before onLapSaved
-          // for the same lap, so this hand-off is safe.
+        const session = this._lapDetector?.session ?? null;
+        if (session && isEligibilityUsable(event.eligibility["tire-analysis"]) && getServerGame(session.gameId).runtime.pit.useDistanceBasedWearCurves) {
+          this.pitTracker.updateWearCurves(event.packets, event.lapDistStart);
+        }
+
+        if (isEligibilityUsable(issueEligibility)) {
           try {
             const corners = detectCorners(event.packets);
             const symptoms = telemetryToSymptoms(event.packets, corners);
@@ -227,7 +326,7 @@ export class LiveTelemetryPipeline {
             this._pendingLapIssues = null;
           }
         } else {
-          this._pendingLapIssues = null;
+          this._pendingLapIssues = [];
         }
       },
 
@@ -235,11 +334,20 @@ export class LiveTelemetryPipeline {
         this.ws.broadcastNotification({ type: "lap-saved", ...event });
 
         // Flush the per-lap issue feed computed in onLapComplete, now that we
-        // have lapId/lapNumber to stamp on it.
-        if (this._pendingLapIssues) {
-          const issues = this._pendingLapIssues.map((i) => ({ ...i, lapNumber: event.lapNumber }));
+        // have lapId/lapNumber to stamp on it. Blocked analyses still publish
+        // their versioned decision so clients never mistake unavailable evidence
+        // for a clean lap.
+        if (this._pendingLapIssueEligibility) {
+          const issues = (this._pendingLapIssues ?? []).map((issue) => ({ ...issue, lapNumber: event.lapNumber }));
+          this.ws.broadcastNotification({
+            type: "lap-issues",
+            lapId: event.lapId,
+            lapNumber: event.lapNumber,
+            issues,
+            eligibility: this._pendingLapIssueEligibility,
+          });
           this._pendingLapIssues = null;
-          this.ws.broadcastNotification({ type: "lap-issues", lapId: event.lapId, lapNumber: event.lapNumber, issues });
+          this._pendingLapIssueEligibility = null;
         }
 
         // Append to in-memory list and broadcast
@@ -260,12 +368,14 @@ export class LiveTelemetryPipeline {
             carOrdinal: session.carOrdinal,
             trackOrdinal: session.trackOrdinal,
             sectorTimes: event.sectors ?? undefined,
+            source: event.quality.sourceKind,
+            quality: event.quality,
+            eligibility: event.eligibility,
+            qualityGeneration: event.quality.provenance.outputGeneration,
+            qualityStale: event.quality.provenance.outputGeneration === "legacy",
           });
           if (this._sessionLaps.length > CURRENT_SESSION_LAP_SNAPSHOT_LIMIT) {
-            this._sessionLaps.splice(
-              0,
-              this._sessionLaps.length - CURRENT_SESSION_LAP_SNAPSHOT_LIMIT,
-            );
+            this._sessionLaps.splice(0, this._sessionLaps.length - CURRENT_SESSION_LAP_SNAPSHOT_LIMIT);
           }
           this._broadcastSessionLaps();
         }
@@ -281,6 +391,9 @@ export class LiveTelemetryPipeline {
         db: this.db,
         bypassPacketRateFilter: this._bypassPacketRateFilter,
         callbacks: this._buildCallbacks(),
+        sourceKind: this._sourceKind,
+        sourceChannelProfile: this._sourceChannelProfile,
+        versionIdentity: this._versionIdentity,
       });
       this._lapDetectorGameId = gameId;
     }
@@ -312,19 +425,10 @@ export class LiveTelemetryPipeline {
   }
 
   /** Seed in-memory session laps from DB (called once on session start). */
-  private async _seedSessionLaps(
-    sessionId: number,
-    trackOrdinal: number,
-    carOrdinal: number,
-    gameId: GameId
-  ): Promise<void> {
+  private async _seedSessionLaps(sessionId: number, trackOrdinal: number, carOrdinal: number, gameId: GameId): Promise<void> {
     try {
       const allLaps = await this.db.getLaps(gameId, CURRENT_SESSION_LAP_SNAPSHOT_LIMIT);
-      const sessionLaps = allLaps
-        .filter(
-          (l) => l.sessionId === sessionId && l.trackOrdinal === trackOrdinal && l.carOrdinal === carOrdinal,
-        )
-        .sort((a, b) => a.id - b.id);
+      const sessionLaps = allLaps.filter((l) => l.sessionId === sessionId && l.trackOrdinal === trackOrdinal && l.carOrdinal === carOrdinal).sort((a, b) => a.id - b.id);
       if (sessionLaps.length > CURRENT_SESSION_LAP_SNAPSHOT_LIMIT) {
         sessionLaps.splice(0, sessionLaps.length - CURRENT_SESSION_LAP_SNAPSHOT_LIMIT);
       }
@@ -332,6 +436,21 @@ export class LiveTelemetryPipeline {
     } catch {
       this._sessionLaps = [];
     }
+  }
+
+  private async _refreshFinalizedSessionLaps(sessionId: number, gameId: GameId): Promise<void> {
+    if (!this._sessionLaps.some((lap) => lap.sessionId === sessionId)) return;
+
+    const persisted = await this.db.getLaps(gameId, CURRENT_SESSION_LAP_SNAPSHOT_LIMIT);
+    const finalizedById = new Map(persisted.filter((lap) => lap.sessionId === sessionId).map((lap) => [lap.id, lap]));
+    let replaced = false;
+    this._sessionLaps = this._sessionLaps.map((lap) => {
+      const finalized = lap.sessionId === sessionId ? finalizedById.get(lap.id) : undefined;
+      if (!finalized) return lap;
+      replaced = true;
+      return finalized;
+    });
+    if (replaced) this._broadcastSessionLaps();
   }
 
   /** Push in-memory session laps to all WS clients. */
@@ -353,7 +472,12 @@ export class LiveTelemetryPipeline {
     const epochBefore = this.recorder.epoch;
     if (sourceFrame && this.recorder.active) {
       rawByteOffset = this.recorder.getCurrentByteOffset();
-      this.recorder.writeRecord(sourceFrame);
+      try {
+        this.recorder.writeRecord(sourceFrame);
+      } catch (error) {
+        rawByteOffset = undefined;
+        this._recordingQuality?.noteWriterFailure(error);
+      }
     }
 
     const adapter = getServerGame(packet.gameId);
@@ -363,11 +487,7 @@ export class LiveTelemetryPipeline {
     }
 
     // Normalize coordinates and derived channels using the adapter profile.
-    normalizeTelemetryPacket(
-      packet,
-      adapter.coordSystem === "standard-xyz",
-      adapter.runtime.normSuspensionTravelMm,
-    );
+    normalizeTelemetryPacket(packet, adapter.coordSystem === "standard-xyz", adapter.runtime.normSuspensionTravelMm);
 
     const detector = this._getOrCreateDetector(packet.gameId);
     await detector.feed(packet, rawByteOffset);
@@ -379,9 +499,14 @@ export class LiveTelemetryPipeline {
     // the detector's lap byte offset so the DB row points at the right place.
     if (sourceFrame && this.recorder.active && this.recorder.epoch !== epochBefore) {
       const firstOffset = this.recorder.getCurrentByteOffset();
-      this.recorder.writeRecord(sourceFrame);
-      detector.setCurrentLapByteOffset?.(firstOffset);
+      try {
+        this.recorder.writeRecord(sourceFrame);
+        detector.setCurrentLapByteOffset?.(firstOffset);
+      } catch (error) {
+        this._recordingQuality?.noteWriterFailure(error);
+      }
     }
+    this._recordingQuality?.observe(packet);
 
     const sectors = this.sectorTracker.feed(packet);
 
@@ -391,11 +516,7 @@ export class LiveTelemetryPipeline {
       packet.BestLap = sessionBest;
     }
 
-    const pit = this.pitTracker.feed(
-      packet,
-      this.sectorTracker.getTrackLength(),
-      this.sectorTracker.getLapDistStart()
-    );
+    const pit = this.pitTracker.feed(packet, this.sectorTracker.getTrackLength(), this.sectorTracker.getLapDistStart());
 
     // Collect calibration positions for adapters that require track-outline alignment.
     if (this._totalProcessed % 6 === 0 && adapter.runtime.requiresTrackCalibration) {
@@ -403,21 +524,14 @@ export class LiveTelemetryPipeline {
       if (session?.trackOrdinal) {
         const outline = getTrackOutlineByOrdinal(session.trackOrdinal, session.gameId);
         if (outline) {
-          feedCalibrationPosition(
-            session.trackOrdinal,
-            { x: packet.PositionX, z: packet.PositionZ },
-            packet.LapNumber,
-            outline
-          );
+          feedCalibrationPosition(session.trackOrdinal, { x: packet.PositionX, z: packet.PositionZ }, packet.LapNumber, outline);
         }
       }
     }
 
     // Live Tuning Dashboard transient detector — gated, off by default. Stateless
     // per-packet call; skipped entirely (no cost) unless the client opted in.
-    const liveIssues = this._liveIssuesEnabled
-      ? detectLiveIssues(packet, this.sectorTracker.getTrackLength())
-      : undefined;
+    const liveIssues = this._liveIssuesEnabled ? detectLiveIssues(packet, this.sectorTracker.getTrackLength()) : undefined;
 
     const projection = this.projector.project({
       packet,
@@ -439,7 +553,7 @@ export class LiveTelemetryPipeline {
   }
 
   async flushSessionRecorder(): Promise<void> {
-    await withSessionCaptureMaintenanceLock(() => this.recorder.stop());
+    await this._finishRecordedSession(this._recordingSession, "stream-ended");
   }
 
   /** Flush buffered writes to disk without closing. */
@@ -450,7 +564,9 @@ export class LiveTelemetryPipeline {
 
 // Module-level pipeline used by live runtime callers.
 const _defaultWs: WsAdapter = {
-  get wantsDevTelemetry() { return wsManager.wantsDevTelemetry; },
+  get wantsDevTelemetry() {
+    return wsManager.wantsDevTelemetry;
+  },
   broadcast: (packet, sectors, pit, liveIssues) => wsManager.broadcast(packet, sectors, pit, liveIssues),
   stageDevTelemetry: (packet) => wsManager.stageDevTelemetry(packet),
   publishTelemetry: ({ packet, sectors, pit, liveIssues, projection }) => {
@@ -465,10 +581,7 @@ const _default = new LiveTelemetryPipeline(new RealDbAdapter(), _defaultWs, {
     try {
       await reconcileSessionResult(sessionId, gameId);
     } catch (error) {
-      console.error(
-        `[Race Results] Failed to reconcile session ${sessionId}:`,
-        error,
-      );
+      console.error(`[Race Results] Failed to reconcile session ${sessionId}:`, error);
     }
   },
 });
@@ -476,17 +589,26 @@ const _default = new LiveTelemetryPipeline(new RealDbAdapter(), _defaultWs, {
 // Wire session laps provider so WS manager can send laps on client connect
 wsManager.setSessionLapsProvider(() => _default.sessionLaps);
 
-export const processPacket = (packet: TelemetryPacket, sourceFrame?: Buffer) =>
-  _default.processPacket(packet, sourceFrame);
+export const processPacket = (packet: TelemetryPacket, sourceFrame?: Buffer) => _default.processPacket(packet, sourceFrame);
 
 /** Returns the current lap detector (may be null before the first packet is processed). */
 export const lapDetector = {
-  get session() { return _default.lapDetector?.session ?? null; },
-  get fuelHistory() { return _default.lapDetector?.fuelHistory ?? []; },
-  get tireWearHistory() { return _default.lapDetector?.tireWearHistory ?? []; },
-  async finalizeCurrentSession() { await _default.finalizeCurrentSession(); },
+  get session() {
+    return _default.lapDetector?.session ?? null;
+  },
+  get fuelHistory() {
+    return _default.lapDetector?.fuelHistory ?? [];
+  },
+  get tireWearHistory() {
+    return _default.lapDetector?.tireWearHistory ?? [];
+  },
+  async finalizeCurrentSession() {
+    await _default.finalizeCurrentSession();
+  },
 };
-
+export function noteSourceLifecycle(event: SourceLifecycleEvidence, source?: LiveSourceScope): void {
+  _default.noteSourceLifecycle(event, source);
+}
 
 /** Toggle the Live Tuning Dashboard's per-packet transient issue detector. */
 export function setLiveIssuesEnabled(enabled: boolean): void {

--- a/server/telemetry/pipeline-ports.ts
+++ b/server/telemetry/pipeline-ports.ts
@@ -383,8 +383,7 @@ export class RealSessionRecorderAdapter implements SessionRecorderAdapter {
   async stop(): Promise<ArchiveVerification> {
     const inner = this._inner;
     this._inner = null;
-    if (!inner) return { state: "unavailable", sourceGeneration: null, details: "Recorder was not active" };
-    return (await inner.stop()) ?? { state: "unavailable", sourceGeneration: null, details: "Recorder did not provide archive verification" };
+    return inner ? inner.stop() : { state: "unavailable", sourceGeneration: null, details: "Recorder was not active" };
   }
 }
 

--- a/test/live-strategy/pit-tracker.test.ts
+++ b/test/live-strategy/pit-tracker.test.ts
@@ -1,9 +1,14 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, spyOn } from "bun:test";
+import type { EligibilityDecision, EligibilityDecisionSet, EligibilityPolicyId } from "../../shared/racing/quality/contracts";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
+import type { LapMeta } from "../../shared/racing/sessions/types";
+import * as LapReadQueries from "../../server/db/lap-read-queries";
+import { finalizeLapQualityGeneration } from "../../server/lap-analysis/quality-generation";
 import { PitTracker } from "../../server/live-strategy/pit-tracker";
 import { forzaServerAdapter } from "../../server/games/fm-2023";
 import { f1ServerAdapter } from "../../server/games/f1-2025";
 import { accServerAdapter } from "../../server/games/acc";
+import { qualityPackets, summarize } from "../support/lap-analysis/quality-model";
 
 function pkt(overrides: Partial<TelemetryPacket>): TelemetryPacket {
   return {
@@ -27,33 +32,68 @@ function pkt(overrides: Partial<TelemetryPacket>): TelemetryPacket {
   } as TelemetryPacket;
 }
 
+function policyDecision(policyId: EligibilityPolicyId, status: EligibilityDecision["status"] = "eligible"): EligibilityDecision {
+  return {
+    status,
+    policyId,
+    policyVersion: "1",
+    confidence: { level: status === "unknown" ? "unknown" : "high", score: status === "unknown" ? null : 1 },
+    reasons: status === "eligible" ? [] : [{ code: "channel_unavailable", severity: "error", evidenceIds: [`test:${policyId}`], timeRange: null, distanceRange: null, semanticIds: [] }],
+    evidenceIds: status === "eligible" ? [] : [`test:${policyId}`],
+  };
+}
+
+function pitEligibility(overrides: Partial<Record<"normal-pace" | "fuel-burn" | "tire-analysis", EligibilityDecision>> = {}): EligibilityDecisionSet {
+  return {
+    "normal-pace": policyDecision("normal-pace"),
+    "fuel-burn": policyDecision("fuel-burn"),
+    "tire-analysis": policyDecision("tire-analysis"),
+    ...overrides,
+  } as EligibilityDecisionSet;
+}
+
 /** Simulate completing a lap: feed a mid-lap packet then a new-lap packet. */
-function completeLap(tracker: PitTracker, lapNum: number, opts: {
-  fuel: number;
-  wearFL: number; wearFR: number; wearRL: number; wearRR: number;
-  lapTime?: number;
-}) {
+function completeLap(
+  tracker: PitTracker,
+  lapNum: number,
+  opts: {
+    fuel: number;
+    wearFL: number;
+    wearFR: number;
+    wearRL: number;
+    wearRR: number;
+    lapTime?: number;
+    eligibility?: EligibilityDecisionSet;
+  },
+) {
   const lapTime = opts.lapTime ?? 90;
   // Mid-lap: set CurrentLap to the lap time (this is what lastCurrentLap captures)
-  tracker.feed(pkt({
-    LapNumber: lapNum,
-    CurrentLap: lapTime,
-    Fuel: opts.fuel + 0.01, // slightly more fuel than at boundary
-    TireWearFL: opts.wearFL - 0.001,
-    TireWearFR: opts.wearFR - 0.001,
-    TireWearRL: opts.wearRL - 0.001,
-    TireWearRR: opts.wearRR - 0.001,
-  }), 5000);
+  tracker.feed(
+    pkt({
+      LapNumber: lapNum,
+      CurrentLap: lapTime,
+      Fuel: opts.fuel + 0.01, // slightly more fuel than at boundary
+      TireWearFL: opts.wearFL - 0.001,
+      TireWearFR: opts.wearFR - 0.001,
+      TireWearRL: opts.wearRL - 0.001,
+      TireWearRR: opts.wearRR - 0.001,
+    }),
+    5000,
+  );
+  tracker.acceptCompletedLap(opts.eligibility ?? pitEligibility());
   // Lap boundary
-  tracker.feed(pkt({
-    LapNumber: lapNum + 1,
-    CurrentLap: 0,
-    Fuel: opts.fuel,
-    TireWearFL: opts.wearFL,
-    TireWearFR: opts.wearFR,
-    TireWearRL: opts.wearRL,
-    TireWearRR: opts.wearRR,
-  }), 5000);
+  tracker.feed(
+    pkt({
+      LapNumber: lapNum + 1,
+      CurrentLap: 0,
+      Fuel: opts.fuel,
+      TireWearFL: opts.wearFL,
+      TireWearFR: opts.wearFR,
+      TireWearRL: opts.wearRL,
+      TireWearRR: opts.wearRR,
+    }),
+    5000,
+  );
 }
 
 describe("PitTracker", () => {
@@ -71,13 +111,33 @@ describe("PitTracker", () => {
     // Init
     tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, CurrentLap: 0 }), 5000);
     // Complete 3 laps using 0.10 fuel each
-    completeLap(tracker, 1, { fuel: 0.90, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
-    completeLap(tracker, 2, { fuel: 0.80, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
-    completeLap(tracker, 3, { fuel: 0.70, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
+    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
+    completeLap(tracker, 2, { fuel: 0.8, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
+    completeLap(tracker, 3, { fuel: 0.7, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
 
-    const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.70, CurrentLap: 5 }), 5000);
-    expect(r.fuelPerLap).toBeCloseTo(0.10, 2);
+    const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.7, CurrentLap: 5 }), 5000);
+    expect(r.fuelPerLap).toBeCloseTo(0.1, 2);
     expect(r.fuelLapsRemaining).toBeCloseTo(7.0, 0);
+  });
+
+  test("policy-rejected lap does not update fuel or tire estimates", () => {
+    const tracker = new PitTracker();
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 1, CurrentLap: 0 }), 5_000);
+    completeLap(tracker, 1, {
+      fuel: 0.9,
+      wearFL: 0.1,
+      wearFR: 0.1,
+      wearRL: 0.1,
+      wearRR: 0.1,
+      eligibility: pitEligibility({
+        "fuel-burn": policyDecision("fuel-burn", "ineligible"),
+        "tire-analysis": policyDecision("tire-analysis", "unknown"),
+      }),
+    });
+
+    const result = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.1, TireWearFR: 0.1, TireWearRL: 0.1, TireWearRR: 0.1, CurrentLap: 5 }), 5_000);
+    expect(result.fuelPerLap).toBe(0);
+    expect(result.tireWearPerLap).toBe(0);
   });
 
   test("tire: per-tire rolling average of last 3 laps, worst governs", () => {
@@ -86,12 +146,12 @@ describe("PitTracker", () => {
 
     // 3 laps: FL wears 0.08, 0.10, 0.12 → avg FL = 0.10
     completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.08, wearFR: 0.05, wearRL: 0.04, wearRR: 0.04 });
-    completeLap(tracker, 2, { fuel: 0.8, wearFL: 0.18, wearFR: 0.10, wearRL: 0.08, wearRR: 0.08 });
-    completeLap(tracker, 3, { fuel: 0.7, wearFL: 0.30, wearFR: 0.15, wearRL: 0.12, wearRR: 0.12 });
+    completeLap(tracker, 2, { fuel: 0.8, wearFL: 0.18, wearFR: 0.1, wearRL: 0.08, wearRR: 0.08 });
+    completeLap(tracker, 3, { fuel: 0.7, wearFL: 0.3, wearFR: 0.15, wearRL: 0.12, wearRR: 0.12 });
 
-    const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.7, TireWearFL: 0.30, TireWearFR: 0.15, TireWearRL: 0.12, TireWearRR: 0.12, CurrentLap: 5 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.7, TireWearFL: 0.3, TireWearFR: 0.15, TireWearRL: 0.12, TireWearRR: 0.12, CurrentLap: 5 }), 5000);
     // FL avg = (0.08 + 0.10 + 0.12) / 3 = 0.10
-    expect(r.tireWearPerLap).toBeCloseTo(0.10, 2);
+    expect(r.tireWearPerLap).toBeCloseTo(0.1, 2);
     // health = 1 - 0.30 = 0.70, bad threshold = 0.40, wear until bad = 0.30
     // At 0.10/lap → 3.0 laps
     expect(r.tireLapsToBad).toBeCloseTo(3.0, 0);
@@ -100,9 +160,9 @@ describe("PitTracker", () => {
   test("tireLapsToCritical uses 20% health threshold", () => {
     const tracker = new PitTracker();
     tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0, TireWearFR: 0, TireWearRL: 0, TireWearRR: 0, CurrentLap: 0 }), 5000);
-    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.10, wearFR: 0.10, wearRL: 0.10, wearRR: 0.10 });
+    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.1, wearFR: 0.1, wearRL: 0.1, wearRR: 0.1 });
 
-    const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.10, TireWearFR: 0.10, TireWearRL: 0.10, TireWearRR: 0.10, CurrentLap: 5 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.1, TireWearFR: 0.1, TireWearRL: 0.1, TireWearRR: 0.1, CurrentLap: 5 }), 5000);
     // health = 0.90, critical = 0.20, wear until critical = 0.70
     // At 0.10/lap → 7.0 laps
     expect(r.tireLapsToCritical).toBeCloseTo(7.0, 0);
@@ -110,12 +170,12 @@ describe("PitTracker", () => {
 
   test("setTireThresholds changes bad health target", () => {
     const tracker = new PitTracker();
-    tracker.setTireThresholds(0.70); // ACC stricter
+    tracker.setTireThresholds(0.7); // ACC stricter
 
     tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0, TireWearFR: 0, TireWearRL: 0, TireWearRR: 0, CurrentLap: 0 }), 5000);
-    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.10, wearFR: 0.08, wearRL: 0.06, wearRR: 0.06 });
+    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.1, wearFR: 0.08, wearRL: 0.06, wearRR: 0.06 });
 
-    const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.10, TireWearFR: 0.08, TireWearRL: 0.06, TireWearRR: 0.06, CurrentLap: 5 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.1, TireWearFR: 0.08, TireWearRL: 0.06, TireWearRR: 0.06, CurrentLap: 5 }), 5000);
     // health = 0.90, bad = 0.70, wear until bad = 0.20, at 0.10/lap → 2.0
     expect(r.tireLapsToBad).toBeCloseTo(2.0, 0);
     // Critical unchanged: 7.0
@@ -124,7 +184,7 @@ describe("PitTracker", () => {
 
   test("returns 0 when already past threshold", () => {
     const tracker = new PitTracker();
-    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.50, TireWearFR: 0.50, TireWearRL: 0.50, TireWearRR: 0.50, CurrentLap: 0 }), 5000);
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.5, TireWearFR: 0.5, TireWearRL: 0.5, TireWearRR: 0.5, CurrentLap: 0 }), 5000);
     completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.65, wearFR: 0.65, wearRL: 0.65, wearRR: 0.65 });
 
     const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.65, TireWearFR: 0.65, TireWearRL: 0.65, TireWearRR: 0.65, CurrentLap: 5 }), 5000);
@@ -137,9 +197,9 @@ describe("PitTracker", () => {
   test("pitInLaps uses whichever runs out first", () => {
     const tracker = new PitTracker();
     tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0, TireWearFR: 0, TireWearRL: 0, TireWearRR: 0, CurrentLap: 0 }), 5000);
-    completeLap(tracker, 1, { fuel: 0.90, wearFL: 0.10, wearFR: 0.10, wearRL: 0.10, wearRR: 0.10 });
+    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.1, wearFR: 0.1, wearRL: 0.1, wearRR: 0.1 });
 
-    const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.90, TireWearFL: 0.10, TireWearFR: 0.10, TireWearRL: 0.10, TireWearRR: 0.10, CurrentLap: 5 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.1, TireWearFR: 0.1, TireWearRL: 0.1, TireWearRR: 0.1, CurrentLap: 5 }), 5000);
     // Fuel: 0.90 / 0.10 = 9.0
     // Tires to bad: (0.90 - 0.40) / 0.10 = 5.0
     expect(r.limitedBy).toBe("tires");
@@ -151,29 +211,29 @@ describe("PitTracker", () => {
     tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0, TireWearFR: 0, TireWearRL: 0, TireWearRR: 0, CurrentLap: 0 }), 5000);
 
     // Normal lap: 90s, 0.10 fuel
-    completeLap(tracker, 1, { fuel: 0.90, wearFL: 0.05, wearFR: 0.05, wearRL: 0.05, wearRR: 0.05, lapTime: 90 });
+    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0.05, wearFR: 0.05, wearRL: 0.05, wearRR: 0.05, lapTime: 90 });
     // Another normal lap
-    completeLap(tracker, 2, { fuel: 0.80, wearFL: 0.10, wearFR: 0.10, wearRL: 0.10, wearRR: 0.10, lapTime: 91 });
+    completeLap(tracker, 2, { fuel: 0.8, wearFL: 0.1, wearFR: 0.1, wearRL: 0.1, wearRR: 0.1, lapTime: 91 });
 
     // Formation/safety car lap: 200s (>2x 90.5 avg) — should be excluded
     completeLap(tracker, 3, { fuel: 0.78, wearFL: 0.11, wearFR: 0.11, wearRL: 0.11, wearRR: 0.11, lapTime: 200 });
 
     const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.78, CurrentLap: 5 }), 5000);
     // Fuel should still be ~0.10 (formation lap's 0.02 excluded)
-    expect(r.fuelPerLap).toBeCloseTo(0.10, 1);
+    expect(r.fuelPerLap).toBeCloseTo(0.1, 1);
   });
 
   test("outlier rejection: skips refuel lap (fuel increased)", () => {
     const tracker = new PitTracker();
-    tracker.feed(pkt({ LapNumber: 1, Fuel: 0.50, CurrentLap: 0 }), 5000);
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 0.5, CurrentLap: 0 }), 5000);
     // Normal lap
-    completeLap(tracker, 1, { fuel: 0.40, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0, lapTime: 90 });
+    completeLap(tracker, 1, { fuel: 0.4, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0, lapTime: 90 });
     // Pit stop: fuel increased from 0.40 to 0.90
-    completeLap(tracker, 2, { fuel: 0.90, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0, lapTime: 90 });
+    completeLap(tracker, 2, { fuel: 0.9, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0, lapTime: 90 });
 
-    const r = tracker.feed(pkt({ LapNumber: 3, Fuel: 0.90, CurrentLap: 5 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 3, Fuel: 0.9, CurrentLap: 5 }), 5000);
     // Should only have the first lap's 0.10 usage, pit lap excluded
-    expect(r.fuelPerLap).toBeCloseTo(0.10, 2);
+    expect(r.fuelPerLap).toBeCloseTo(0.1, 2);
   });
 });
 
@@ -193,13 +253,87 @@ describe("PitTracker history seeding policy", () => {
     expect(accServerAdapter.runtime.pit.seedTireWearFromHistory).toBe(true);
   });
 
+  test("continues past newer fuel-only laps until independent tire quota is filled", async () => {
+    const historicalLap = (id: number, fuelStatus: EligibilityDecision["status"], tireStatus: EligibilityDecision["status"]): LapMeta => {
+      const packets = qualityPackets(100);
+      const generated = finalizeLapQualityGeneration(summarize(packets), "legacy", {
+        lapNumber: id,
+        rawByteOffset: null,
+        rawFrameCount: packets.length,
+      });
+      return {
+        id,
+        sessionId: 1,
+        lapNumber: id,
+        lapTime: 90,
+        isValid: true,
+        phase: "flying",
+        conditions: [],
+        paceEligibility: "eligible",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        pi: 900,
+        gameId: "acc",
+        carOrdinal: 901,
+        trackOrdinal: 902,
+        quality: generated.quality,
+        eligibility: {
+          ...generated.eligibility,
+          "fuel-burn": policyDecision("fuel-burn", fuelStatus),
+          "tire-analysis": policyDecision("tire-analysis", tireStatus),
+        },
+        qualityGeneration: generated.quality.provenance.outputGeneration,
+        qualityStale: false,
+      };
+    };
+    const candidates = [
+      historicalLap(6, "eligible", "ineligible"),
+      historicalLap(5, "eligible", "ineligible"),
+      historicalLap(4, "eligible", "ineligible"),
+      historicalLap(3, "eligible", "ineligible"),
+      historicalLap(2, "eligible", "ineligible"),
+      historicalLap(1, "ineligible", "eligible"),
+    ];
+    const reads: number[] = [];
+    const getLaps = spyOn(LapReadQueries, "getLaps").mockResolvedValue(candidates);
+    const getLapById = spyOn(LapReadQueries, "getLapById").mockImplementation(async (id) => {
+      reads.push(id);
+      const metadata = candidates.find((lap) => lap.id === id);
+      if (!metadata) return null;
+      const fuelUsed = id === 6 ? 0.1 : id === 5 ? 0.2 : 0;
+      const tireWear = id === 1 ? 0.04 : 0;
+      return {
+        ...metadata,
+        telemetry: Array.from({ length: 50 }, (_, index) => {
+          const fraction = index / 49;
+          return pkt({
+            Fuel: 1 - fuelUsed * fraction,
+            TireWearFL: tireWear * fraction,
+            TireWearFR: tireWear * fraction,
+            TireWearRL: tireWear * fraction,
+            TireWearRR: tireWear * fraction,
+          });
+        }),
+      };
+    });
+
+    try {
+      const tracker = new PitTracker();
+      await tracker.seedFromHistory(902, 901, 900, "acc", accServerAdapter.runtime.pit);
+      expect(tracker.getDebugState()).toMatchObject({ fuelHistoryLength: 2, tireWearHistoryLength: 1 });
+      expect(reads).toEqual([6, 5, 1]);
+    } finally {
+      getLaps.mockRestore();
+      getLapById.mockRestore();
+    }
+  });
+
   test("seeded fuel data produces immediate estimate", () => {
     const tracker = new PitTracker();
     tracker._seedForTest([0.08, 0.09], []);
 
     // No laps completed yet, but fuel history is seeded
-    tracker.feed(pkt({ LapNumber: 1, Fuel: 0.50, CurrentLap: 0 }), 5000);
-    const r = tracker.feed(pkt({ LapNumber: 1, Fuel: 0.50, CurrentLap: 10 }), 5000);
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 0.5, CurrentLap: 0 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 1, Fuel: 0.5, CurrentLap: 10 }), 5000);
 
     expect(r.fuelPerLap).toBeCloseTo(0.085, 2);
     expect(r.fuelLapsRemaining).not.toBeNull();
@@ -212,8 +346,8 @@ describe("PitTracker history seeding policy", () => {
     const tracker = new PitTracker();
     tracker._seedForTest([], [{ fl: 0.03, fr: 0.03, rl: 0.02, rr: 0.02 }]);
 
-    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.10, TireWearFR: 0.10, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 0 }), 5000);
-    const r = tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.10, TireWearFR: 0.10, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 10 }), 5000);
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.1, TireWearFR: 0.1, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 0 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.1, TireWearFR: 0.1, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 10 }), 5000);
 
     // Worst tire wear rate = FL 0.03/lap
     expect(r.tireWearPerLap).toBeCloseTo(0.03, 2);
@@ -228,11 +362,11 @@ describe("PitTracker history seeding policy", () => {
 
     tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, CurrentLap: 0 }), 5000);
     // Complete 3 laps using 0.10 fuel each
-    completeLap(tracker, 1, { fuel: 0.90, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
-    completeLap(tracker, 2, { fuel: 0.80, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
-    completeLap(tracker, 3, { fuel: 0.70, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
+    completeLap(tracker, 1, { fuel: 0.9, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
+    completeLap(tracker, 2, { fuel: 0.8, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
+    completeLap(tracker, 3, { fuel: 0.7, wearFL: 0, wearFR: 0, wearRL: 0, wearRR: 0 });
 
-    const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.70, CurrentLap: 5 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 4, Fuel: 0.7, CurrentLap: 5 }), 5000);
     // Rolling 5: [0.05, 0.05, 0.10, 0.10, 0.10] → avg = 0.08
     expect(r.fuelPerLap).toBeCloseTo(0.08, 2);
   });
@@ -251,15 +385,17 @@ describe("PitTracker wear curve interpolation", () => {
     for (let i = 0; i < opts.count; i++) {
       const frac = i / (opts.count - 1);
       const [fl, fr, rl, rr] = opts.wearProfile(frac);
-      packets.push(pkt({
-        DistanceTraveled: opts.distStart + frac * opts.trackLen,
-        CurrentLap: frac * 90,
-        LapNumber: 1,
-        TireWearFL: fl,
-        TireWearFR: fr,
-        TireWearRL: rl,
-        TireWearRR: rr,
-      }));
+      packets.push(
+        pkt({
+          DistanceTraveled: opts.distStart + frac * opts.trackLen,
+          CurrentLap: frac * 90,
+          LapNumber: 1,
+          TireWearFL: fl,
+          TireWearFR: fr,
+          TireWearRL: rl,
+          TireWearRR: rr,
+        }),
+      );
     }
     return packets;
   }
@@ -270,21 +406,21 @@ describe("PitTracker wear curve interpolation", () => {
       trackLen: 1000,
       distStart: 0,
       count: 200,
-      wearProfile: (f) => [f * 0.10, f * 0.08, f * 0.06, f * 0.06],
+      wearProfile: (f) => [f * 0.1, f * 0.08, f * 0.06, f * 0.06],
     });
     tracker.updateWearCurves(packets, 0);
     const ref = tracker._getRefWearCurve();
     expect(ref).not.toBeNull();
     expect(ref!.length).toBe(1000);
     // Total wear should match profile endpoint
-    expect(ref!.totalWear[0]).toBeCloseTo(0.10, 2); // FL
+    expect(ref!.totalWear[0]).toBeCloseTo(0.1, 2); // FL
     expect(ref!.totalWear[1]).toBeCloseTo(0.08, 2); // FR
   });
 
   test("averaged reference from 3 laps", () => {
     const tracker = new PitTracker();
     // 3 laps with varying FL wear: 0.08, 0.10, 0.12 → avg 0.10
-    for (const total of [0.08, 0.10, 0.12]) {
+    for (const total of [0.08, 0.1, 0.12]) {
       const packets = makeLapPackets({
         trackLen: 1000,
         distStart: 0,
@@ -295,7 +431,7 @@ describe("PitTracker wear curve interpolation", () => {
     }
     const ref = tracker._getRefWearCurve();
     expect(ref).not.toBeNull();
-    expect(ref!.totalWear[0]).toBeCloseTo(0.10, 2); // FL averaged
+    expect(ref!.totalWear[0]).toBeCloseTo(0.1, 2); // FL averaged
   });
 
   test("curve-based estimate adjusts mid-lap based on wear deviation", () => {
@@ -305,28 +441,32 @@ describe("PitTracker wear curve interpolation", () => {
       trackLen: 1000,
       distStart: 0,
       count: 200,
-      wearProfile: (f) => [f * 0.10, f * 0.05, f * 0.04, f * 0.04],
+      wearProfile: (f) => [f * 0.1, f * 0.05, f * 0.04, f * 0.04],
     });
     tracker.updateWearCurves(packets, 0);
 
     // Init tracker state
-    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.20, TireWearFR: 0.10, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 0 }), 1000);
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.2, TireWearFR: 0.1, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 0 }), 1000);
     // Simulate next lap boundary to set liveWearAtLapStart
-    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.20, TireWearFR: 0.10, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 85 }), 1000);
-    tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.20, TireWearFR: 0.10, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 0 }), 1000);
+    tracker.feed(pkt({ LapNumber: 1, Fuel: 1.0, TireWearFL: 0.2, TireWearFR: 0.1, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 85 }), 1000);
+    tracker.feed(pkt({ LapNumber: 2, Fuel: 0.9, TireWearFL: 0.2, TireWearFR: 0.1, TireWearRL: 0.08, TireWearRR: 0.08, CurrentLap: 0 }), 1000);
 
     // At 500m (50%), ref says FL should have worn 0.05.
     // If actual FL is 0.06 (wore 0.01 more than expected), projected = 0.10 + 0.01 = 0.11
-    const r = tracker.feed(pkt({
-      LapNumber: 2,
-      DistanceTraveled: 500,
-      TireWearFL: 0.26, // 0.20 + 0.06 delta
-      TireWearFR: 0.12,
-      TireWearRL: 0.10,
-      TireWearRR: 0.10,
-      CurrentLap: 45,
-      Fuel: 0.89,
-    }), 1000, 0);
+    const r = tracker.feed(
+      pkt({
+        LapNumber: 2,
+        DistanceTraveled: 500,
+        TireWearFL: 0.26, // 0.20 + 0.06 delta
+        TireWearFR: 0.12,
+        TireWearRL: 0.1,
+        TireWearRR: 0.1,
+        CurrentLap: 45,
+        Fuel: 0.89,
+      }),
+      1000,
+      0,
+    );
 
     // FL projected wear per lap should be ~0.11 (ref 0.10 + deviation 0.01)
     expect(r.tireEstimates.wearPerLap[0]).toBeCloseTo(0.11, 1);
@@ -335,13 +475,11 @@ describe("PitTracker wear curve interpolation", () => {
   test("falls back to rolling average when no curves", () => {
     const tracker = new PitTracker();
     // No curves built — just per-lap history
-    tracker._seedForTest([], [
-      { fl: 0.10, fr: 0.08, rl: 0.06, rr: 0.06 },
-    ]);
-    tracker.feed(pkt({ LapNumber: 1, TireWearFL: 0.10, TireWearFR: 0.08, TireWearRL: 0.06, TireWearRR: 0.06, CurrentLap: 0, Fuel: 1 }), 5000);
-    const r = tracker.feed(pkt({ LapNumber: 1, TireWearFL: 0.10, TireWearFR: 0.08, TireWearRL: 0.06, TireWearRR: 0.06, CurrentLap: 10, Fuel: 1 }), 5000);
+    tracker._seedForTest([], [{ fl: 0.1, fr: 0.08, rl: 0.06, rr: 0.06 }]);
+    tracker.feed(pkt({ LapNumber: 1, TireWearFL: 0.1, TireWearFR: 0.08, TireWearRL: 0.06, TireWearRR: 0.06, CurrentLap: 0, Fuel: 1 }), 5000);
+    const r = tracker.feed(pkt({ LapNumber: 1, TireWearFL: 0.1, TireWearFR: 0.08, TireWearRL: 0.06, TireWearRR: 0.06, CurrentLap: 10, Fuel: 1 }), 5000);
     // Should use rolling average fallback
-    expect(r.tireWearPerLap).toBeCloseTo(0.10, 2); // worst = FL
+    expect(r.tireWearPerLap).toBeCloseTo(0.1, 2); // worst = FL
     expect(r.tireLapsToBad).not.toBeNull();
   });
 
@@ -367,18 +505,22 @@ describe("PitTracker wear curve interpolation", () => {
     // At 750m (75% through), past the heavy zone — reference says most wear already happened
     // On pace: FL ref at 750m ≈ 0.08 + 0.5*0.02 = 0.09
     // Actual FL = 0.09 (on pace) → deviation = 0, projected = totalWear (0.10)
-    const r = tracker.feed(pkt({
-      LapNumber: 2,
-      DistanceTraveled: 750,
-      TireWearFL: 0.09,
-      TireWearFR: 0.072,
-      TireWearRL: 0.054,
-      TireWearRR: 0.054,
-      CurrentLap: 67,
-      Fuel: 0.88,
-    }), 1000, 0);
+    const r = tracker.feed(
+      pkt({
+        LapNumber: 2,
+        DistanceTraveled: 750,
+        TireWearFL: 0.09,
+        TireWearFR: 0.072,
+        TireWearRL: 0.054,
+        TireWearRR: 0.054,
+        CurrentLap: 67,
+        Fuel: 0.88,
+      }),
+      1000,
+      0,
+    );
 
     // Projected FL ≈ 0.10 (reference total + ~0 deviation)
-    expect(r.tireEstimates.wearPerLap[0]).toBeCloseTo(0.10, 1);
+    expect(r.tireEstimates.wearPerLap[0]).toBeCloseTo(0.1, 1);
   });
 });

--- a/test/runtime/udp-listener-lifecycle.test.ts
+++ b/test/runtime/udp-listener-lifecycle.test.ts
@@ -1,0 +1,62 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import type { GameId } from "../../shared/games/ids";
+import type { SourceLifecycleEvidence } from "../../shared/racing/quality/contracts";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+import { UdpListener, type UdpListenerDependencies } from "../../server/runtime/udp-listener";
+import { stopMaintenanceTasks, type LiveSourceScope } from "../../server/telemetry/live-pipeline";
+
+class UdpListenerHarness extends UdpListener {
+  ingest(sourceFrame: Buffer): Promise<void> {
+    return this.handlePacket(sourceFrame);
+  }
+
+  forceTimeout(gameId: GameId): void {
+    Object.assign(this, {
+      _receiving: false,
+      _timedOut: true,
+      _activeSourceGame: gameId,
+      _timedOutSourceGame: gameId,
+      _activeSourceSessionId: 42,
+      _timedOutSourceSessionId: 42,
+    });
+  }
+}
+
+afterAll(() => stopMaintenanceTasks());
+
+describe("UDP source lifecycle", () => {
+  test("ignores invalid post-timeout datagrams and records reconnect immediately before next accepted packet", async () => {
+    const order: string[] = [];
+    const lifecycleEvents: Array<{ event: SourceLifecycleEvidence; source?: LiveSourceScope }> = [];
+    const acceptedPacket = { gameId: "fm-2023" } as TelemetryPacket;
+    const dependencies: UdpListenerDependencies = {
+      parsePacket: (sourceFrame) => (sourceFrame[0] === 1 ? acceptedPacket : null),
+      processPacket: async () => {
+        order.push("process");
+      },
+      noteSourceLifecycle: (event, source) => {
+        lifecycleEvents.push({ event, source });
+        order.push(event.kind);
+      },
+    };
+    const listener = new UdpListenerHarness(dependencies);
+    listener.forceTimeout("fm-2023");
+
+    await listener.ingest(Buffer.alloc(29));
+
+    expect(lifecycleEvents).toHaveLength(0);
+    expect(listener.receiving).toBe(false);
+
+    const accepted = Buffer.alloc(29);
+    accepted[0] = 1;
+    await listener.ingest(accepted);
+
+    expect(lifecycleEvents).toHaveLength(1);
+    expect(lifecycleEvents[0]).toMatchObject({
+      event: { kind: "reconnect" },
+      source: { kind: "udp", gameId: "fm-2023", sessionId: 42 },
+    });
+    expect(order).toEqual(["reconnect", "process"]);
+    expect(listener.receiving).toBe(true);
+  });
+});

--- a/test/session-capture/raw-binary-storage.test.ts
+++ b/test/session-capture/raw-binary-storage.test.ts
@@ -37,20 +37,22 @@ describe("SessionRecorder meta frame", () => {
     recorder.writeMetaFrame();
     recorder.writeRecord(Buffer.from([0x01, 0x02]));
     recorder.writeRecord(Buffer.from([0x03, 0x04]));
-    await recorder.stop();
+    const verification = await recorder.stop();
 
     const buf = Buffer.from(await Bun.file(recorder.path!).arrayBuffer());
     expect(buf.readUInt32LE(0)).toBe(META_FRAME_MAGIC);
     expect(buf.readUInt32LE(4)).toBe(4); // payload length always 4
     expect(buf.readUInt32LE(8)).toBe(2); // frame count patched on stop()
+    expect(verification.state).toBe("verified");
+    expect(verification.sourceGeneration).toMatch(/^sha256:[0-9a-f]{64}$/);
   });
 
-  test("getCurrentByteOffset starts at 0 before any writes", () => {
+  test("getCurrentByteOffset starts at 0 before any writes", async () => {
     tmpDir = mkdtempSync(join(tmpdir(), "raceiq-test-"));
     const recorder = new SessionRecorder();
     recorder.start(join(tmpDir, "session.bin"));
     expect(recorder.getCurrentByteOffset()).toBe(0);
-    recorder.stop();
+    expect((await recorder.stop()).state).toBe("unavailable");
   });
 
   test("getCurrentByteOffset tracks written bytes", async () => {

--- a/test/session-capture/raw-binary-storage.test.ts
+++ b/test/session-capture/raw-binary-storage.test.ts
@@ -15,6 +15,7 @@ import { eq } from "drizzle-orm";
 import { initGameAdapters } from "../../shared/games/init";
 import { initServerGameAdapters } from "../../server/games/init";
 import { countStaleSessions, getStaleSessions } from "../../server/db/session-queries";
+import { QUALITY_SCHEMA_VERSION } from "../../shared/racing/quality/contracts";
 import { sessionRoutes } from "../../server/routes/session-routes";
 
 initGameAdapters();
@@ -338,7 +339,14 @@ describe("countStaleSessions", () => {
   async function insertSession(rawFile: string | null, lapDetectorVersion: string | null): Promise<number> {
     const row = await db
       .insert(sessions)
-      .values({ carOrdinal: 1, trackOrdinal: 1, gameId: "fm-2023", rawFile, lapDetectorVersion })
+      .values({
+        carOrdinal: 1,
+        trackOrdinal: 1,
+        gameId: "fm-2023",
+        rawFile,
+        lapDetectorVersion,
+        qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+      })
       .returning({ id: sessions.id })
       .get();
     const id = row!.id;

--- a/test/telemetry/live-pipeline-source-lifecycle.test.ts
+++ b/test/telemetry/live-pipeline-source-lifecycle.test.ts
@@ -1,0 +1,269 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { initGameAdapters } from "../../shared/games/init";
+import type { GameId } from "../../shared/games/ids";
+import type { LapMeta } from "../../shared/racing/sessions/types";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type ArchiveVerification,
+  type LapQualitySummary,
+  type RecordingQualitySummary,
+} from "../../shared/racing/quality/contracts";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+import { initServerGameAdapters } from "../../server/games/init";
+import { LiveTelemetryPipeline, stopMaintenanceTasks } from "../../server/telemetry/live-pipeline";
+import { CapturingDbAdapter, CapturingWsAdapter, NullSessionRecorderAdapter, NullWsAdapter, type SessionRecorderAdapter } from "../../server/telemetry/pipeline-ports";
+
+initGameAdapters();
+initServerGameAdapters();
+
+afterAll(() => stopMaintenanceTasks());
+
+function telemetryPacket(gameId: GameId, timestampMs: number): TelemetryPacket {
+  return {
+    gameId,
+    IsRaceOn: 1,
+    TimestampMS: timestampMs,
+    LapNumber: 1,
+    CurrentLap: timestampMs / 1000,
+    LastLap: 0,
+    BestLap: 0,
+    CurrentRaceTime: timestampMs / 1000,
+    DistanceTraveled: timestampMs / 10,
+    CarOrdinal: 100,
+    TrackOrdinal: 5,
+    CarPerformanceIndex: 0,
+    CarClass: 0,
+    RacePosition: 1,
+    Speed: 50,
+    PositionX: timestampMs / 100,
+    PositionY: 0,
+    PositionZ: timestampMs / 50,
+    Fuel: 50,
+    TireWearFL: 1,
+    TireWearFR: 1,
+    TireWearRL: 1,
+    TireWearRR: 1,
+  } as TelemetryPacket;
+}
+
+class CapturingSessionRecorder implements SessionRecorderAdapter {
+  readonly sessions: Array<{ gameId: GameId; records: Buffer[] }> = [];
+  private current: { gameId: GameId; records: Buffer[] } | null = null;
+  private currentEpoch = 0;
+
+  get active(): boolean {
+    return this.current !== null;
+  }
+  get path(): string | null {
+    return null;
+  }
+  get epoch(): number {
+    return this.currentEpoch;
+  }
+  start(gameId: GameId): void {
+    this.current = { gameId, records: [] };
+    this.sessions.push(this.current);
+    this.currentEpoch++;
+  }
+  writeMetaFrame(): void {}
+  writeRecord(buf: Buffer): void {
+    this.current?.records.push(buf);
+  }
+  getCurrentByteOffset(): number {
+    return this.current?.records.reduce((total, record) => total + record.length + 4, 0) ?? 0;
+  }
+  flush(): void {}
+  stop(): Promise<ArchiveVerification> {
+    this.current = null;
+    return Promise.resolve({ state: "verified", sourceGeneration: "sha256:test" });
+  }
+}
+
+class DelayedQualityDb extends CapturingDbAdapter {
+  private releaseQualityUpdate!: () => void;
+  private markQualityUpdateStarted!: () => void;
+  private readonly qualityUpdateGate = new Promise<void>((resolve) => {
+    this.releaseQualityUpdate = resolve;
+  });
+  readonly qualityUpdateStarted = new Promise<void>((resolve) => {
+    this.markQualityUpdateStarted = resolve;
+  });
+
+  release(): void {
+    this.releaseQualityUpdate();
+  }
+
+  override async updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+    this.markQualityUpdateStarted();
+    await this.qualityUpdateGate;
+    return super.updateSessionQuality(sessionId, quality);
+  }
+}
+
+const PROVISIONAL_LAP_GENERATION = "provisional:live-lap";
+const FINALIZED_LAP_GENERATION = "sha256:finalized-live-lap";
+
+class FinalizingSnapshotDb extends CapturingDbAdapter {
+  snapshotProvider: () => readonly LapMeta[] = () => [];
+  private finalizedLaps: LapMeta[] = [];
+
+  constructor(private readonly provisionalLaps: LapMeta[]) {
+    super();
+  }
+
+  override async updateSessionQuality(sessionId: number, quality: RecordingQualitySummary): Promise<RecordingQualitySummary> {
+    const finalized = await super.updateSessionQuality(sessionId, quality);
+    this.finalizedLaps = this.snapshotProvider().map((lap) => ({
+      ...lap,
+      quality: {
+        ...lap.quality!,
+        provenance: {
+          ...lap.quality!.provenance,
+          outputGeneration: FINALIZED_LAP_GENERATION,
+        },
+      },
+      qualityGeneration: FINALIZED_LAP_GENERATION,
+      qualityStale: false,
+    }));
+    return finalized;
+  }
+
+  override getLaps(): Promise<LapMeta[]> {
+    return Promise.resolve(this.finalizedLaps.length > 0 ? this.finalizedLaps : this.provisionalLaps);
+  }
+}
+
+describe("LiveTelemetryPipeline source lifecycle scoping", () => {
+  afterAll(() => {
+    stopMaintenanceTasks();
+  });
+  test("drops stale UDP timeout evidence while ACC session is active", async () => {
+    const db = new CapturingDbAdapter();
+    const pipeline = new LiveTelemetryPipeline(db, new NullWsAdapter(), {
+      bypassPacketRateFilter: true,
+      skipHistorySeeding: true,
+      skipDevState: true,
+      recorder: new NullSessionRecorderAdapter(),
+    });
+
+    await pipeline.processPacket(telemetryPacket("acc", 1_000));
+    pipeline.noteSourceLifecycle(
+      {
+        kind: "timeout",
+        timestampMs: Date.now(),
+        eventId: "udp-timeout:stale",
+      },
+      { kind: "udp", gameId: "fm-2023", sessionId: 99 },
+    );
+    await pipeline.processPacket(telemetryPacket("acc", 1_100));
+    await pipeline.finalizeCurrentSession();
+
+    const quality = db.sessionQuality.get(1);
+    expect(quality).toBeDefined();
+    expect(quality?.facts.some(({ details }) => details?.lifecycleEvent === "timeout")).toBe(false);
+    expect(quality?.facts.some(({ eventIds }) => eventIds.includes("udp-timeout:stale"))).toBe(false);
+  });
+
+  test("records lifecycle evidence for matching UDP session identity", async () => {
+    const db = new CapturingDbAdapter();
+    const pipeline = new LiveTelemetryPipeline(db, new NullWsAdapter(), {
+      bypassPacketRateFilter: true,
+      skipHistorySeeding: true,
+      skipDevState: true,
+      recorder: new NullSessionRecorderAdapter(),
+    });
+
+    await pipeline.processPacket(telemetryPacket("fm-2023", 1_000));
+    pipeline.noteSourceLifecycle(
+      {
+        kind: "reconnect",
+        timestampMs: Date.now(),
+        eventId: "udp-reconnect:accepted",
+      },
+      { kind: "udp", gameId: "fm-2023", sessionId: 1 },
+    );
+    await pipeline.processPacket(telemetryPacket("fm-2023", 1_100));
+    await pipeline.finalizeCurrentSession();
+
+    expect(db.sessionQuality.get(1)?.facts.find(({ code }) => code === "source_reconnect")?.eventIds).toEqual(["udp-reconnect:accepted"]);
+  });
+
+  test("refreshes in-memory lap snapshots after session quality finalization", async () => {
+    const db = new FinalizingSnapshotDb([
+      {
+        id: 1,
+        sessionId: 1,
+        lapNumber: 1,
+        lapTime: 90,
+        isValid: true,
+        phase: "flying",
+        conditions: [],
+        paceEligibility: "eligible",
+        createdAt: new Date(0).toISOString(),
+        gameId: "fm-2023",
+        carOrdinal: 100,
+        trackOrdinal: 5,
+        source: "native-live",
+        quality: {
+          provenance: {
+            schemaVersion: QUALITY_SCHEMA_VERSION,
+            policyVersion: ELIGIBILITY_POLICY_VERSION,
+            configurationVersion: QUALITY_CONFIG_VERSION,
+            sourceGeneration: PROVISIONAL_LAP_GENERATION,
+            outputGeneration: PROVISIONAL_LAP_GENERATION,
+          },
+        } as unknown as LapQualitySummary,
+        qualityGeneration: PROVISIONAL_LAP_GENERATION,
+        qualityStale: true,
+      },
+    ]);
+    const ws = new CapturingWsAdapter();
+    const pipeline = new LiveTelemetryPipeline(db, ws, {
+      bypassPacketRateFilter: true,
+      skipDevState: true,
+      recorder: new NullSessionRecorderAdapter(),
+    });
+    db.snapshotProvider = () => pipeline.sessionLaps;
+
+    await pipeline.processPacket(telemetryPacket("fm-2023", 1_000));
+    await pipeline.finalizeCurrentSession();
+
+    expect(pipeline.sessionLaps).toHaveLength(1);
+    expect(pipeline.sessionLaps[0]?.qualityGeneration).toBe(FINALIZED_LAP_GENERATION);
+    expect(pipeline.sessionLaps[0]?.quality?.provenance.outputGeneration).toBe(FINALIZED_LAP_GENERATION);
+    expect(ws.broadcastedNotifications).toContainEqual({
+      type: "session-laps",
+      laps: [expect.objectContaining({ qualityGeneration: FINALIZED_LAP_GENERATION })],
+    });
+  });
+
+  test("starts the rotated recorder before old-session quality persistence completes", async () => {
+    const db = new DelayedQualityDb();
+    const recorder = new CapturingSessionRecorder();
+    const pipeline = new LiveTelemetryPipeline(db, new NullWsAdapter(), {
+      bypassPacketRateFilter: true,
+      skipHistorySeeding: true,
+      skipDevState: true,
+      recorder,
+    });
+    const firstFrame = Buffer.from("first-session");
+    const rotationFrame = Buffer.from("rotation");
+    const concurrentFrame = Buffer.from("during-finalization");
+
+    await pipeline.processPacket(telemetryPacket("acc", 1_000), firstFrame);
+    const rotation = pipeline.processPacket(telemetryPacket("ac-evo", 1_100), rotationFrame);
+    await db.qualityUpdateStarted;
+
+    const activeDuringFinalization = recorder.active;
+    const concurrentPacket = pipeline.processPacket(telemetryPacket("ac-evo", 1_200), concurrentFrame);
+    const recordsBeforeRelease = recorder.sessions[1]?.records.map((record) => record.toString()) ?? [];
+
+    db.release();
+    await Promise.all([rotation, concurrentPacket]);
+
+    expect(activeDuringFinalization).toBe(true);
+    expect(recordsBeforeRelease).toContain("during-finalization");
+  });
+});

--- a/test/telemetry/pipeline-live-issues.test.ts
+++ b/test/telemetry/pipeline-live-issues.test.ts
@@ -6,10 +6,11 @@
  */
 import { describe, test, expect, afterAll } from "bun:test";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
+import type { EligibilityDecision, EligibilityDecisionSet, EligibilityPolicyId } from "../../shared/racing/quality/contracts";
 import { initGameAdapters } from "../../shared/games/init";
 import { initServerGameAdapters } from "../../server/games/init";
-import { CapturingDbAdapter, CapturingWsAdapter, NullSessionRecorderAdapter } from "../../server/telemetry/pipeline-ports"
-import { LiveTelemetryPipeline, stopMaintenanceTasks } from "../../server/telemetry/live-pipeline"
+import { CapturingDbAdapter, CapturingWsAdapter, NullSessionRecorderAdapter } from "../../server/telemetry/pipeline-ports";
+import { LiveTelemetryPipeline, resolveLapIssueEligibility, stopMaintenanceTasks } from "../../server/telemetry/live-pipeline";
 
 initGameAdapters();
 initServerGameAdapters();
@@ -40,9 +41,7 @@ function pkt(overrides: Partial<TelemetryPacket> = {}): TelemetryPacket {
   } as TelemetryPacket;
 }
 
-function makePipeline(
-  onSessionFinalized?: (sessionId: number, gameId: TelemetryPacket["gameId"]) => Promise<void>,
-) {
+function makePipeline(onSessionFinalized?: (sessionId: number, gameId: TelemetryPacket["gameId"]) => Promise<void>) {
   const db = new CapturingDbAdapter();
   const ws = new CapturingWsAdapter();
   const pipeline = new LiveTelemetryPipeline(db, ws, {
@@ -55,10 +54,38 @@ function makePipeline(
   return { pipeline, ws };
 }
 
+function eligibilityDecision(policyId: EligibilityPolicyId, status: EligibilityDecision["status"]): EligibilityDecision {
+  return {
+    status,
+    policyId,
+    policyVersion: "1",
+    confidence: { level: status === "unknown" ? "unknown" : "high", score: status === "unknown" ? null : 1 },
+    reasons: status === "eligible" ? [] : [{ code: "channel_unavailable", severity: "error", evidenceIds: ["test:channel"], timeRange: null, distanceRange: null, semanticIds: ["motion.speed"] }],
+    evidenceIds: status === "eligible" ? [] : ["test:channel"],
+  };
+}
+
+function issueEligibility(overrides: Partial<Record<"normal-pace" | "corner-trace" | "transient-event", EligibilityDecision>> = {}): EligibilityDecisionSet {
+  return {
+    "normal-pace": eligibilityDecision("normal-pace", "eligible"),
+    "corner-trace": eligibilityDecision("corner-trace", "eligible"),
+    "transient-event": eligibilityDecision("transient-event", "eligible"),
+    ...overrides,
+  } as EligibilityDecisionSet;
+}
+
 describe("LiveTelemetryPipeline live issue gating", () => {
   test("liveIssuesEnabled defaults to false", () => {
     const { pipeline } = makePipeline();
     expect(pipeline.liveIssuesEnabled).toBe(false);
+  });
+
+  test("publishes first policy-owned reason when lap issue analysis is unavailable", () => {
+    const corner = eligibilityDecision("corner-trace", "ineligible");
+    const transient = eligibilityDecision("transient-event", "unknown");
+
+    expect(resolveLapIssueEligibility(issueEligibility({ "corner-trace": corner, "transient-event": transient }))).toBe(corner);
+    expect(resolveLapIssueEligibility(issueEligibility()).policyId).toBe("transient-event");
   });
 
   test("disabled: broadcast liveIssues arg is undefined", async () => {
@@ -103,13 +130,105 @@ describe("LiveTelemetryPipeline live issue gating", () => {
     });
     await pipeline.processPacket(pkt());
 
-    await Promise.all([
-      pipeline.finalizeCurrentSession(),
-      pipeline.finalizeCurrentSession(),
-    ]);
+    await Promise.all([pipeline.finalizeCurrentSession(), pipeline.finalizeCurrentSession()]);
     await pipeline.finalizeCurrentSession();
 
     expect(finalized).toEqual([{ sessionId: 1, gameId: "fm-2023" }]);
     expect(pipeline.lapDetector?.session).toBeNull();
+  });
+
+  test("keeps canonical recorder failure separate from original source verification", async () => {
+    const db = new CapturingDbAdapter();
+    const pipeline = new LiveTelemetryPipeline(db, new CapturingWsAdapter(), {
+      bypassPacketRateFilter: true,
+      skipHistorySeeding: true,
+      skipDevState: true,
+      recorder: new NullSessionRecorderAdapter(),
+      sourceArchiveVerification: {
+        state: "verified",
+        sourceGeneration: "sha256:original-source",
+      },
+    });
+
+    await pipeline.processPacket(pkt());
+    await pipeline.flushSessionRecorder();
+
+    expect(db.sessionQuality.get(1)?.archiveVerification).toEqual({
+      state: "verified",
+      sourceGeneration: "sha256:original-source",
+    });
+    expect(db.sessionQuality.get(1)?.canonicalVerification).toEqual({
+      state: "unavailable",
+      sourceGeneration: null,
+      details: "Recording disabled",
+    });
+  });
+
+  test("waits for lap persistence before finalizing rotated session quality", async () => {
+    const db = new CapturingDbAdapter();
+    const insertLap = db.insertLap.bind(db);
+    const updateSessionQuality = db.updateSessionQuality.bind(db);
+    let releaseLapWrite!: () => void;
+    let markLapWriteStarted!: () => void;
+    const lapWriteGate = new Promise<void>((resolve) => {
+      releaseLapWrite = resolve;
+    });
+    const lapWriteStarted = new Promise<void>((resolve) => {
+      markLapWriteStarted = resolve;
+    });
+    let qualityUpdated = false;
+    db.insertLap = async (input) => {
+      markLapWriteStarted();
+      await lapWriteGate;
+      return insertLap(input);
+    };
+    db.updateSessionQuality = async (sessionId, quality) => {
+      qualityUpdated = true;
+      return updateSessionQuality(sessionId, quality);
+    };
+    const recorder = new NullSessionRecorderAdapter();
+    const stopRecorder = recorder.stop.bind(recorder);
+    let recorderStopCount = 0;
+    let markRotatedRecorderStopped!: () => void;
+    const rotatedRecorderStopped = new Promise<void>((resolve) => {
+      markRotatedRecorderStopped = resolve;
+    });
+    recorder.stop = () => {
+      recorderStopCount++;
+      if (recorderStopCount === 2) markRotatedRecorderStopped();
+      return stopRecorder();
+    };
+    const pipeline = new LiveTelemetryPipeline(db, new CapturingWsAdapter(), {
+      bypassPacketRateFilter: true,
+      skipHistorySeeding: true,
+      skipDevState: true,
+      recorder,
+    });
+
+    await pipeline.processPacket(pkt());
+    let rotationSettled = false;
+    const rotation = pipeline
+      .processPacket(
+        pkt({
+          TimestampMS: 2_000,
+          CurrentLap: 31,
+          DistanceTraveled: 2_100,
+          CarOrdinal: 101,
+        }),
+      )
+      .then(() => {
+        rotationSettled = true;
+      });
+    await Promise.all([lapWriteStarted, rotatedRecorderStopped]);
+    await Promise.resolve();
+
+    expect(rotationSettled).toBe(false);
+    expect(qualityUpdated).toBe(false);
+    releaseLapWrite();
+    await rotation;
+
+    expect(db.laps).toHaveLength(1);
+    expect(db.sessionQuality.has(1)).toBe(true);
+    expect(qualityUpdated).toBe(true);
   });
 });


### PR DESCRIPTION
Replacement for closed #270 after reviewer remediation.

Part 4 of 8 for #231

Parent: #269. Base: `issue-229/03-quality-persistence`.

## Behavior
- Serialize session rotation and shutdown so old detector writes drain into old session before capture changes.
- Persist finalized quality and provenance before broadcasting session completion; preserve native packet timing and live gap evidence.

## Focused verification
- `Focused live pipeline lifecycle, issue, adapter, UDP listener, SessionRecorder, raw capture, and pit tracker suites.`
- `bun run typecheck`