### PR TITLE
feat(server): gate analysis by quality policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@
 - Validate RaceIQ canonical recording and every archive manifest/member separately from imported-source provenance so valid source cannot hide corrupt local evidence
 - Reject RaceIQ archives that omit session captures declared by their v2 manifest
 - Preserve native-live provenance when migrating legacy sessions while retaining explicit imported-source labels
+- Mark analysis unsuitable when imported recording omits required controls or continuous tire channel contains only isolated samples instead of treating filled zeroes as real telemetry
+- Keep valid timed laps in lap-time experiment metrics when unrelated steering or input trace channels are unavailable
+- Reject stale eligibility snapshots in policy consumers, AI cache reads, and raw-recording cleanup decisions
+- Keep every recorded experiment lap available for inspection in Tune Review while limiting aggregate setup evaluation to its curated evidence pool
+- Preserve telemetry warning reasons in setup-analysis decisions and Setup Engineer lap summaries
+- Clear displayed comparison analysis and conversations when either lap quality generation changes
 - Make stale-session reprocessing recoverable with retry and dismissal actions, accessible progress states, and clear failure feedback
 - Skip unavailable raw captures during stale-session reprocessing instead of failing the entire maintenance run
 - Keep newly started session captures from being removed by concurrent storage cleanup

--- a/mastra/README.md
+++ b/mastra/README.md
@@ -1,0 +1,26 @@
+# Mastra
+
+Mastra composition for RaceIQ AI agents, deterministic prerequisite workflows, model tools, evaluations, and development observability.
+
+## Structure
+
+- `index.ts` registers agents, workflows, scorers, storage, logging, and observability.
+- `agents/` defines one agent per user-facing analysis or coaching role.
+- `tools/` exposes bounded reads and actions over RaceIQ domains. `setup-engineer.ts` binds session and game identity through request context rather than model-supplied arguments.
+- `workflows/` gathers deterministic prerequisites before model reasoning. `setup-engineer-turn.ts` assembles setup, experiment, clean-lap, quality, and version evidence.
+- `evals/` owns model-backed fixtures and scorers.
+- `model.ts` resolves configured model providers.
+
+## Boundaries and invariants
+
+Mastra orchestrates domain APIs; it does not own telemetry parsing, lap quality policy, experiment curation, setup rules, persistence, or HTTP validation. Import those contracts from their existing shared or server owners instead of duplicating them in tools or prompts.
+
+Setup conclusions use shared `setup-analysis` and related lap eligibility decisions. Tools and workflows preserve exact eligibility status and reason codes in gathered context; `unknown` and `ineligible` evidence cannot support a setup conclusion. Manual experiment exclusion, policy rejection, and fastest-lap caps remain separate concepts.
+
+Per-turn game and session identity comes from trusted request context. Models may choose supported actions and action arguments, but may not choose persistence scope. Keep read-before-reason workflows deterministic and action tools guarded by existing setup and experiment services.
+
+`index.ts` is used by server chat routes and development Studio integration. Production imports remain environment-gated, and DuckDB observability keeps one writer.
+
+## Testing
+
+Use focused prompt, tool, workflow, and setup-engineer guard tests. Assert observable tool results, eligibility rejection, request-context scoping, and side-effect guards rather than Mastra implementation details.

--- a/mastra/tools/setup-engineer.ts
+++ b/mastra/tools/setup-engineer.ts
@@ -37,32 +37,29 @@ import { saveAssistantChatMessage, tuneSessionThreadId } from "../../server/ai/c
 import { wsManager } from "../../server/runtime/websocket-manager";
 import { formatSymptoms } from "../../server/ai/tune-chat-prompt";
 import { buildAppliedChangesMarkdown } from "../../server/setups/applied-change-markdown";
-import {
-  computeSessionSymptoms,
-  computeSessionTrackConditions,
-} from "../../server/experiments/representative-lap";
 import { formatTrackConditions } from "../../server/ai/track-conditions";
-import {
-  gameHasSetupFile,
-  loadActiveExperimentContext,
-} from "../../server/experiments/setup-lineage";
+import { gameHasSetupFile, loadActiveExperimentContext } from "../../server/experiments/setup-lineage";
 import { readActiveSetup, writeAppliedSetup } from "../../server/setups/io";
 import { readSetupEngineerContext } from "./setup-engineer-request-context";
 import { consultLapAnalystForSession } from "../../server/ai/consult-lap-analyst";
 import { loadCleanLapAggregate } from "../../server/experiments/lap-evidence/aggregate";
+import { selectEvaluationLaps } from "../../shared/racing/laps/review-selection";
+import { eligibilityDecisionText } from "../../shared/racing/quality/display";
 import { setLapExperimentExcluded, getLapsForExperiment } from "../../server/db/experiment-lap-queries";
 import { getLapById } from "../../server/db/lap-read-queries";
 import { resolveTrack } from "../../server/tracks/info";
 import { recordAction } from "../../server/db/experiment-action-queries";
-import { undoLastAction } from "../../server/experiments/undo"
+import { undoLastAction } from "../../server/experiments/undo";
 import { detectCorners } from "../../server/lap-analysis/corners";
 import { telemetryToSymptoms } from "../../server/ai/tune-symptoms";
 import { symptomsToIssues } from "../../server/ai/tune-issues";
 import { compareLaps } from "../../server/lap-analysis/comparison";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
+import type { LapMeta } from "../../shared/racing/sessions/types";
 
 const DirectionEnum = z.enum(["increase", "decrease"]);
 const MagnitudeEnum = z.enum(["small", "medium", "large"]);
+const EligibilityStatusEnum = z.enum(["eligible", "eligible_with_warning", "ineligible", "unknown"]);
 
 // Per-session binding (gameId, sessionId) comes from Mastra requestContext, set
 // once per turn by the chat route — NOT a model-supplied tool arg. Weak local
@@ -121,8 +118,30 @@ const MAX_ISSUE_LAPS = 8;
 // Matches loadRepresentativeLap's/clean-lap-aggregate's analysable-lap gate.
 const MIN_TELEMETRY_FRAMES = 30;
 
-export function buildSetupEngineerTools() {
+export function buildSetupEngineerLapSummaries(laps: LapMeta[]) {
+  const selection = selectEvaluationLaps(laps, Number.POSITIVE_INFINITY);
+  const bestLapTime = selection.chosen[0]?.lapTime ?? null;
+  return laps.map((lap) => {
+    const decision = selection.rejectionDecisionById.get(lap.id) ?? selection.setupDecision;
+    const analysisEligible = selection.chosenIds.has(lap.id);
+    return {
+      lapId: lap.id,
+      lapNumber: lap.lapNumber,
+      lapTime: lap.lapTime,
+      isValid: lap.isValid,
+      excluded: Boolean(lap.experimentExcluded),
+      analysisEligible,
+      eligibilityStatus: decision.status,
+      reasonCodes: analysisEligible ? decision.reasons.map(({ code }) => code) : [...(selection.reasonCodesById.get(lap.id) ?? [])],
+      s1Time: lap.sectorTimes?.[0] ?? null,
+      s2Time: lap.sectorTimes?.[1] ?? null,
+      s3Time: lap.sectorTimes?.[2] ?? null,
+      deltaToBestSec: bestLapTime != null && analysisEligible ? lap.lapTime - bestLapTime : null,
+    };
+  });
+}
 
+export function buildSetupEngineerTools() {
   const getSetupTool = createTool({
     id: "get-setup",
     description:
@@ -134,13 +153,17 @@ export function buildSetupEngineerTools() {
       ok: z.boolean(),
       error: z.string().optional(),
       version: z.number().optional(),
-      knobs: z.array(z.object({
-        component: z.string(),
-        current: z.number().nullable(),
-        min: z.number(),
-        max: z.number(),
-        step: z.object({ small: z.number(), medium: z.number(), large: z.number() }),
-      })).default([]),
+      knobs: z
+        .array(
+          z.object({
+            component: z.string(),
+            current: z.number().nullable(),
+            min: z.number(),
+            max: z.number(),
+            step: z.object({ small: z.number(), medium: z.number(), large: z.number() }),
+          }),
+        )
+        .default([]),
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
@@ -157,36 +180,50 @@ export function buildSetupEngineerTools() {
   const getSymptomsTool = createTool({
     id: "get-symptoms",
     description:
-      "Get the deterministic symptom report (balance per corner phase, lockups, bottoming) computed from " +
-      "the session's fastest valid lap. Call this before diagnosing handling problems or proposing setup " +
-      "changes, so recommendations target measured symptoms rather than guesses. Returns 'available: false' " +
-      "when no lap has been driven yet — in that case, discuss the setup from the driver's description of " +
-      "how the car feels.",
+      "Get the deterministic symptom report computed from the shared setup-analysis lap pool. " +
+      "Returns the exact policy status and machine-readable reason codes. Unknown or ineligible " +
+      "evidence is unavailable and must not be used for setup conclusions.",
     inputSchema: NoInput,
     outputSchema: z.object({
       available: z.boolean(),
       summary: z.string(),
+      eligibilityStatus: EligibilityStatusEnum,
+      reasonCodes: z.array(z.string()),
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
-      const symptoms = await computeSessionSymptoms(sessionId);
-      if (!symptoms) return { available: false, summary: "No analysable lap yet for this session." };
-      return { available: true, summary: formatSymptoms(symptoms) };
+      const agg = await loadCleanLapAggregate(sessionId);
+      const eligibilityStatus = agg.setupDecision.status;
+      const reasonCodes = agg.setupDecision.reasons.map((reason) => reason.code);
+      if (!agg.symptoms) {
+        return {
+          available: false,
+          summary: eligibilityDecisionText(agg.setupDecision),
+          eligibilityStatus,
+          reasonCodes,
+        };
+      }
+      return {
+        available: true,
+        summary: formatSymptoms(agg.symptoms),
+        eligibilityStatus,
+        reasonCodes,
+      };
     },
   });
 
   const getTrackConditionsTool = createTool({
     id: "get-track-conditions",
     description:
-      "Get the deterministic weather / track-surface conditions (air & road temperature, rain, grip level, " +
-      "wind, and for AC-EVO the static starting-grip label) measured across the session's representative lap — " +
-      "the same fastest valid lap the symptom report uses. Returns 'available: false' when no lap has been " +
-      "driven yet. Use this to reason about temperature-sensitive knobs (tyre pressures, which climb with hot " +
-      "track/air) and grip: a green or wet track wants a softer, more compliant setup than an optimum dry one.",
+      "Get deterministic weather / track-surface conditions from the same shared setup-analysis " +
+      "lap pool as the symptom report. Returns the exact policy status and machine-readable reason " +
+      "codes. Unknown or ineligible evidence is unavailable.",
     inputSchema: NoInput,
     outputSchema: z.object({
       available: z.boolean(),
       summary: z.string(),
+      eligibilityStatus: EligibilityStatusEnum,
+      reasonCodes: z.array(z.string()),
       airTempC: z.object({ min: z.number(), max: z.number(), avg: z.number() }).nullable().optional(),
       roadTempC: z.object({ min: z.number(), max: z.number(), avg: z.number() }).nullable().optional(),
       rainIntensity: z.number().optional(),
@@ -199,11 +236,23 @@ export function buildSetupEngineerTools() {
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
-      const tc = await computeSessionTrackConditions(sessionId);
-      if (!tc) return { available: false, summary: "No analysable lap yet for this session." };
+      const agg = await loadCleanLapAggregate(sessionId);
+      const eligibilityStatus = agg.setupDecision.status;
+      const reasonCodes = agg.setupDecision.reasons.map((reason) => reason.code);
+      const tc = agg.trackConditions;
+      if (!tc) {
+        return {
+          available: false,
+          summary: eligibilityDecisionText(agg.setupDecision),
+          eligibilityStatus,
+          reasonCodes,
+        };
+      }
       return {
         available: true,
         summary: formatTrackConditions(tc),
+        eligibilityStatus,
+        reasonCodes,
         airTempC: tc.airTempC,
         roadTempC: tc.roadTempC,
         rainIntensity: tc.rainIntensity,
@@ -220,16 +269,16 @@ export function buildSetupEngineerTools() {
   const consultLapAnalystTool = createTool({
     id: "consult-lap-analyst",
     description:
-      "Delegate a full corner-by-corner driving/telemetry analysis of the session's representative lap to the " +
-      "Lap Analyst — a separate expert agent. Use this when the driver asks something that needs telemetry " +
-      "insight beyond the setup itself (e.g. where they're losing time, braking/throttle habits, which corners " +
-      "cost the most), or to decide whether a slow lap is a driving issue rather than a setup one. Returns " +
-      "'available: false' when no lap has been driven yet. This is a heavier call than get_symptoms — reach for " +
-      "it when the setup signals aren't enough.",
+      "Delegate corner-by-corner driving/telemetry analysis of the shared policy-selected lap to " +
+      "the Lap Analyst. Use this when the driver asks where time is lost or whether a problem is " +
+      "driving rather than setup. Returns exact eligibility status and machine-readable reason codes; " +
+      "unknown or ineligible evidence is unavailable.",
     inputSchema: NoInput,
     outputSchema: z.object({
       available: z.boolean(),
       summary: z.string(),
+      eligibilityStatus: EligibilityStatusEnum,
+      reasonCodes: z.array(z.string()),
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
@@ -245,19 +294,23 @@ export function buildSetupEngineerTools() {
       "a change that was already tried, or to reason about what's been attempted.",
     inputSchema: NoInput,
     outputSchema: z.object({
-      versions: z.array(z.object({
-        version: z.number(),
-        label: z.string(),
-        engine: z.string().nullable(),
-        driverComment: z.string().nullable(),
-        notes: z.string().nullable(),
-        changes: z.array(z.object({
-          component: z.string(),
-          from: z.number(),
-          to: z.number(),
-          direction: z.string(),
-        })),
-      })),
+      versions: z.array(
+        z.object({
+          version: z.number(),
+          label: z.string(),
+          engine: z.string().nullable(),
+          driverComment: z.string().nullable(),
+          notes: z.string().nullable(),
+          changes: z.array(
+            z.object({
+              component: z.string(),
+              from: z.number(),
+              to: z.number(),
+              direction: z.string(),
+            }),
+          ),
+        }),
+      ),
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
@@ -270,7 +323,9 @@ export function buildSetupEngineerTools() {
             try {
               const parsed = JSON.parse(t.appliedChanges);
               if (Array.isArray(parsed)) changes = parsed;
-            } catch { /* malformed history row — surface as no changes */ }
+            } catch {
+              /* malformed history row — surface as no changes */
+            }
           }
           return {
             version: t.version,
@@ -309,12 +364,14 @@ export function buildSetupEngineerTools() {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
       const ctx = await loadActiveExperimentContext(sessionId);
       if (!ctx.ok) return { ok: false, error: ctx.error };
-      const { setup, applied, skipped } = applyIntents(ctx.gameId, ctx.setup, [{
-        component: inputData.component,
-        direction: inputData.direction as TuneDirection,
-        magnitude: inputData.magnitude as TuneMagnitude,
-        reason: "preview",
-      }]);
+      const { setup, applied, skipped } = applyIntents(ctx.gameId, ctx.setup, [
+        {
+          component: inputData.component,
+          direction: inputData.direction as TuneDirection,
+          magnitude: inputData.magnitude as TuneMagnitude,
+          reason: "preview",
+        },
+      ]);
       void setup;
       if (applied.length > 0) {
         const c = applied[0]!;
@@ -335,14 +392,22 @@ export function buildSetupEngineerTools() {
       "several experimental children of v1), pass `target` — do NOT use branch-from-version for that, since " +
       "a plain branch is a byte-copy with no changes recorded.",
     inputSchema: z.object({
-      changes: z.array(z.object({
-        component: z.string(),
-        direction: DirectionEnum,
-        magnitude: MagnitudeEnum,
-        reason: z.string().describe("One short sentence: why this change, grounded in the symptoms/conversation."),
-      })).min(1),
-      goal: z.string().describe("One short line: the driver's goal for this version, e.g. \"faster straight speed\", \"stiffer suspension\". Stored on the version and shown in the tree."),
-      driverConfirmed: z.boolean().describe("true ONLY if the driver explicitly approved this exact set of changes in a message AFTER you proposed it (e.g. \"yes\", \"apply that\"). false if you have not yet proposed the changes and been told to go ahead."),
+      changes: z
+        .array(
+          z.object({
+            component: z.string(),
+            direction: DirectionEnum,
+            magnitude: MagnitudeEnum,
+            reason: z.string().describe("One short sentence: why this change, grounded in the symptoms/conversation."),
+          }),
+        )
+        .min(1),
+      goal: z.string().describe('One short line: the driver\'s goal for this version, e.g. "faster straight speed", "stiffer suspension". Stored on the version and shown in the tree.'),
+      driverConfirmed: z
+        .boolean()
+        .describe(
+          'true ONLY if the driver explicitly approved this exact set of changes in a message AFTER you proposed it (e.g. "yes", "apply that"). false if you have not yet proposed the changes and been told to go ahead.',
+        ),
       target: z.string().optional().describe("Label or version number to apply the changes on top of (becomes the new version's parent). Omit to apply on the current head."),
     }),
     outputSchema: z.object({
@@ -371,10 +436,7 @@ export function buildSetupEngineerTools() {
         };
       }
       const turnMessages = execCtx?.requestContext?.get(CHAT_TURN_MESSAGES_KEY);
-      if (
-        Array.isArray(turnMessages) &&
-        !inputData.changes.every((change) => hasExplicitChangeConfirmation(turnMessages as { role?: string; parts?: unknown[]; content?: unknown }[], change))
-      ) {
+      if (Array.isArray(turnMessages) && !inputData.changes.every((change) => hasExplicitChangeConfirmation(turnMessages as { role?: string; parts?: unknown[]; content?: unknown }[], change))) {
         return {
           ok: false,
           error: "Not applied — explicit confirmation must follow a matching preview in a later driver message.",
@@ -499,10 +561,7 @@ export function buildSetupEngineerTools() {
       // Best-effort: a memory write failure must not fail the apply — the
       // file + tuning test are already committed.
       try {
-        await saveAssistantChatMessage(
-          tuneSessionThreadId(sessionId),
-          buildAppliedChangesMarkdown(label, applied, written.fileName, gameHasSetupFile(ctx.gameId), inputData.goal?.trim() || null),
-        );
+        await saveAssistantChatMessage(tuneSessionThreadId(sessionId), buildAppliedChangesMarkdown(label, applied, written.fileName, gameHasSetupFile(ctx.gameId), inputData.goal?.trim() || null));
       } catch (err: any) {
         console.error("[SetupEngineer] Failed to post applied-tweaks message:", err?.message);
       }
@@ -561,12 +620,7 @@ export function buildSetupEngineerTools() {
       "instead. Defaults to the current version; pass `version` to annotate an earlier one. This OVERWRITES " +
       "the note, so include anything from the existing note you want to keep. Pass an empty note to clear it.",
     inputSchema: z.object({
-      version: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .describe("Version number to annotate. Omit to note the current (head) version."),
+      version: z.number().int().positive().optional().describe("Version number to annotate. Omit to note the current (head) version."),
       note: z.string().max(4000).describe("The note text. Empty string clears the note."),
     }),
     outputSchema: z.object({
@@ -618,21 +672,11 @@ export function buildSetupEngineerTools() {
       "and only call this with `driverConfirmed: true` after they approve it in a later message. Defaults to " +
       "the current version; pass `version` to annotate an earlier one.",
     inputSchema: z.object({
-      version: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .describe("Version number to annotate. Omit to note the current (head) version."),
-      note: z
-        .string()
-        .max(4000)
-        .describe("The driver's notes, in their terms — feel and issues. Empty string clears the note."),
+      version: z.number().int().positive().optional().describe("Version number to annotate. Omit to note the current (head) version."),
+      note: z.string().max(4000).describe("The driver's notes, in their terms — feel and issues. Empty string clears the note."),
       driverConfirmed: z
         .boolean()
-        .describe(
-          "true ONLY if the driver explicitly approved this exact note text in a message AFTER you read it back to them. false if you have not yet shown them the wording.",
-        ),
+        .describe("true ONLY if the driver explicitly approved this exact note text in a message AFTER you read it back to them. false if you have not yet shown them the wording."),
     }),
     outputSchema: z.object({
       ok: z.boolean(),
@@ -692,13 +736,17 @@ export function buildSetupEngineerTools() {
     outputSchema: z.object({
       available: z.boolean(),
       summary: z.string(),
-      corners: z.array(z.object({
-        corner: z.string(),
-        lateralSpreadM: z.number(),
-        brakeVar: z.number(),
-        throttleVar: z.number(),
-        lowTrust: z.boolean(),
-      })).default([]),
+      corners: z
+        .array(
+          z.object({
+            corner: z.string(),
+            lateralSpreadM: z.number(),
+            brakeVar: z.number(),
+            throttleVar: z.number(),
+            lowTrust: z.boolean(),
+          }),
+        )
+        .default([]),
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
@@ -722,46 +770,38 @@ export function buildSetupEngineerTools() {
   const listLapsTool = createTool({
     id: "list-laps",
     description:
-      "Read-only. List every lap recorded in this tuning session: lap id/number, lap time, sector times, " +
-      "delta to the session's best valid lap, validity, and the excluded flag. Compact — no telemetry arrays. " +
-      "Use this to see the full lap pool before deciding which lap(s) to dig into with get_lap_detail, " +
-      "get_lap_issues, or compare_laps.",
+      "Read-only. List every lap in this tuning session with structural validity, shared setup-analysis " +
+      "eligibility status, exact machine-readable reason codes, and delta to best policy-selected lap. " +
+      "Compact — no telemetry arrays. Use before inspecting or comparing specific laps.",
     inputSchema: NoInput,
     outputSchema: z.object({
       ok: z.boolean(),
       error: z.string().optional(),
-      laps: z.array(z.object({
-        lapId: z.number(),
-        lapNumber: z.number(),
-        lapTime: z.number(),
-        isValid: z.boolean(),
-        excluded: z.boolean(),
-        s1Time: z.number().nullable(),
-        s2Time: z.number().nullable(),
-        s3Time: z.number().nullable(),
-        deltaToBestSec: z.number().nullable(),
-      })).default([]),
+      laps: z
+        .array(
+          z.object({
+            lapId: z.number(),
+            lapNumber: z.number(),
+            lapTime: z.number(),
+            isValid: z.boolean(),
+            excluded: z.boolean(),
+            analysisEligible: z.boolean(),
+            eligibilityStatus: EligibilityStatusEnum,
+            reasonCodes: z.array(z.string()),
+            s1Time: z.number().nullable(),
+            s2Time: z.number().nullable(),
+            s3Time: z.number().nullable(),
+            deltaToBestSec: z.number().nullable(),
+          }),
+        )
+        .default([]),
     }),
     execute: async (_input, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
       const laps = await getLapsForExperiment(sessionId);
-      const bestLapTime = laps.reduce<number | null>((best, l) => {
-        if (!l.isValid || l.lapTime <= 0) return best;
-        return best == null || l.lapTime < best ? l.lapTime : best;
-      }, null);
       return {
         ok: true,
-        laps: laps.map((l) => ({
-          lapId: l.id,
-          lapNumber: l.lapNumber,
-          lapTime: l.lapTime,
-          isValid: l.isValid,
-          excluded: Boolean(l.experimentExcluded),
-          s1Time: l.sectorTimes?.[0] ?? null,
-          s2Time: l.sectorTimes?.[1] ?? null,
-          s3Time: l.sectorTimes?.[2] ?? null,
-          deltaToBestSec: bestLapTime != null && l.isValid && l.lapTime > 0 ? l.lapTime - bestLapTime : null,
-        })),
+        laps: buildSetupEngineerLapSummaries(laps),
       };
     },
   });
@@ -784,21 +824,31 @@ export function buildSetupEngineerTools() {
       s1Time: z.number().nullable().optional(),
       s2Time: z.number().nullable().optional(),
       s3Time: z.number().nullable().optional(),
-      corners: z.array(z.object({
-        label: z.string(),
-        minSpeedKph: z.number().optional(),
-      })).optional(),
-      tires: z.object({
-        FL: CornerSnapShape,
-        FR: CornerSnapShape,
-        RL: CornerSnapShape,
-        RR: CornerSnapShape,
-      }).nullable().optional(),
-      metrics: z.object({
-        topSpeedKph: z.number(),
-        avgThrottle: z.number(),
-        avgBrake: z.number(),
-      }).nullable().optional(),
+      corners: z
+        .array(
+          z.object({
+            label: z.string(),
+            minSpeedKph: z.number().optional(),
+          }),
+        )
+        .optional(),
+      tires: z
+        .object({
+          FL: CornerSnapShape,
+          FR: CornerSnapShape,
+          RL: CornerSnapShape,
+          RR: CornerSnapShape,
+        })
+        .nullable()
+        .optional(),
+      metrics: z
+        .object({
+          topSpeedKph: z.number(),
+          avgThrottle: z.number(),
+          avgBrake: z.number(),
+        })
+        .nullable()
+        .optional(),
     }),
     execute: async (inputData, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
@@ -853,24 +903,28 @@ export function buildSetupEngineerTools() {
   const getLapIssuesTool = createTool({
     id: "get-lap-issues",
     description:
-      "Read-only. Detected issues (understeer/oversteer, brake lockup, suspension bottoming, tyre pressure) " +
-      "for a lap in this session, via the SAME deterministic detector the review dashboard's issue feed uses. " +
-      "Pass lapId for one lap; omit it to scan every analysable lap in the session (capped, newest matter most). " +
-      "Rejects a lapId that isn't in this session.",
+      "Read-only. Detect handling issues only from laps accepted by shared setup-analysis policy. " +
+      "Pass lapId for one lap; omit it to scan policy-selected laps (capped). Unknown/ineligible " +
+      "laps are rejected with exact machine-readable policy reason codes.",
     inputSchema: z.object({ lapId: z.number().int().positive().optional() }),
     outputSchema: z.object({
       ok: z.boolean(),
       error: z.string().optional(),
       truncated: z.boolean().optional(),
-      laps: z.array(z.object({
-        lapId: z.number(),
-        lapNumber: z.number(),
-        issues: z.array(IssueShape),
-      })).default([]),
+      laps: z
+        .array(
+          z.object({
+            lapId: z.number(),
+            lapNumber: z.number(),
+            issues: z.array(IssueShape),
+          }),
+        )
+        .default([]),
     }),
     execute: async (inputData, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
       const sessionLaps = await getLapsForExperiment(sessionId);
+      const selection = selectEvaluationLaps(sessionLaps, Number.POSITIVE_INFINITY);
 
       const issuesForLap = async (meta: (typeof sessionLaps)[number]) => {
         const lap = await getLapById(meta.id);
@@ -883,12 +937,36 @@ export function buildSetupEngineerTools() {
       if (inputData.lapId != null) {
         const meta = sessionLaps.find((l) => l.id === inputData.lapId);
         if (!meta) return { ok: false, error: `Lap ${inputData.lapId} is not in this session.`, laps: [] };
+        const selectionReason = selection.reasonById.get(meta.id);
+        if (selectionReason === "invalid") {
+          return {
+            ok: false,
+            error: `Lap ${meta.id} is structurally invalid and cannot support handling conclusions.`,
+            laps: [],
+          };
+        }
+        if (selectionReason === "manual") {
+          return {
+            ok: false,
+            error: `Lap ${meta.id} was manually excluded from setup analysis.`,
+            laps: [],
+          };
+        }
+        if (!selection.chosenIds.has(meta.id)) {
+          const decision = selection.rejectionDecisionById.get(meta.id) ?? selection.setupDecision;
+          const codes = selection.reasonCodesById.get(meta.id) ?? [];
+          return {
+            ok: false,
+            error: `Lap ${meta.id} is ${decision.status} for ${decision.policyId}: ${codes.join(", ") || "no policy reason"}.`,
+            laps: [],
+          };
+        }
         const issues = await issuesForLap(meta);
         if (issues == null) return { ok: false, error: `Lap ${inputData.lapId} has no analysable telemetry.`, laps: [] };
         return { ok: true, laps: [{ lapId: meta.id, lapNumber: meta.lapNumber, issues }] };
       }
 
-      const analysable = sessionLaps.filter((l) => l.isValid && l.lapTime > 0);
+      const analysable = selection.chosen;
       const truncated = analysable.length > MAX_ISSUE_LAPS;
       const scoped = analysable.slice(0, MAX_ISSUE_LAPS);
       const laps: { lapId: number; lapNumber: number; issues: ReturnType<typeof symptomsToIssues> }[] = [];
@@ -916,12 +994,16 @@ export function buildSetupEngineerTools() {
       lapA: z.object({ lapId: z.number(), lapNumber: z.number(), lapTime: z.number() }).optional(),
       lapB: z.object({ lapId: z.number(), lapNumber: z.number(), lapTime: z.number() }).optional(),
       timeDeltaSec: z.number().optional().describe("Final cumulative delta: positive = lap A slower overall."),
-      corners: z.array(z.object({
-        label: z.string(),
-        deltaSeconds: z.number(),
-        timeA: z.number(),
-        timeB: z.number(),
-      })).optional(),
+      corners: z
+        .array(
+          z.object({
+            label: z.string(),
+            deltaSeconds: z.number(),
+            timeA: z.number(),
+            timeB: z.number(),
+          }),
+        )
+        .optional(),
     }),
     execute: async (inputData, execCtx) => {
       const { sessionId } = readSetupEngineerContext(execCtx?.requestContext);
@@ -1003,8 +1085,8 @@ export function buildSetupEngineerTools() {
     id: "undo-last-action",
     description:
       "Undo the most recent action taken in this session (apply/branch/add-base/inspire/import/set-head/delete/" +
-      "restore/rename/exclude) — user or AI. Use when the driver says \"undo that\" / \"undo the last change\" / " +
-      "\"go back\". Reverses exactly one action per call; call again to go further back. If undoing a version " +
+      'restore/rename/exclude) — user or AI. Use when the driver says "undo that" / "undo the last change" / ' +
+      '"go back". Reverses exactly one action per call; call again to go further back. If undoing a version ' +
       "created by apply/branch/add-base/inspire and that version already has laps or child branches on it, it " +
       "warns and soft-deletes the whole subtree so nothing is silently stranded (restorable from the trash).",
     inputSchema: NoInput,
@@ -1021,10 +1103,7 @@ export function buildSetupEngineerTools() {
 
       if (result.undone) {
         try {
-          await saveAssistantChatMessage(
-            tuneSessionThreadId(sessionId),
-            result.warning ? `Undone — ${result.warning}` : `Undone (${result.kind}).`,
-          );
+          await saveAssistantChatMessage(tuneSessionThreadId(sessionId), result.warning ? `Undone — ${result.warning}` : `Undone (${result.kind}).`);
         } catch (err: any) {
           console.error("[SetupEngineer] Failed to post undo note:", err?.message);
         }

--- a/mastra/workflows/setup-engineer-turn.ts
+++ b/mastra/workflows/setup-engineer-turn.ts
@@ -31,12 +31,10 @@ import { describeKnobs } from "../../server/setups/rules/engine";
 import { formatSymptoms } from "../../server/ai/tune-chat-prompt";
 import { formatTrackConditions } from "../../server/ai/track-conditions";
 import { loadActiveExperimentContext } from "../../server/experiments/setup-lineage";
-import {
-  loadCleanLapAggregate,
-  baselineFallbackNote,
-} from "../../server/experiments/lap-evidence/aggregate";
+import { loadCleanLapAggregate, baselineFallbackNote } from "../../server/experiments/lap-evidence/aggregate";
 import { formatLapObservations } from "../../server/ai/lap-observations";
 import { getOrComputeLapMetricsBatch } from "../../server/lap-analysis/metrics-store";
+import { eligibilityDecisionText, qualityReasonText } from "../../shared/racing/quality/display";
 import { listExperimentVersions } from "../../server/db/experiment-version-queries";
 
 const InputSchema = z.object({
@@ -49,8 +47,7 @@ const OutputSchema = z.object({
 const gatherPrereqs = createStep({
   id: "gather-prereqs",
   description:
-    "Force-call the Setup Engineer read tools (current setup, symptoms, track conditions, version " +
-    "history) deterministically so the engineer always reasons from grounded, current data.",
+    "Force-call the Setup Engineer read tools (current setup, symptoms, track conditions, version " + "history) deterministically so the engineer always reasons from grounded, current data.",
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
   execute: async ({ inputData }) => {
@@ -66,10 +63,7 @@ const gatherPrereqs = createStep({
       sections.push(
         `--- CURRENT SETUP (v${ctx.activeTest?.version ?? 0}) — the ONLY knobs you may move ---\n` +
           tunable.map((k) => `${k.component}: ${k.current} [${k.min}..${k.max}]`).join("\n") +
-          (missing.length
-            ? `\n--- NOT TUNABLE ON THIS CAR (value: None — never suggest or apply changes to these) ---\n` +
-              missing.map((k) => `${k.component}: None`).join("\n")
-            : ""),
+          (missing.length ? `\n--- NOT TUNABLE ON THIS CAR (value: None — never suggest or apply changes to these) ---\n` + missing.map((k) => `${k.component}: None`).join("\n") : ""),
       );
     } else {
       sections.push(`--- CURRENT SETUP ---\n(unavailable: ${ctx.error})`);
@@ -85,12 +79,18 @@ const gatherPrereqs = createStep({
       `confidence: ${consistency.confidence.toUpperCase()}`,
       `clean laps: ${consistency.cleanLapCount}`,
       `best lap: ${consistency.bestLapSec != null ? `${consistency.bestLapSec.toFixed(3)}s` : "n/a"}`,
-      `spread: ${consistency.spreadSec != null ? `${consistency.spreadSec.toFixed(3)}s` : "n/a"}` +
-        (consistency.spreadPct != null ? ` (${(consistency.spreadPct * 100).toFixed(2)}%)` : ""),
+      `spread: ${consistency.spreadSec != null ? `${consistency.spreadSec.toFixed(3)}s` : "n/a"}` + (consistency.spreadPct != null ? ` (${(consistency.spreadPct * 100).toFixed(2)}%)` : ""),
       `dropped outliers: ${consistency.droppedOutliers}`,
       `fallback to single lap: ${agg.fallbackSingleLap}`,
       `source: ${agg.sourceScope}`,
     ];
+    confidenceLines.push(`setup-analysis policy: ${agg.setupDecision.status}; ${eligibilityDecisionText(agg.setupDecision)}`);
+    for (const reason of agg.setupDecision.reasons) {
+      confidenceLines.push(`- ${reason.code}: ${qualityReasonText(reason.code, reason.timeRange, reason.distanceRange)}`);
+    }
+    if (agg.setupDecision.status === "unknown" || agg.setupDecision.status === "ineligible") {
+      confidenceLines.push("SETUP EVIDENCE BLOCKED: do not draw handling or setup conclusions from these laps.");
+    }
     if (agg.sourceScope === "session-baseline") {
       confidenceLines.push("(session baseline pool — laps may mix setups; confidence capped at medium)");
     }
@@ -99,9 +99,7 @@ const gatherPrereqs = createStep({
     const fallbackNote = baselineFallbackNote(agg);
     if (fallbackNote) confidenceLines.push(fallbackNote);
     if (agg.fallbackSingleLap) {
-      confidenceLines.push(
-        "(only <2 clean laps — reasoning from the single fastest lap; treat suggestions as low-confidence)",
-      );
+      confidenceLines.push("(only <2 clean laps — reasoning from the single fastest lap; treat suggestions as low-confidence)");
     }
     sections.push(`--- CONFIDENCE ---\n${confidenceLines.join("\n")}`);
 
@@ -109,7 +107,10 @@ const gatherPrereqs = createStep({
       "--- LAP BREAKDOWN ---\n" +
         (agg.lapBreakdown.length
           ? agg.lapBreakdown
-              .map((r) => `lap ${r.lapId}: ${r.lapTimeSec.toFixed(3)}s — ${r.reason}${r.imported ? " (imported)" : ""}`)
+              .map((r) => {
+                const policyReasons = r.reasonCodes.length > 0 ? ` [policy: ${r.reasonCodes.join(", ")}]` : "";
+                return `lap ${r.lapId}: ${r.lapTimeSec.toFixed(3)}s — ${r.reason}${policyReasons}${r.imported ? " (imported)" : ""}`;
+              })
               .join("\n")
           : "No laps recorded for this session yet."),
     );
@@ -145,8 +146,7 @@ const gatherPrereqs = createStep({
     );
 
     sections.push(
-      `--- SYMPTOMS (aggregate over ${consistency.cleanLapCount} clean laps) ---\n` +
-        (agg.symptoms ? formatSymptoms(agg.symptoms) : "No analysable lap yet — reason from the driver's description."),
+      `--- SYMPTOMS (aggregate over ${consistency.cleanLapCount} clean laps) ---\n` + (agg.symptoms ? formatSymptoms(agg.symptoms) : "No analysable lap yet — reason from the driver's description."),
     );
 
     // Raw driving observations over the same clean pool. Deliberately separate
@@ -155,14 +155,9 @@ const gatherPrereqs = createStep({
     // no knowledge of which experiment is running. Cached per lap in
     // `lap_metrics`, so a week-long experiment does not re-decode every .bin.
     const metricsByLap = await getOrComputeLapMetricsBatch(agg.lapIds);
-    sections.push(
-      `--- DRIVING OBSERVATIONS (raw measurements) ---\n${formatLapObservations([...metricsByLap.values()])}`,
-    );
+    sections.push(`--- DRIVING OBSERVATIONS (raw measurements) ---\n${formatLapObservations([...metricsByLap.values()])}`);
 
-    sections.push(
-      "--- TRACK CONDITIONS ---\n" +
-        (agg.trackConditions ? formatTrackConditions(agg.trackConditions) : "No conditions data for this session yet."),
-    );
+    sections.push("--- TRACK CONDITIONS ---\n" + (agg.trackConditions ? formatTrackConditions(agg.trackConditions) : "No conditions data for this session yet."));
 
     // What's already been tried this session, so the model doesn't repeat it.
     // This is the one test-scoped block: the experiment frame (what was expected
@@ -181,11 +176,7 @@ const gatherPrereqs = createStep({
                   t.verdict ? `driver's verdict: ${t.verdict}` : null,
                   t.notes ? `note: ${t.notes}` : null,
                 ].filter((s): s is string => s != null);
-                return (
-                  `v${t.version} "${t.label}"${t.kind === "drill" ? " (driving drill)" : ""}` +
-                  `${t.engine ? ` (${t.engine})` : ""}` +
-                  (frame.length ? ` — ${frame.join("; ")}` : "")
-                );
+                return `v${t.version} "${t.label}"${t.kind === "drill" ? " (driving drill)" : ""}` + `${t.engine ? ` (${t.engine})` : ""}` + (frame.length ? ` — ${frame.join("; ")}` : "");
               })
               .join("\n")
           : "none yet"),
@@ -199,6 +190,5 @@ export const setupEngineerTurnWorkflow = createWorkflow({
   id: "setup-engineer-turn",
   inputSchema: InputSchema,
   outputSchema: OutputSchema,
-})
-  .then(gatherPrereqs);
+}).then(gatherPrereqs);
 setupEngineerTurnWorkflow.commit();

--- a/server/ai/README.md
+++ b/server/ai/README.md
@@ -7,13 +7,15 @@ Collect all AI-facing logic: deterministic telemetry symptom extraction, prompt 
 - Deterministic symptom layer: `tune-symptoms.ts`, `tune-tire-symptoms.ts`, `tune-damper-symptoms.ts`, `tune-weight-transfer.ts`.
 - Auto-tune pipeline: `tune-intent.ts`, `tune-recommend.ts`, `tune-writer.ts`.
 - AI provider/response path: `providers.ts`, `schemas.ts`, `google-provider-options.ts`.
-- Prompt formatting and coaching entry points: `tune-*` prompt files, `chat-prompt.ts`, `compare-chat-prompt.ts`, `analyst-prompt.ts`, `inputs-compare-prompt.ts`.
+- Prompt formatting and coaching entry points: `tune-*` prompt files, `chat-prompt.ts`, `compare-chat-prompt.ts`, `analyst-prompt.ts`, and `inputs-compare-prompt.ts`.
+  `quality-context.ts` renders exact eligibility status, reasons, and generation identity for analyst, lap-chat, comparison-chat, and inputs-comparison prompts.
 - Chat persistence/state: `chat-agent.ts`.
 - Track knowledge bridge: `track-guides.ts`.
 
 ## Boundaries and invariants
 - Public contracts kept stable unless proven unused across repository.
 - Deterministic symptom builders return `null` when required channels are unavailable instead of throwing.
+- Quality context is evidence, not a second policy engine. Prompts and Mastra tools must not reinterpret unknown or ineligible laps as usable evidence, and cached analysis stays tied to quality generation and policy identity.
 - Provider calls are side-effect isolated; formatting/parsing functions own schema expectations.
 - `writeSetupFile` enforces setup-path confinement before writing.
 - `chat-agent` owns thread-id conventions and generation ordering.

--- a/server/ai/analyst-prompt.ts
+++ b/server/ai/analyst-prompt.ts
@@ -1,7 +1,9 @@
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { Tune } from "../../shared/racing/tuning/types";
 import type { GameId } from "../../shared/games/ids";
-import { generateExport, type UnitSystem, type TemperatureUnit } from "../lap-analysis/report"
+import { generateExport, type UnitSystem, type TemperatureUnit } from "../lap-analysis/report";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import { buildQualityPromptContext } from "./quality-context";
 import { resolveCarName } from "../../shared/racing/cars/resolve-name";
 import { fmCarSpecsCatalog } from "../../shared/racing/cars/fm";
 import { resolveTrackName } from "../../shared/racing/tracks/resolve-name";
@@ -143,6 +145,9 @@ export function buildAnalystPrompt(
     carOrdinal?: number;
     trackOrdinal?: number;
     gameId?: GameId;
+    quality?: LapQualitySummary | null;
+    eligibility?: EligibilityDecisionSet | null;
+    qualityGeneration?: string | null;
   },
   packets: TelemetryPacket[],
   corners: CornerDef[],
@@ -161,13 +166,11 @@ export function buildAnalystPrompt(
   const trackName = resolveTrackName(lap.trackOrdinal ?? 0, lap.gameId);
 
   // F1 uses adapter-specific compact context; generic export is Forza-specific.
-  const exportText = lap.gameId === "f1-2025"
-    ? ""
-    : generateExport(lap, packets, unit, temperatureUnit);
+  const exportText = lap.gameId === "f1-2025" ? "" : generateExport(lap, packets, unit, temperatureUnit);
   const cornerData = buildCornerData(packets, corners, unit === "metric" ? "kmh" : "mph");
 
   // Run precomputed insight analysis
-  const insights = analyzeLap(packets, lap.gameId ?? packets[0]?.gameId);
+  const insights = analyzeLap(packets, lap.gameId ?? packets[0]?.gameId, lap.quality);
   let insightsText = "";
   if (insights.length > 0) {
     insightsText = "\n--- Precomputed Insights (unverified — validate against raw data) ---\n";
@@ -240,12 +243,7 @@ export function buildAnalystPrompt(
       const covers = inSector(index);
       sectorsText += `S${n}: ${t.toFixed(3)}s${covers ? ` — covers ${covers}` : ""}\n`;
     }
-    const boundaries = sectorStarts
-      .slice(1)
-      .map(
-        (start, index) =>
-          `S${index + 1} ends at ${(start * 100).toFixed(1)}%`,
-      );
+    const boundaries = sectorStarts.slice(1).map((start, index) => `S${index + 1} ends at ${(start * 100).toFixed(1)}%`);
     sectorsText += `Boundaries: ${boundaries.join(", ")} of the lap.\n`;
   }
 
@@ -282,9 +280,11 @@ export function buildAnalystPrompt(
   const conditionsText = conditions
     ? `\n--- Track Conditions ---\n${formatTrackConditions(conditions)}\nWeigh these before blaming pace on the driver or setup — a cold, green, or wet surface costs grip everywhere.\n`
     : "";
+  const qualityContext = buildQualityPromptContext(lap, ["official-timing", "normal-pace", "corner-trace", "transient-event", "fuel-burn", "tire-analysis"]);
 
   const context = `${carDetailsText}
 Track: ${trackName}
+${qualityContext}
 ${conditionsText}${tuneText}${segmentsList}${sectorsText}${cornerGuardrail}${trackGuide}
 ${exportText}
 ${cornerData}

--- a/server/ai/chat-prompt.ts
+++ b/server/ai/chat-prompt.ts
@@ -3,10 +3,12 @@
  * Includes the same telemetry context as the analysis prompt,
  * plus the original analysis as reference.
  */
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
+import { buildQualityPromptContext } from "./quality-context";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import type { Tune } from "../../shared/racing/tuning/types";
 import type { GameId } from "../../shared/games/ids";
-import { generateExport, type UnitSystem, type TemperatureUnit } from "../lap-analysis/report"
+import { generateExport, type UnitSystem, type TemperatureUnit } from "../lap-analysis/report";
 import { resolveCarName } from "../../shared/racing/cars/resolve-name";
 import { resolveTrackName } from "../../shared/racing/tracks/resolve-name";
 import { buildCornerData } from "./corner-data";
@@ -43,6 +45,9 @@ export function buildChatSystemPrompt(
     carOrdinal?: number;
     trackOrdinal?: number;
     gameId?: GameId;
+    quality?: LapQualitySummary | null;
+    eligibility?: EligibilityDecisionSet | null;
+    qualityGeneration?: string | null;
   },
   packets: TelemetryPacket[],
   corners: CornerDef[],
@@ -65,7 +70,7 @@ export function buildChatSystemPrompt(
   const cornerData = buildCornerData(packets, corners, unit === "metric" ? "kmh" : "mph");
 
   // Precomputed insights
-  const insights = analyzeLap(packets, lap.gameId ?? packets[0]?.gameId);
+  const insights = analyzeLap(packets, lap.gameId ?? packets[0]?.gameId, lap.quality);
   let insightsText = "";
   if (insights.length > 0) {
     insightsText = "\n--- Precomputed Insights ---\n";
@@ -111,7 +116,6 @@ export function buildChatSystemPrompt(
     }
   }
 
-
   // Game-specific extended context
   let extendedContext = "";
   if (serverAdapter?.buildAiContext && packets.length > 0) {
@@ -120,6 +124,7 @@ export function buildChatSystemPrompt(
 
   // Game-specific system prompt override (use chat version, not analysis JSON version)
   const gameSystemNote = serverAdapter?.aiSystemPrompt ? `\nGame-specific notes: This is ${serverAdapter.aiSystemPrompt.split("\n")[0]}\n` : "";
+  const qualityContext = buildQualityPromptContext(lap, ["corner-trace", "transient-event", "fuel-burn", "tire-analysis"]);
 
   return `${chatSystemPrompt(unit, temperatureUnit, language)}
 ${gameSystemNote}
@@ -135,6 +140,7 @@ ${formatLapChatIdentity(lap)}
 Car: ${carName}
 Track: ${trackName}
 Lap #${lap.lapNumber} — ${lap.lapTime.toFixed(3)}s${lap.isValid ? "" : " (INVALID)"}
+${qualityContext}
 ${tuneText}${analysisContext}
 --- TELEMETRY DATA ---
 ${exportText}

--- a/server/ai/consult-lap-analyst.ts
+++ b/server/ai/consult-lap-analyst.ts
@@ -5,7 +5,7 @@
  * The Setup Engineer reasons about *setup*; the Lap Analyst reasons about
  * *driving and telemetry*. When the driver asks something that needs the latter
  * ("why am I slow in the last sector?"), the engineer calls this to get a real
- * analysis of the session's representative lap instead of guessing.
+ * analysis of the policy-selected lap instead of guessing.
  *
  * Mirrors the invocation the `/api/laps/:id/analyse` route uses (corners,
  * track context, prompt, and the provider secret→env bridge for the Lap
@@ -14,7 +14,7 @@
  */
 import type { GameId } from "../../shared/games/ids";
 import { getCorners } from "../db/track-queries";
-import { detectCorners } from "../lap-analysis/corners"
+import { detectCorners } from "../lap-analysis/corners";
 import { getSecret } from "../runtime/platform/keystore";
 import { loadSettings } from "../runtime/config/settings";
 import { buildAnalystPrompt } from "./analyst-prompt";
@@ -24,16 +24,26 @@ import { resolveTrack } from "../tracks/info";
 // has no such back-edge. We lose the dev-only observability wrapper here, which
 // the setup-engineer consult doesn't need.
 import { lapAnalystAgent } from "../../mastra/agents/lap-analyst";
-import { loadRepresentativeLap } from "../experiments/representative-lap";
+import { loadRepresentativeLapSelection } from "../experiments/representative-lap";
 
 interface LapAnalystConsult {
   available: boolean;
   summary: string;
+  eligibilityStatus: "eligible" | "eligible_with_warning" | "ineligible" | "unknown";
+  reasonCodes: string[];
 }
 
 export async function consultLapAnalystForSession(sessionId: number): Promise<LapAnalystConsult> {
-  const lap = await loadRepresentativeLap(sessionId);
-  if (!lap) return { available: false, summary: "No analysable lap yet for this session." };
+  const selection = await loadRepresentativeLapSelection(sessionId);
+  const { lap } = selection;
+  if (!lap) {
+    return {
+      available: false,
+      summary: "No policy-suitable analysable lap yet for this session.",
+      eligibilityStatus: selection.setupDecision.status,
+      reasonCodes: selection.reasonCodes,
+    };
+  }
 
   const trackOrdinal = lap.trackOrdinal ?? 0;
   let corners = trackOrdinal > 0 && lap.gameId ? await getCorners(trackOrdinal, lap.gameId as GameId) : [];
@@ -41,31 +51,33 @@ export async function consultLapAnalystForSession(sessionId: number): Promise<La
 
   const settings = loadSettings();
   const segments = resolveTrack(lap.gameId, lap.trackOrdinal).segments;
-  const prompt = buildAnalystPrompt(
-    lap,
-    lap.telemetry,
-    corners,
-    settings.unit,
-    settings.temperatureUnit,
-    undefined,
-    segments,
-    undefined,
-    settings.language,
-  );
+  const prompt = buildAnalystPrompt(lap, lap.telemetry, corners, settings.unit, settings.temperatureUnit, undefined, segments, undefined, settings.language);
 
   // Bridge the Lap Analyst's provider secret → env. It reads `aiProvider`
   // (default gemini), independent of the setup-engineer chat provider.
   const provider = settings.aiProvider;
   if (provider === "openai") {
     const key = await getSecret("openai-api-key");
-    if (!key) return { available: false, summary: "Lap Analyst unavailable — OpenAI API key not set (Settings → AI Analysis)." };
+    if (!key)
+      return {
+        available: false,
+        summary: "Lap Analyst unavailable — OpenAI API key not set (Settings → AI Analysis).",
+        eligibilityStatus: selection.setupDecision.status,
+        reasonCodes: selection.reasonCodes,
+      };
     process.env.OPENAI_API_KEY = key;
   } else if (provider === "local") {
     process.env.OPENAI_API_KEY = process.env.OPENAI_API_KEY || "local";
     process.env.OPENAI_BASE_URL = settings.localEndpoint || "http://localhost:1234/v1";
   } else {
     const key = await getSecret("gemini-api-key");
-    if (!key) return { available: false, summary: "Lap Analyst unavailable — Gemini API key not set (Settings → AI Analysis)." };
+    if (!key)
+      return {
+        available: false,
+        summary: "Lap Analyst unavailable — Gemini API key not set (Settings → AI Analysis).",
+        eligibilityStatus: selection.setupDecision.status,
+        reasonCodes: selection.reasonCodes,
+      };
     process.env.GOOGLE_GENERATIVE_AI_API_KEY = key;
   }
 
@@ -76,5 +88,10 @@ export async function consultLapAnalystForSession(sessionId: number): Promise<La
     modelSettings: { maxOutputTokens: 4096, temperature: 0 },
   });
   const text = typeof result.text === "string" ? result.text.trim() : "";
-  return { available: true, summary: text || "Lap Analyst returned no content." };
+  return {
+    available: true,
+    summary: text || "Lap Analyst returned no content.",
+    eligibilityStatus: selection.setupDecision.status,
+    reasonCodes: selection.reasonCodes,
+  };
 }

--- a/server/ai/tune-chat-prompt.ts
+++ b/server/ai/tune-chat-prompt.ts
@@ -4,8 +4,8 @@
  * A setup-scoped conversation the driver has *before* asking for the next tune:
  * the AI is a race engineer discussing THIS car+track setup. It reasons over
  *   - the current setup values (summarised, not a raw JSON dump),
- *   - the deterministic symptom report (telemetryToSymptoms) for the stint's
- *     representative lap, and
+ *   - the deterministic symptom report (telemetryToSymptoms) for the
+ *     policy-selected setup evidence, and
  *   - the applied-change history across the session's setup versions.
  *
  * Hard rule (parity §4d): the deterministic engine owns the maths. The chat
@@ -46,8 +46,8 @@ interface TuneChatPromptInput {
   session: TuneChatSession;
   /** Setup versions under evaluation, oldest-first (v1 base → latest). */
   tests: TuneChatTest[];
-  /** Deterministic symptom report over the representative lap; null when the
-   *  session has no analysable lap yet (legacy/empty telemetry). */
+  /** Deterministic symptom report over policy-selected setup evidence; null
+   *  when the session has no suitable analysable telemetry. */
   symptoms: TuneSymptoms | null;
   /** Human-readable summary of the active setup's values; null when no setup
    *  file could be read. */
@@ -107,11 +107,7 @@ export function formatSymptoms(symptoms: TuneSymptoms): string {
     .map((c) => {
       const phases = c.phases
         .map((p) => {
-          const flags = [
-            p.balance !== "neutral" ? p.balance : null,
-            p.brakeLockup ? "brake lockup" : null,
-            p.bottoming ? "bottoming" : null,
-          ].filter(Boolean);
+          const flags = [p.balance !== "neutral" ? p.balance : null, p.brakeLockup ? "brake lockup" : null, p.bottoming ? "bottoming" : null].filter(Boolean);
           return `${p.phase}: ${flags.length ? flags.join("/") : "neutral"}`;
         })
         .join("; ");
@@ -173,8 +169,8 @@ export function buildTuneChatSystemPrompt(input: TuneChatPromptInput): string {
     : "--- CURRENT SETUP VALUES ---\n(no setup file available for the active version)";
 
   const symptomBlock = symptoms
-    ? `--- SYMPTOM REPORT (deterministic, from the stint's representative lap) ---\n${formatSymptoms(symptoms)}`
-    : "--- SYMPTOM REPORT ---\n(no analysable lap yet — discuss the setup from the driver's feel and the current values above)";
+    ? `--- SYMPTOM REPORT (deterministic, from policy-selected setup evidence) ---\n${formatSymptoms(symptoms)}`
+    : "--- SYMPTOM REPORT ---\n(no policy-suitable analysable evidence yet — discuss the setup from the driver's feel and the current values above)";
 
   return `You are a sharp, decisive GT3 / endurance race engineer working the setup for ${car}${track} in ${gameId.toUpperCase()} (session "${session.name}"). The driver talks to you between runs about how the car feels and what to change.
 

--- a/server/experiments/README.md
+++ b/server/experiments/README.md
@@ -14,7 +14,7 @@ Own tuning-experiment state, setup lineage, reversible actions, lap evidence, an
 
 ## Boundaries and invariants
 
-- Lap eligibility, outlier handling, reference-lap choice, sample ordering, minimum frame count, and frame-budget drops are explicit parts of comparison evidence. Never trim or reorder them silently.
+- Shared `normal-pace`, `corner-trace`, and group `setup-analysis` decisions determine policy eligibility before `selectEvaluationLaps` applies review ordering and caps. Policy rejection, manual exclusion, outlier handling, and fastest-lap caps remain separate and must never be silently reordered.
 - Frame metrics hold one reference lap and one candidate lap at a time. Both comparison arms use the same fence policy and are streamed sequentially.
 - Significance describes distinguishability from noise, not a tuning verdict. Persisted verdicts remain human decisions.
 - Setup lineage walks through drill nodes to the nearest setup-bearing ancestor and guards cycles. F1 setup state is JSON snapshot data; ACC and AC EVO normally use guarded setup files.

--- a/server/experiments/auto-exclude.ts
+++ b/server/experiments/auto-exclude.ts
@@ -1,5 +1,6 @@
-import { fastestLaps, REVIEW_LAP_CAP } from "../../shared/racing/laps/review-selection";
-import { isPitCycleLap } from "../../shared/racing/laps/pit-cycle";
+import { REVIEW_LAP_CAP, selectEvaluationLaps } from "../../shared/racing/laps/review-selection";
+import type { LapCondition, LapPhase, PaceEligibility } from "../../shared/racing/laps/classification";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
 
 /**
  * Tuning auto-exclude: fastest-5 lap curation
@@ -15,9 +16,14 @@ export interface ExclusionScopeLap {
   id: number;
   lapTime: number;
   isValid: boolean;
+  phase: LapPhase;
+  conditions: LapCondition[];
+  paceEligibility: PaceEligibility;
   invalidReason: string | null;
   experimentExcluded: boolean;
   experimentExcludedSource: "auto" | "manual" | null;
+  quality: LapQualitySummary | null;
+  eligibility: EligibilityDecisionSet | null;
 }
 
 /** Minimal DB surface `reconcileAutoExclusions` needs. */
@@ -45,40 +51,23 @@ function targetState(lap: ExclusionScopeLap, excluded: boolean): boolean {
  *
  *   1. Manual laps (`source = 'manual'`) are never read for ranking purposes
  *      and never written — they don't occupy a fastest-5 slot.
- *   2. Invalid or pit-cycle laps are ineligible — always `(1, 'auto')`.
- *   3. Remaining candidates are ranked via `fastestLaps()` — the same
- *      fastest-N definition the review path uses. Keepers → `(NULL, 'auto')`,
- *      the rest → `(1, 'auto')`.
+ *   2. Remaining laps route through `selectEvaluationLaps`, which consumes
+ *      persisted policy decisions and the shared setup-analysis group policy.
+ *   3. Selected fastest-N laps become `(NULL, 'auto')`; all other auto-owned
+ *      laps become `(1, 'auto')`.
  *   4. Only rows whose state pair actually changed are written.
  */
-export async function reconcileAutoExclusions(
-  db: LapExclusionWriter,
-  experimentId: number,
-  tuneId: number,
-): Promise<void> {
+export async function reconcileAutoExclusions(db: LapExclusionWriter, experimentId: number, tuneId: number): Promise<void> {
   const scopeLaps = await db.getLapsForExclusionScope(experimentId, tuneId);
 
-  const candidates: ExclusionScopeLap[] = [];
-  const ineligible: ExclusionScopeLap[] = [];
+  const autoOwned = scopeLaps.filter((lap) => lap.experimentExcludedSource !== "manual");
+  const selection = selectEvaluationLaps(autoOwned, REVIEW_LAP_CAP);
 
-  for (const lap of scopeLaps) {
-    if (lap.experimentExcludedSource === "manual") continue; // never read, never written
-    if (!lap.isValid || isPitCycleLap({ invalidReason: lap.invalidReason ?? undefined })) {
-      ineligible.push(lap);
-    } else {
-      candidates.push(lap);
+  for (const lap of autoOwned) {
+    const shouldExclude = !selection.chosenIds.has(lap.id);
+    if (!targetState(lap, shouldExclude)) {
+      await db.setLapAutoExclusion(lap.id, shouldExclude);
     }
-  }
-
-  const keepers = new Set(fastestLaps(candidates, REVIEW_LAP_CAP).map((l) => l.id));
-
-  for (const lap of ineligible) {
-    if (!targetState(lap, true)) await db.setLapAutoExclusion(lap.id, true);
-  }
-
-  for (const lap of candidates) {
-    const shouldExclude = !keepers.has(lap.id);
-    if (!targetState(lap, shouldExclude)) await db.setLapAutoExclusion(lap.id, shouldExclude);
   }
 }
 
@@ -88,10 +77,7 @@ export async function reconcileAutoExclusions(
  * skipping entirely when either is null (lap recorded outside a tuning
  * session, or with no tune assigned) — see the design doc's "Trigger" section.
  */
-export async function reconcileAutoExclusionsForLap(
-  db: LapExclusionWriter & LapExperimentScopeReader,
-  lapId: number,
-): Promise<void> {
+export async function reconcileAutoExclusionsForLap(db: LapExclusionWriter & LapExperimentScopeReader, lapId: number): Promise<void> {
   const { experimentId, tuneId } = await db.getLapExperimentScope(lapId);
   if (experimentId == null || tuneId == null) return;
   await reconcileAutoExclusions(db, experimentId, tuneId);

--- a/server/experiments/comparison/metrics.ts
+++ b/server/experiments/comparison/metrics.ts
@@ -54,6 +54,7 @@
  */
 
 import type { TelemetryPacket } from "../../../shared/telemetry/types";
+import type { EligibilityPolicyId } from "../../../shared/racing/quality/contracts";
 import { type EvaluableLap, type EvaluationReason, REVIEW_LAP_CAP, selectEvaluationLaps } from "../../../shared/racing/laps/review-selection";
 import type { Corner } from "../../lap-analysis/corners";
 import { computeLapConsistencyDelta, LINE_SPREAD_FULL_SCALE_M } from "../../lap-analysis/consistency";
@@ -76,6 +77,9 @@ export type OutcomeMetricId = (typeof OUTCOME_METRIC_IDS)[number];
 
 /** Input channel an `inputVariance*` metric measures. */
 type InputChannel = "brake" | "throttle";
+const TIMING_ELIGIBILITY_POLICY_IDS = ["normal-pace"] as const satisfies readonly EligibilityPolicyId[];
+const TRACE_ELIGIBILITY_POLICY_IDS = ["normal-pace", "corner-trace"] as const satisfies readonly EligibilityPolicyId[];
+
 
 /**
  * How an arm's raw lap pool is reduced to the laps a metric is computed over.
@@ -95,6 +99,8 @@ type InputChannel = "brake" | "throttle";
  *   distribution.
  */
 export interface CurationSpec {
+  /** Per-lap evidence policies this metric needs; unrelated channels cannot shrink its sample. */
+  requiredPolicyIds: readonly EligibilityPolicyId[];
   mode: "fastest-n" | "all-valid";
   /** Only meaningful for `fastest-n`. */
   n?: number;
@@ -198,7 +204,10 @@ export function curateLaps<T extends EvaluableLap>(
   opts?: { fence?: number | null },
 ): CuratedPool<T> {
   const cap = curation.mode === "fastest-n" ? (curation.n ?? REVIEW_LAP_CAP) : Number.POSITIVE_INFINITY;
-  const selection = selectEvaluationLaps(laps, cap);
+  const selection = selectEvaluationLaps(laps, cap, {
+    requireSetupEligibility: false,
+    requiredPolicyIds: curation.requiredPolicyIds,
+  });
 
   const reasonById = new Map<number, CurationReason>(selection.reasonById);
   let kept = selection.chosen;
@@ -449,7 +458,7 @@ const lapTimeSec: MetadataOutcomeMetric = {
   label: "Lap time",
   unit: "s",
   direction: "lower-better",
-  curation: { mode: "all-valid", outlierRule: "blunder-fence" },
+  curation: { mode: "all-valid", outlierRule: "blunder-fence", requiredPolicyIds: TIMING_ELIGIBILITY_POLICY_IDS },
   sampling: "metadata",
   extract: (input) => input.laps.map((e) => ({ lapId: e.lap.id, value: e.lap.lapTime })),
 };
@@ -476,7 +485,7 @@ const consistencySpreadSec: MetadataOutcomeMetric = {
   label: "Lap-time deviation",
   unit: "s",
   direction: "lower-better",
-  curation: { mode: "all-valid", outlierRule: "blunder-fence" },
+  curation: { mode: "all-valid", outlierRule: "blunder-fence", requiredPolicyIds: TIMING_ELIGIBILITY_POLICY_IDS },
   sampling: "metadata",
   extract: (input) => {
     const times = input.laps.map((e) => e.lap.lapTime).sort((a, b) => a - b);
@@ -492,7 +501,7 @@ function inputVarianceMetric(channel: InputChannel): PairwiseFramesOutcomeMetric
     label: channel === "brake" ? "Brake input variance" : "Throttle input variance",
     unit: "",
     direction: "lower-better",
-    curation: { mode: "all-valid", outlierRule: "blunder-fence" },
+    curation: { mode: "all-valid", outlierRule: "blunder-fence", requiredPolicyIds: TRACE_ELIGIBILITY_POLICY_IDS },
     sampling: "pairwise-frames",
     reduce: (input) => {
       const d = pairwiseDelta(input);
@@ -512,7 +521,7 @@ const lineSpreadScore: PairwiseFramesOutcomeMetric = {
   label: "Line consistency",
   unit: "/100",
   direction: "higher-better",
-  curation: { mode: "all-valid", outlierRule: "blunder-fence" },
+  curation: { mode: "all-valid", outlierRule: "blunder-fence", requiredPolicyIds: TRACE_ELIGIBILITY_POLICY_IDS },
   sampling: "pairwise-frames",
   reduce: (input) => {
     const spread = pairwiseDelta(input).overall.lateralSpreadM;

--- a/server/experiments/lap-evidence/aggregate.ts
+++ b/server/experiments/lap-evidence/aggregate.ts
@@ -21,6 +21,8 @@
  * single-lap one.
  */
 import type { LapMeta } from "../../../shared/racing/sessions/types";
+import type { EligibilityDecision, QualityReasonCode } from "../../../shared/racing/quality/contracts";
+import { selectEvaluationLaps } from "../../../shared/racing/laps/review-selection";
 import type { TelemetryPacket } from "../../../shared/telemetry/types";
 import type { Corner } from "../../lap-analysis/corners";
 import { detectCorners } from "../../lap-analysis/corners";
@@ -59,7 +61,9 @@ export interface LapBreakdownRow {
   lapId: number;
   lapTimeSec: number;
   valid: boolean;
-  reason: "clean" | "invalid" | "user-excluded" | "auto-outlier";
+  reason: "clean" | "invalid" | "non-pace" | "user-excluded" | "auto-outlier";
+  /** Exact policy reasons; empty for manual, structural, and statistical drops. */
+  reasonCodes: QualityReasonCode[];
   imported: boolean;
 }
 
@@ -70,6 +74,8 @@ export interface CleanLapAggregate {
   trackConditions: TrackConditions | null;
   consistency: ConsistencyReport;
   fallbackSingleLap: boolean;
+  /** Shared policy-owned decision for the selected setup evidence pool. */
+  setupDecision: EligibilityDecision;
   sourceScope: "branch" | "session-baseline";
   /** Laps stamped to the active head test (any cleanliness), or null when no
    *  active head test exists. 0 + "session-baseline" means the current setup
@@ -84,21 +90,15 @@ export interface CleanLapAggregate {
  * back to the session baseline pool while an active head test exists with zero
  * laps of its own — i.e. the laps shown are NOT this setup version's laps.
  */
-export function baselineFallbackNote(
-  agg: Pick<CleanLapAggregate, "sourceScope" | "headOwnLapCount">,
-): string | null {
+export function baselineFallbackNote(agg: Pick<CleanLapAggregate, "sourceScope" | "headOwnLapCount">): string | null {
   if (agg.sourceScope !== "session-baseline" || agg.headOwnLapCount !== 0) return null;
-  return (
-    "NOTE: no laps recorded on this setup version yet — laps below are the session baseline " +
-    "(earlier versions). Drive laps on this version before judging changes."
-  );
+  return "NOTE: no laps recorded on this setup version yet — laps below are the session baseline " + "(earlier versions). Drive laps on this version before judging changes.";
 }
 
 // Cap on how many clean laps feed the symptom aggregate — beyond this the
 // marginal value per lap is low and the per-lap telemetry fetch cost isn't
 // worth it.
 const MAX_CLEAN_LAPS = 8;
-
 
 function median(values: number[]): number | null {
   if (values.length === 0) return null;
@@ -109,7 +109,7 @@ function median(values: number[]): number | null {
  * Split a session/branch's laps into a clean candidate pool and the dropped
  * ones, with a full per-lap breakdown of why. Pure — no DB.
  *
- * Candidacy: isValid && lapTime > 0. Among candidates, user-excluded laps are
+ * Candidacy: valid pace lap with lapTime > 0. User-excluded candidates are
  * dropped, then a blunder rule (median + 1.5*IQR, floored at best*1.02) drops
  * statistical outliers. Everything else survives as "clean".
  */
@@ -117,31 +117,53 @@ export function selectCleanLaps(laps: LapMeta[]): {
   clean: LapMeta[];
   dropped: LapMeta[];
   breakdown: LapBreakdownRow[];
+  setupDecision: EligibilityDecision;
 } {
+  const selection = selectEvaluationLaps(laps, Number.POSITIVE_INFINITY);
   const candidates: LapMeta[] = [];
   const breakdown: LapBreakdownRow[] = [];
 
   for (const lap of laps) {
     const imported = lap.experimentVersionId == null;
-    if (!(lap.isValid === true && lap.lapTime > 0)) {
-      breakdown.push({ lapId: lap.id, lapTimeSec: lap.lapTime, valid: lap.isValid, reason: "invalid", imported });
+    const selectionReason = selection.reasonById.get(lap.id);
+    if (selectionReason === "manual") {
+      breakdown.push({
+        lapId: lap.id,
+        lapTimeSec: lap.lapTime,
+        valid: lap.isValid,
+        reason: "user-excluded",
+        reasonCodes: [],
+        imported,
+      });
+      continue;
+    }
+    if (selectionReason === "invalid") {
+      breakdown.push({
+        lapId: lap.id,
+        lapTimeSec: lap.lapTime,
+        valid: lap.isValid,
+        reason: "invalid",
+        reasonCodes: [],
+        imported,
+      });
+      continue;
+    }
+    if (!selection.chosenIds.has(lap.id)) {
+      breakdown.push({
+        lapId: lap.id,
+        lapTimeSec: lap.lapTime,
+        valid: lap.isValid,
+        reason: "non-pace",
+        reasonCodes: [...(selection.reasonCodesById.get(lap.id) ?? [])],
+        imported,
+      });
       continue;
     }
     candidates.push(lap);
   }
 
-  const notExcluded: LapMeta[] = [];
-  for (const lap of candidates) {
-    const imported = lap.experimentVersionId == null;
-    if (lap.experimentExcluded === true) {
-      breakdown.push({ lapId: lap.id, lapTimeSec: lap.lapTime, valid: lap.isValid, reason: "user-excluded", imported });
-      continue;
-    }
-    notExcluded.push(lap);
-  }
-
   // Blunder rule over the surviving candidates' lap times.
-  const times = notExcluded.map((l) => l.lapTime).sort((a, b) => a - b);
+  const times = candidates.map((lap) => lap.lapTime).sort((a, b) => a - b);
   const best = times.length > 0 ? times[0] : 0;
   const q1 = percentile(times, 0.25);
   const q3 = percentile(times, 0.75);
@@ -151,18 +173,32 @@ export function selectCleanLaps(laps: LapMeta[]): {
 
   const clean: LapMeta[] = [];
   const dropped: LapMeta[] = [];
-  for (const lap of notExcluded) {
+  for (const lap of candidates) {
     const imported = lap.experimentVersionId == null;
     if (times.length > 1 && lap.lapTime > threshold) {
-      breakdown.push({ lapId: lap.id, lapTimeSec: lap.lapTime, valid: lap.isValid, reason: "auto-outlier", imported });
+      breakdown.push({
+        lapId: lap.id,
+        lapTimeSec: lap.lapTime,
+        valid: lap.isValid,
+        reason: "auto-outlier",
+        reasonCodes: [],
+        imported,
+      });
       dropped.push(lap);
       continue;
     }
-    breakdown.push({ lapId: lap.id, lapTimeSec: lap.lapTime, valid: lap.isValid, reason: "clean", imported });
+    breakdown.push({
+      lapId: lap.id,
+      lapTimeSec: lap.lapTime,
+      valid: lap.isValid,
+      reason: "clean",
+      reasonCodes: [],
+      imported,
+    });
     clean.push(lap);
   }
 
-  return { clean, dropped, breakdown };
+  return { clean, dropped, breakdown, setupDecision: selection.setupDecision };
 }
 
 /**
@@ -170,12 +206,7 @@ export function selectCleanLaps(laps: LapMeta[]): {
  * a coarse confidence band on raw lap-time repeatability (not track-scaled;
  * that's what `consistencyRating` in lap-analysis/stats.ts is for elsewhere).
  */
-export function computeConsistency(
-  cleanLaps: LapMeta[],
-  cornerConsistency: CornerConsistency[] | null,
-  droppedOutliers: number,
-  lineSpread: LineSpreadTrace | null = null,
-): ConsistencyReport {
+export function computeConsistency(cleanLaps: LapMeta[], cornerConsistency: CornerConsistency[] | null, droppedOutliers: number, lineSpread: LineSpreadTrace | null = null): ConsistencyReport {
   const times = cleanLaps.map((l) => l.lapTime);
   const cleanLapCount = times.length;
   const bestLapSec = cleanLapCount > 0 ? Math.min(...times) : null;
@@ -294,6 +325,7 @@ async function representativeLapFallback(
   sourceScope: CleanLapAggregate["sourceScope"],
   headOwnLapCount: number | null,
   lapBreakdown: LapBreakdownRow[],
+  setupDecision: EligibilityDecision,
 ): Promise<CleanLapAggregate> {
   const lap = await loadRepresentativeLap(sessionId);
   if (!lap) {
@@ -304,6 +336,7 @@ async function representativeLapFallback(
       trackConditions: null,
       consistency: emptyConsistency("very-low"),
       fallbackSingleLap: true,
+      setupDecision,
       sourceScope,
       headOwnLapCount,
       lapBreakdown,
@@ -318,6 +351,7 @@ async function representativeLapFallback(
     trackConditions: telemetryToTrackConditions(lap.telemetry),
     consistency: emptyConsistency("very-low"),
     fallbackSingleLap: true,
+    setupDecision,
     sourceScope,
     headOwnLapCount,
     lapBreakdown,
@@ -331,10 +365,7 @@ async function representativeLapFallback(
  * session baseline pool. Falls back further to the single-representative-lap
  * path when even the baseline pool has fewer than 2 clean laps.
  */
-export async function loadCleanLapAggregate(
-  sessionId: number,
-  opts?: { versionId?: number },
-): Promise<CleanLapAggregate> {
+export async function loadCleanLapAggregate(sessionId: number, opts?: { versionId?: number }): Promise<CleanLapAggregate> {
   const headVersionId = opts?.versionId ?? (await resolveActiveTestId(sessionId));
 
   let pool: LapMeta[] = [];
@@ -355,11 +386,11 @@ export async function loadCleanLapAggregate(
     pool = await getLapsForExperiment(sessionId);
   }
 
-  const { clean, breakdown } = selectCleanLaps(pool);
+  const { clean, breakdown, setupDecision } = selectCleanLaps(pool);
   const droppedOutliers = breakdown.filter((r) => r.reason === "auto-outlier").length;
 
   if (clean.length < 2) {
-    return representativeLapFallback(sessionId, sourceScope, headOwnLapCount, breakdown);
+    return representativeLapFallback(sessionId, sourceScope, headOwnLapCount, breakdown, setupDecision);
   }
 
   // Fastest-first, capped.
@@ -376,7 +407,7 @@ export async function loadCleanLapAggregate(
   if (loadedLaps.length < 2) {
     // Telemetry too thin to analyse as a pool — fall back to the single
     // representative lap rather than aggregating over <2 laps.
-    return representativeLapFallback(sessionId, sourceScope, headOwnLapCount, breakdown);
+    return representativeLapFallback(sessionId, sourceScope, headOwnLapCount, breakdown, setupDecision);
   }
 
   const fastestLoaded = loadedLaps.find((l) => l.meta.id === fastestMeta.id) ?? loadedLaps[0]!;
@@ -393,7 +424,10 @@ export async function loadCleanLapAggregate(
   const symptoms = aggregateSymptoms(perLapSymptoms);
   const trackConditions = telemetryToTrackConditions(fastestLoaded.telemetry);
 
-  const cornerConsistencyDelta = computeLapConsistencyDelta(loadedLaps.map((l) => l.telemetry), corners);
+  const cornerConsistencyDelta = computeLapConsistencyDelta(
+    loadedLaps.map((l) => l.telemetry),
+    corners,
+  );
   const cornerConsistency = cornerConsistencyDelta.perCorner.length > 0 ? cornerConsistencyDelta.perCorner : null;
   const lineSpread = computeLineSpreadTrace(
     loadedLaps.map((l) => l.telemetry),
@@ -421,6 +455,7 @@ export async function loadCleanLapAggregate(
     trackConditions,
     consistency,
     fallbackSingleLap: false,
+    setupDecision,
     sourceScope,
     headOwnLapCount,
     lapBreakdown: breakdown,

--- a/server/experiments/representative-lap.ts
+++ b/server/experiments/representative-lap.ts
@@ -1,51 +1,42 @@
 /** Representative lap and derived setup-engineer context for an experiment. */
 import type { LapMeta } from "../../shared/racing/sessions/types";
+import type { EligibilityDecision, QualityReasonCode } from "../../shared/racing/quality/contracts";
+import { selectEvaluationLaps } from "../../shared/racing/laps/review-selection";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
-import { detectCorners } from "../lap-analysis/corners";
 import { getLapById } from "../db/lap-read-queries";
 import { getLapsForExperiment } from "../db/experiment-lap-queries";
-import { telemetryToSymptoms, type TuneSymptoms } from "../ai/tune-symptoms";
-import { telemetryToTrackConditions, type TrackConditions } from "../ai/track-conditions";
 import { MIN_TELEMETRY_FRAMES } from "./lap-policy";
 
 export type RepresentativeLap = LapMeta & {
   telemetry: TelemetryPacket[];
   parseError?: string;
 };
+export interface RepresentativeLapSelection {
+  lap: RepresentativeLap | null;
+  setupDecision: EligibilityDecision;
+  reasonCodes: QualityReasonCode[];
+}
 
 /**
- * The session's representative lap — the fastest valid lap it owns, with enough
- * telemetry to analyse (≥30 frames). Single source of truth so symptom and
- * track-condition reads always describe the same lap. Returns null when no such
- * lap exists yet.
+ * Load the representative lap together with the exact setup-analysis policy
+ * result that selected or rejected it. This keeps machine-readable reasons
+ * available to AI/tool consumers instead of collapsing rejection to `null`.
  */
-export async function loadRepresentativeLap(
-  experimentId: number,
-): Promise<RepresentativeLap | null> {
+export async function loadRepresentativeLapSelection(experimentId: number): Promise<RepresentativeLapSelection> {
   const sessionLaps = await getLapsForExperiment(experimentId);
-  let best: (typeof sessionLaps)[number] | null = null;
-  for (const lap of sessionLaps) {
-    if (!lap.isValid || lap.lapTime <= 0) continue;
-    if (best == null || lap.lapTime < best.lapTime) best = lap;
-  }
-  if (!best) return null;
+  const selection = selectEvaluationLaps(sessionLaps, Number.POSITIVE_INFINITY);
+  const reasonCodes = selection.setupDecision.reasons.map((reason) => reason.code);
+  const best = selection.chosen[0];
+  if (!best) return { lap: null, setupDecision: selection.setupDecision, reasonCodes };
 
   const lap = await getLapById(best.id);
-  if (!lap || lap.telemetry.length < MIN_TELEMETRY_FRAMES) return null;
-  return lap;
+  if (!lap || lap.telemetry.length < MIN_TELEMETRY_FRAMES) {
+    return { lap: null, setupDecision: selection.setupDecision, reasonCodes };
+  }
+  return { lap, setupDecision: selection.setupDecision, reasonCodes };
 }
 
-/** Deterministic symptom report for the experiment's representative lap. */
-export async function computeSessionSymptoms(experimentId: number): Promise<TuneSymptoms | null> {
-  const lap = await loadRepresentativeLap(experimentId);
-  if (!lap) return null;
-  const corners = detectCorners(lap.telemetry);
-  return telemetryToSymptoms(lap.telemetry, corners);
-}
-
-/** Deterministic weather/track-surface context for the representative lap. */
-export async function computeSessionTrackConditions(experimentId: number): Promise<TrackConditions | null> {
-  const lap = await loadRepresentativeLap(experimentId);
-  if (!lap) return null;
-  return telemetryToTrackConditions(lap.telemetry);
+/** Fastest policy-selected lap, or null when evidence is unavailable. */
+export async function loadRepresentativeLap(experimentId: number): Promise<RepresentativeLap | null> {
+  return (await loadRepresentativeLapSelection(experimentId)).lap;
 }

--- a/server/lap-analysis/README.md
+++ b/server/lap-analysis/README.md
@@ -8,14 +8,17 @@ Transforms completed-lap telemetry into deterministic comparison traces, corner 
 
 - `comparison.ts`, `corners.ts`, and `sectors.ts` align laps and derive distance-based structure.
 - `metrics.ts` and `stats.ts` own pure packet metrics and shared numerical primitives; `metrics-store.ts` owns their database cache.
-- `quality.ts` applies recording-validity checks.
+- `quality-generation.ts` finalizes reproducible source/output identities; `quality-rebuild.ts` chooses eligibility-only rebuild or raw reprocessing.
+- `canonical-archive-availability.ts` reports canonical inventory support, which is currently unavailable; `evidence-retention.ts` evaluates whether raw removal would preserve required policy evidence.
 - `recap.ts` builds session recap data.
 - `consistency.ts` measures racing-line and input repeatability.
 - `report.ts` renders the stable text export used by analysis prompts and lap downloads.
 
 ## Boundaries and invariants
 
-Telemetry units, game steering conventions, native sector layouts, and curated track geometry enter from existing shared/game and track APIs. Persistence remains isolated in `metrics-store.ts`; other modules are deterministic apart from the metrics timestamp. Preserve threshold strictness, lap and corner ordering, sector authority and fallback precedence, interpolation rules, rounding precision, and report text exactly when changing calculations. Cached metric shape changes require an algorithm-version bump.
+Telemetry units, game steering conventions, native sector layouts, and curated track geometry enter from existing shared/game and track APIs. `metrics-store.ts` owns metric-cache persistence; quality rebuild, canonical-archive availability, and retention are explicit database/filesystem-backed status modules. Remaining computational modules are deterministic apart from the metrics timestamp. Preserve threshold strictness, lap and corner ordering, sector authority and fallback precedence, interpolation rules, rounding precision, and report text exactly when changing calculations. Cached metric shape changes require an algorithm-version bump.
+
+Packet-derived facts may be recomputed from retained evidence. A stale detector, quality schema, or measurement configuration requires raw reprocessing; only a stale eligibility policy can rebuild decisions from stored quality facts. Persist every result with the applicable version and generation identity so cached analysis remains reproducible.
 
 ## Testing
 

--- a/server/lap-analysis/report.ts
+++ b/server/lap-analysis/report.ts
@@ -1,3 +1,4 @@
+import { lapClassificationLabel, type ClassifiedLap } from "../../shared/racing/laps/classification";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 import { tryGetGame } from "../../shared/games/registry";
 
@@ -20,7 +21,7 @@ function convertTemp(value: number, unit: "F" | "C", source: "F" | "C" = "F"): n
  * Generate a Claude-formatted lap export summary.
  */
 export function generateExport(
-  lap: {
+  lap: ClassifiedLap & {
     lapNumber: number;
     lapTime: number;
     isValid: boolean;
@@ -138,7 +139,7 @@ export function generateExport(
 
   let output = `=== RaceIQ Lap Export ===
 Car: #${first.CarOrdinal} | Class: ${className} (PI ${first.CarPerformanceIndex}) | Drivetrain: ${drivetrainName}
-Track: #${lap.trackOrdinal ?? 0} | Lap: ${lap.lapNumber} | Time: ${lapTimeStr} | Valid: ${lap.isValid ? "Yes" : "No"}
+Track: #${lap.trackOrdinal ?? 0} | Lap: ${lap.lapNumber} | Time: ${lapTimeStr} | Valid: ${lap.isValid ? "Yes" : "No"} | Classification: ${lapClassificationLabel(lap)}
 
 --- Performance Summary ---
 Speed (${speedLabel}):    min=${minSpeed.toFixed(1)}  avg=${avgSpeed.toFixed(1)}  max=${maxSpeed.toFixed(1)}

--- a/server/routes/README.md
+++ b/server/routes/README.md
@@ -9,12 +9,13 @@
 ## Structure
 
 - Top-level route files expose cross-cutting resources such as settings, drivers, sessions, chats, cars, tunes, and cache status.
-- `laps/` handles lap resources, transfer, analysis, chat, and comparison.
+- `laps/` handles lap resources, transfer, analysis, chat, comparison, per-lap quality, and eligibility-aware trace access.
 - `tracks/` handles track catalog, geometry, outlines, segments, sectors, corners, and leaderboards.
 - `tunes/` handles tune CRUD, setup-file workflows, and automatic setup resources; `experiments/` handles tuning-session lifecycle and comparisons.
 - `games/` exposes game-specific setup and source endpoints.
 - `system/` exposes diagnostics, storage, networking, updates, extraction, and telemetry history.
 - `dev/` exposes recording and import tools and is mounted only when `IS_DEV` is true.
+- Session routes expose quality status and evidence-retention assessment. `GET /api/sessions/:id/evidence-retention` reports whether retained evidence supports raw removal. `GET /api/sessions/:id/quality` reports rebuild state, while `POST /api/sessions/:id/quality/rebuild` rebuilds decisions or reprocesses retained raw evidence and returns `409` when source evidence is unavailable. Missing sessions return `404`; operational failures remain server errors. Bulk stale processing clears stale health only after every session reaches a current state.
 
 Subdirectories with an `index.ts` use it as their composition point. Shared helpers stay beside the routes that use them (`support.ts`, `tune-shared.ts`, or `recording-support.ts`).
 
@@ -23,6 +24,7 @@ Subdirectories with an `index.ts` use it as their composition point. Shared help
 - Keep route paths, methods, status codes, and response shapes stable unless the API contract intentionally changes.
 - Preserve router registration order. Static routes must remain ahead of overlapping parameter routes, and middleware must remain ahead of handlers it governs.
 - Validate transport input at the route boundary, then delegate database, telemetry, game-policy, and analysis behavior to their owning domains.
+- Blocked comparison, trace, and AI routes return shared eligibility decisions and exact reasons. Routes delegate policy evaluation and rebuild mechanics rather than interpreting quality locally.
 - Preserve each endpoint's established game-context source (validated query, header, or path parameter); these are not interchangeable.
 - Development routes must remain unreachable in production.
 - Route helpers may normalize transport-facing data, but must not change persisted formats or game-specific meaning.

--- a/server/routes/chats-routes.ts
+++ b/server/routes/chats-routes.ts
@@ -10,6 +10,7 @@ import {
   getChatMemory,
   CHAT_RESOURCE_ID,
   parseThreadGeneration,
+  parseCompareChatThreadId,
   listThreadGenerations,
   truncateChatAfterUserMessage,
   deleteChatLineage,
@@ -97,11 +98,9 @@ export function createChatsRoutes(
               updatedAt: t.updatedAt instanceof Date ? t.updatedAt.toISOString() : String(t.updatedAt),
             });
           } else if (id.startsWith("compare-")) {
-            const parts = id.slice(8).split("-");
-            if (parts.length !== 2) continue;
-            const a = Number(parts[0]);
-            const b = Number(parts[1]);
-            if (!Number.isFinite(a) || !Number.isFinite(b)) continue;
+            const pair = parseCompareChatThreadId(id);
+            if (!pair) continue;
+            const [a, b] = pair;
             const [lapA, lapB] = await Promise.all([loadLapSummary(a), loadLapSummary(b)]);
             if (!lapA || !lapB) continue;
             if (lapA.gameId !== gameId || lapB.gameId !== gameId) continue;

--- a/server/routes/experiments/lifecycle-routes.ts
+++ b/server/routes/experiments/lifecycle-routes.ts
@@ -10,6 +10,7 @@ import { getLapsForExperiment } from "../../db/experiment-lap-queries";
 import { recordAction } from "../../db/experiment-action-queries";
 import { getTrackLengthMeters } from "../../../shared/racing/tracks/recording/outlines";
 import { suggestLapTarget } from "../../../shared/racing/experiments/stint-target";
+import { isTimedLapEligibilityUsable } from "../../../shared/racing/quality/policies";
 import { ExperimentFocusSchema } from "../../../shared/racing/experiments/focus";
 
 const ExperimentQuerySchema = z.object({
@@ -159,7 +160,7 @@ export const experimentDetailRoutes = new Hono()
 
       const sessionLaps = await getLapsForExperiment(id);
       const bestLap = sessionLaps.reduce<number | null>((best, l) => {
-        if (!l.isValid || l.lapTime <= 0) return best;
+        if (!isTimedLapEligibilityUsable(l)) return best;
         return best == null || l.lapTime < best ? l.lapTime : best;
       }, null);
       const trackLengthM = row.trackOrdinal != null ? getTrackLengthMeters(row.trackOrdinal, row.gameId) : null;

--- a/server/routes/laps/analysis-routes.ts
+++ b/server/routes/laps/analysis-routes.ts
@@ -2,6 +2,7 @@ import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 
 import { IdParamSchema } from "@shared/platform/http/route-schemas";
+import type { EligibilityDecision } from "@shared/racing/quality/contracts";
 import { deleteAnalysis } from "../../db/analysis-queries";
 import { generateLapAnalysis } from "../../ai/generate-lap-analysis";
 import { toClientAiError } from "../../ai/provider-error";
@@ -11,6 +12,9 @@ import {
   getAnalysisRun,
 } from "../../ai/analysis-run-registry";
 import { AnalyseQuerySchema } from "./support";
+
+const analysisErrorStatus = (error: string, decision: EligibilityDecision | undefined): 400 | 404 | 422 =>
+  error === "Lap not found" ? 404 : decision?.status === "ineligible" || decision?.status === "unknown" ? 422 : 400;
 
 const analysisRunKey = (lapId: number) => `lap-analysis:${lapId}`;
 
@@ -39,8 +43,8 @@ export const analysisRoutes = new Hono()
       if (!regenerate || cacheOnly) {
         const cached = await generateLapAnalysis(id, { cacheOnly: true });
         if (cached.error) {
-          const status: 404 | 400 = cached.error === "Lap not found" ? 404 : 400;
-          return c.json({ error: cached.error }, status);
+          const status = analysisErrorStatus(cached.error, cached.decision);
+          return c.json({ error: cached.error, decision: cached.decision }, status);
         }
         if (cacheOnly || cached.cached) return c.json(cached);
       }
@@ -54,8 +58,8 @@ export const analysisRoutes = new Hono()
         preflight: true,
       });
       if (preflight.error) {
-        const status: 404 | 400 = preflight.error === "Lap not found" ? 404 : 400;
-        return c.json({ error: preflight.error }, status);
+        const status = analysisErrorStatus(preflight.error, preflight.decision);
+        return c.json({ error: preflight.error, decision: preflight.decision }, status);
       }
 
       const key = analysisRunKey(id);

--- a/server/routes/laps/chat-routes.ts
+++ b/server/routes/laps/chat-routes.ts
@@ -4,6 +4,8 @@ import { Hono } from "hono";
 
 import { IdParamSchema } from "@shared/platform/http/route-schemas";
 import type { Tune } from "../../../shared/racing/tuning/types";
+import { eligibilityDecisionText } from "../../../shared/racing/quality/display";
+import { isEligibilityUsable, resolveEligibilityDecision } from "../../../shared/racing/quality/policies";
 import { getLapById } from "../../db/lap-read-queries";
 import { deleteAnalysis as deleteAnalysisQuery, getAnalysis } from "../../db/analysis-queries";
 import { getCorners } from "../../db/track-queries";
@@ -14,14 +16,7 @@ import { buildChatSystemPrompt } from "../../ai/chat-prompt";
 import { buildGoogleReasoningProviderOptions } from "../../ai/google-provider-options";
 import { streamAgentTurnResponse } from "../../ai/agent-stream";
 import { lapChatAgent } from "../../ai/agents";
-import {
-  CHAT_RESOURCE_ID,
-  chatThreadId,
-  generationThreadId,
-  getChatMemory,
-  listThreadGenerations,
-  resolveActiveThread,
-} from "../../ai/chat-agent";
+import { CHAT_RESOURCE_ID, chatThreadId, generationThreadId, getChatMemory, listThreadGenerations, resolveActiveThread } from "../../ai/chat-agent";
 import { getSecret } from "../../runtime/platform/keystore";
 import { ChatBodySchema } from "./support";
 import { parseTuneRow } from "../tune-shared";
@@ -33,9 +28,7 @@ export const chatRoutes = new Hono()
       const memory = getChatMemory();
       const base = chatThreadId(id);
       const genParam = Number(c.req.query("gen"));
-      const threadId = Number.isInteger(genParam) && genParam >= 1
-        ? generationThreadId(base, genParam)
-        : await resolveActiveThread(base);
+      const threadId = Number.isInteger(genParam) && genParam >= 1 ? generationThreadId(base, genParam) : await resolveActiveThread(base);
       const thread = await memory.getThreadById({ threadId });
       if (!thread) return c.json({ messages: [] });
       const result = await memory.recall({ threadId });
@@ -43,9 +36,7 @@ export const chatRoutes = new Hono()
 
       const list = new MessageList({ threadId, resourceId: CHAT_RESOURCE_ID });
       list.add(raw, "memory");
-      const uiMessages = list.get.all.aiV5
-        .ui()
-        .filter((m) => m.role === "user" || m.role === "assistant");
+      const uiMessages = list.get.all.aiV5.ui().filter((m) => m.role === "user" || m.role === "assistant");
 
       return c.json({ messages: uiMessages });
     } catch (err: any) {
@@ -60,6 +51,10 @@ export const chatRoutes = new Hono()
 
     const lap = await getLapById(id);
     if (!lap) return c.json({ error: "Lap not found" }, 404);
+    const decision = resolveEligibilityDecision(lap, "corner-trace");
+    if (!isEligibilityUsable(decision)) {
+      return c.json({ error: eligibilityDecisionText(decision), decision }, 422);
+    }
     if (lap.telemetry.length === 0) return c.json({ error: "No telemetry data" }, 400);
 
     const settings = loadSettings();
@@ -111,26 +106,18 @@ export const chatRoutes = new Hono()
       process.env.OPENAI_BASE_URL = settings.localEndpoint || "http://localhost:1234/v1";
     }
 
-    const chatModelLabel = settings.chatModel
-      || (chatProvider === "openai"
-        ? "gpt-4o-mini"
-        : chatProvider === "local"
-          ? "local-model"
-          : "gemini-flash-latest");
+    const chatModelLabel = settings.chatModel || (chatProvider === "openai" ? "gpt-4o-mini" : chatProvider === "local" ? "local-model" : "gemini-flash-latest");
 
     const threadId = await resolveActiveThread(chatThreadId(id));
     const turnStartedAt = Date.now();
     try {
-      const stream = await lapChatAgent.stream(
-        [{ role: "system", content: systemPrompt }, ...messages],
-        {
-          memory: { thread: threadId, resource: CHAT_RESOURCE_ID },
-          providerOptions: {
-            openai: { reasoningEffort: "medium" },
-            google: buildGoogleReasoningProviderOptions(chatModelLabel, settings.chatThinkingBudget) as never,
-          },
+      const stream = await lapChatAgent.stream([{ role: "system", content: systemPrompt }, ...messages], {
+        memory: { thread: threadId, resource: CHAT_RESOURCE_ID },
+        providerOptions: {
+          openai: { reasoningEffort: "medium" },
+          google: buildGoogleReasoningProviderOptions(chatModelLabel, settings.chatThinkingBudget) as never,
         },
-      );
+      });
 
       return streamAgentTurnResponse({
         agentStream: stream,

--- a/server/routes/laps/resource-routes.ts
+++ b/server/routes/laps/resource-routes.ts
@@ -3,6 +3,8 @@ import { Hono } from "hono";
 import { gzip } from "node:zlib";
 import { promisify } from "node:util";
 import { z } from "zod";
+import { eligibilityDecisionText } from "../../../shared/racing/quality/display";
+import { isEligibilityUsable, resolveEligibilityDecision } from "../../../shared/racing/quality/policies";
 
 import { IdParamSchema } from "@shared/platform/http/route-schemas";
 import { GameIdSchema, type GameId } from "../../../shared/games/ids";
@@ -16,7 +18,6 @@ import { getLaps, getLapById, getLapsByIds, getLapsRaw } from "../../db/lap-read
 import { deleteLap, updateLapNotes, updateLapValidity } from "../../db/lap-mutation-queries";
 import { setLapExperimentExcluded } from "../../db/experiment-lap-queries";
 import { recordAction } from "../../db/experiment-action-queries";
-import { assessLapRecording } from "../../lap-analysis/quality";
 import { computeNativeSectorTimeline, computeLapSectors } from "../../lap-analysis/sectors";
 import { generateExport } from "../../lap-analysis/report";
 import { resolveTrack } from "../../tracks/info";
@@ -71,6 +72,10 @@ export const resourceRoutes = new Hono()
     try {
       const lap = await getLapById(id);
       if (!lap || lap.gameId !== gameIdResult.data) return c.json({ error: "Lap not found" }, 404);
+      const decision = resolveEligibilityDecision(lap, "corner-trace");
+      if (!isEligibilityUsable(decision)) {
+        return c.json({ error: eligibilityDecisionText(decision), decision }, 422);
+      }
       const replay = await queryLapTelemetryBySemanticId(id, semanticReplayIds());
       if (!replay) return c.json({ error: "Lap not found" }, 404);
       const nativeLayout = getGame(lap.gameId).getNativeSectorLayout?.(lap.telemetry[0]);
@@ -79,7 +84,10 @@ export const resourceRoutes = new Hono()
         requestedSemanticIds: replay.requestedSemanticIds,
         sectorTimes: lap.sectorTimes ?? null,
         sectorStarts: nativeLayout?.starts ?? null,
-        insights: analyzeLap(lap.telemetry, lap.gameId),
+        insights: analyzeLap(lap.telemetry, lap.gameId, lap.quality),
+        decision,
+        qualityGeneration: lap.qualityGeneration ?? null,
+        channelQuality: lap.quality?.channelQuality ?? [],
         envelopes: replay.envelopes.map((envelope) => ({
           sequence: Number(envelope.sequence),
           observedAt: { domain: "wall-clock", milliseconds: timestampMilliseconds(envelope.observedAt) },
@@ -108,12 +116,28 @@ export const resourceRoutes = new Hono()
 
     const laps = await getLapsByIds(ids);
     const traces: EncodedLapTrace[] = [];
+    const decisions = [];
     for (const lap of laps) {
-      if (lap.telemetry.length === 0) continue;
+      const decision = resolveEligibilityDecision(lap, "corner-trace");
+      decisions.push({ lapId: lap.id, decision });
+      if (!isEligibilityUsable(decision) || lap.telemetry.length === 0) continue;
       const trace = downsampleLap(lap.id, lap.lapNumber, lap.isValid, lap.telemetry, null);
       if (trace) traces.push(encodeLapTrace(trace));
     }
-    return c.json({ traces });
+    return c.json({ traces, decisions });
+  })
+  .get("/api/laps/:id/quality", zValidator("param", IdParamSchema), async (c) => {
+    const { id } = c.req.valid("param");
+    const lap = await getLapById(id);
+    if (!lap) return c.json({ error: "Lap not found" }, 404);
+    return c.json({
+      lapId: lap.id,
+      sessionId: lap.sessionId,
+      quality: lap.quality,
+      eligibility: lap.eligibility,
+      qualityGeneration: lap.qualityGeneration,
+      source: lap.source,
+    });
   })
 
   .get("/api/laps/:id", zValidator("param", IdParamSchema), async (c) => {
@@ -145,11 +169,7 @@ export const resourceRoutes = new Hono()
       const lapDist = lastDist - firstDist;
 
       if (game.nativeSectors && game.getNativeSectorLayout) {
-        const nativeTimeline = computeNativeSectorTimeline(
-          packets,
-          lap.lapTime,
-          game.getNativeSectorLayout,
-        );
+        const nativeTimeline = computeNativeSectorTimeline(packets, lap.lapTime, game.getNativeSectorLayout);
         if (nativeTimeline && lapDist > 0) {
           sectorTimes = {
             ...nativeTimeline,
@@ -198,7 +218,7 @@ export const resourceRoutes = new Hono()
 
     // Precomputed lap insights — server-side so the client gets them in the
     // initial fetch instead of re-deriving on every render
-    const insights = analyzeLap(packets, gameId);
+    const insights = analyzeLap(packets, gameId, lap.quality);
 
     return c.json({ ...lap, sectorTimes, insights });
   })
@@ -246,52 +266,51 @@ export const resourceRoutes = new Hono()
     return c.json({ ok: true });
   })
 
-  .post(
-    "/api/laps/:id/experiment-excluded",
-    zValidator("param", IdParamSchema),
-    zValidator("json", z.object({ excluded: z.boolean() })),
-    async (c) => {
-      const { id } = c.req.valid("param");
-      const { excluded } = c.req.valid("json");
-      const { ok, prev, experimentId } = await setLapExperimentExcluded(id, excluded);
-      if (!ok) return c.json({ error: "Lap not found" }, 404);
+  .post("/api/laps/:id/experiment-excluded", zValidator("param", IdParamSchema), zValidator("json", z.object({ excluded: z.boolean() })), async (c) => {
+    const { id } = c.req.valid("param");
+    const { excluded } = c.req.valid("json");
+    const { ok, prev, experimentId } = await setLapExperimentExcluded(id, excluded);
+    if (!ok) return c.json({ error: "Lap not found" }, 404);
 
-      // Best-effort: an action-log write failure must not fail the request —
-      // the lap flag is already committed. Only log when the lap is linked
-      // to a tuning session (laps outside a tuning session have nothing to undo into).
-      if (experimentId != null) {
-        try {
-          await recordAction(experimentId, "set-lap-excluded", { lapId: id, prevExcluded: prev });
-        } catch (err: any) {
-          console.error("[LapRoutes] Failed to log set-lap-excluded action:", err?.message);
-        }
+    // Best-effort: an action-log write failure must not fail the request —
+    // the lap flag is already committed. Only log when the lap is linked
+    // to a tuning session (laps outside a tuning session have nothing to undo into).
+    if (experimentId != null) {
+      try {
+        await recordAction(experimentId, "set-lap-excluded", { lapId: id, prevExcluded: prev });
+      } catch (err: any) {
+        console.error("[LapRoutes] Failed to log set-lap-excluded action:", err?.message);
       }
+    }
 
-      return c.json({ ok: true, lapId: id, excluded });
-    },
-  )
+    return c.json({ ok: true, lapId: id, excluded });
+  })
 
   .post("/api/laps/:id/recheck", zValidator("param", IdParamSchema), async (c) => {
     const { id } = c.req.valid("param");
     const lap = await getLapById(id);
     if (!lap) return c.json({ error: "Lap not found" }, 404);
 
-    const quality = assessLapRecording(lap.telemetry, lap.lapTime);
+    // Recording fidelity is separate from simulator validity. This legacy
+    // endpoint may refresh derived sectors, but never rewrites validity from
+    // packet gaps or capture completeness.
 
     // Recompute sector times
     const packets = lap.telemetry;
     let sectors: number[] | null = null;
     if (packets.length >= 50 && lap.gameId && lap.trackOrdinal != null) {
-      sectors = await computeLapSectors(
-        lap.trackOrdinal,
-        lap.gameId as GameId,
-        packets,
-        lap.lapTime,
-      );
+      sectors = await computeLapSectors(lap.trackOrdinal, lap.gameId as GameId, packets, lap.lapTime);
     }
 
-    await updateLapValidity(id, quality.valid, quality.valid ? null : quality.reason, sectors);
-    return c.json({ id, valid: quality.valid, reason: quality.reason, sectors });
+    await updateLapValidity(id, lap.isValid, lap.invalidReason ?? null, sectors);
+    return c.json({
+      id,
+      valid: lap.isValid,
+      reason: lap.invalidReason,
+      sectors,
+      quality: lap.quality,
+      eligibility: lap.eligibility,
+    });
   })
 
   .delete("/api/laps/:id", zValidator("param", IdParamSchema), async (c) => {

--- a/server/routes/session-routes.ts
+++ b/server/routes/session-routes.ts
@@ -1,9 +1,12 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
+import { eq } from "drizzle-orm";
 import { GameIdQuerySchema, IdParamSchema } from "@shared/platform/http/route-schemas";
 import { GameIdSchema } from "../../shared/games/ids";
 import { getSessions, deleteSession, updateSession, countStaleSessions, getStaleSessions, getSessionRecapData } from "../db/session-queries";
+import { db } from "../db";
+import { sessions } from "../db/schema";
 import { getSessionResult, getStaleRaceResultSessionIds } from "../db/session-result-queries";
 import { reprocessSession, SessionNotFoundError, SessionRawFileMissingError } from "../session-capture/reprocess";
 import { LAP_DETECTOR_ID } from "../lap-detection/detector";
@@ -17,10 +20,52 @@ import { resolveCarName } from "../../shared/racing/cars/resolve-name";
 import { resolveTrackName } from "../../shared/racing/tracks/resolve-name";
 import { backfillRaceResults, reconcileSessionResult, RACE_RESULT_PROCESSOR_ID } from "../race-results/reconcile";
 import { getRaceResultAggregate, getRecentRaceResults } from "../race-results/aggregates";
+import { getQualityRebuildStatus, rebuildSessionEligibility } from "../lap-analysis/quality-rebuild";
+import { assessEvidenceRetention } from "../lap-analysis/evidence-retention";
+import { getSessionCanonicalAvailability } from "../lap-analysis/canonical-archive-availability";
+import { getLapsForSession } from "../db/lap-reprocessing-queries";
 
 const ALL_DETECTOR_IDS = [LAP_DETECTOR_ID, LAP_DETECTOR_ACC_ID, LAP_DETECTOR_AC_EVO_ID, LAP_DETECTOR_IRACING_ID];
 
-export const sessionRoutes = new Hono()
+export interface SessionRouteDependencies {
+  sessionExists: (sessionId: number) => Promise<boolean>;
+  getQualityRebuildStatus: typeof getQualityRebuildStatus;
+  getLapsForSession: typeof getLapsForSession;
+  reprocessSession: typeof reprocessSession;
+  rebuildSessionEligibility: typeof rebuildSessionEligibility;
+  getStaleSessions: typeof getStaleSessions;
+  countStaleSessions: typeof countStaleSessions;
+  broadcastNotification: (payload: Record<string, unknown>) => void;
+  setStaleSessionsNotification: (payload: Record<string, unknown> | null) => void;
+}
+
+const DEFAULT_SESSION_ROUTE_DEPENDENCIES: SessionRouteDependencies = {
+  sessionExists: async (sessionId) => {
+    const session = await db.select({ id: sessions.id }).from(sessions).where(eq(sessions.id, sessionId)).get();
+    return session != null;
+  },
+  getQualityRebuildStatus,
+  getLapsForSession,
+  reprocessSession,
+  rebuildSessionEligibility,
+  getStaleSessions,
+  countStaleSessions,
+  broadcastNotification: (payload) => wsManager.broadcastNotification(payload),
+  setStaleSessionsNotification: (payload) => wsManager.setStaleSessionsNotification(payload),
+};
+
+function staleSessionsNotification(sessionCount: number): Record<string, unknown> {
+  return {
+    type: "stale-lap-detection",
+    sessionCount,
+    currentVersion: ALL_DETECTOR_IDS.join(","),
+  };
+}
+
+export function createSessionRoutes(overrides: Partial<SessionRouteDependencies> = {}) {
+  const dependencies = { ...DEFAULT_SESSION_ROUTE_DEPENDENCIES, ...overrides };
+
+  return new Hono()
   .get("/api/sessions", zValidator("query", GameIdQuerySchema), async (c) => {
     const { gameId } = c.req.valid("query");
     return c.json(await getSessions(gameId));
@@ -34,7 +79,18 @@ export const sessionRoutes = new Hono()
     const adapter = tryGetGame(gameId);
     const carName = adapter ? adapter.getCarName(data.session.carOrdinal) : resolveCarName(data.session.carOrdinal, gameId);
     const trackName = adapter ? adapter.getTrackName(data.session.trackOrdinal) : resolveTrackName(data.session.trackOrdinal, gameId);
-    return c.json(computeRecap({ session: data.session, laps: data.laps, carName, trackName, trackLengthM: data.trackLengthM, allTimeBestSec: data.allTimeBestSec, allTimeBestSectors: data.allTimeBestSectors, sectorStarts: data.sectorStarts }));
+    return c.json(
+      computeRecap({
+        session: data.session,
+        laps: data.laps,
+        carName,
+        trackName,
+        trackLengthM: data.trackLengthM,
+        allTimeBestSec: data.allTimeBestSec,
+        allTimeBestSectors: data.allTimeBestSectors,
+        sectorStarts: data.sectorStarts,
+      }),
+    );
   })
   .get("/api/sessions/:id/result", zValidator("param", IdParamSchema), zValidator("query", GameIdQuerySchema), async (c) => {
     const { id } = c.req.valid("param");
@@ -44,7 +100,11 @@ export const sessionRoutes = new Hono()
     if (!result) return c.json({ error: "Session result unavailable", outcomeStatus: "unavailable" as const }, 404);
     return c.json(result);
   })
-  .post("/api/race-results/backfill", zValidator("json", z.object({ gameId: GameIdSchema, limit: z.number().int().min(1).max(100).default(25), afterSessionId: z.number().int().optional() })), async (c) => c.json(await backfillRaceResults(c.req.valid("json"))))
+  .post(
+    "/api/race-results/backfill",
+    zValidator("json", z.object({ gameId: GameIdSchema, limit: z.number().int().min(1).max(100).default(25), afterSessionId: z.number().int().optional() })),
+    async (c) => c.json(await backfillRaceResults(c.req.valid("json"))),
+  )
   .post("/api/race-results/reconcile-stale", async (c) => {
     const staleIds = await getStaleRaceResultSessionIds(RACE_RESULT_PROCESSOR_ID);
     const total = staleIds.length;
@@ -68,8 +128,61 @@ export const sessionRoutes = new Hono()
     if (!failed) wsManager.setStaleRaceResultsNotification(null);
     return c.json({ reprocessed: results.filter((result) => result.status !== "error").length, results });
   })
-  .get("/api/race-results/summary", zValidator("query", z.object({ gameId: GameIdSchema, carOrdinal: z.coerce.number().int().optional(), trackOrdinal: z.coerce.number().int().optional() })), async (c) => c.json(await getRaceResultAggregate(c.req.valid("query"))))
-  .get("/api/race-results/recent", zValidator("query", z.object({ gameId: GameIdSchema, limit: z.coerce.number().int().min(1).max(50).default(10) })), async (c) => c.json(await getRecentRaceResults(c.req.valid("query").gameId, c.req.valid("query").limit)))
+  .get(
+    "/api/race-results/summary",
+    zValidator("query", z.object({ gameId: GameIdSchema, carOrdinal: z.coerce.number().int().optional(), trackOrdinal: z.coerce.number().int().optional() })),
+    async (c) => c.json(await getRaceResultAggregate(c.req.valid("query"))),
+  )
+  .get("/api/race-results/recent", zValidator("query", z.object({ gameId: GameIdSchema, limit: z.coerce.number().int().min(1).max(50).default(10) })), async (c) =>
+    c.json(await getRecentRaceResults(c.req.valid("query").gameId, c.req.valid("query").limit)),
+  )
+  .get("/api/sessions/:id/evidence-retention", zValidator("param", IdParamSchema), async (c) => {
+    const { id } = c.req.valid("param");
+    const canonicalArchive = await getSessionCanonicalAvailability(id);
+    if (!canonicalArchive) return c.json({ error: "Session not found" }, 404);
+
+    const status = await getQualityRebuildStatus(id, ALL_DETECTOR_IDS);
+    return c.json(
+      await assessEvidenceRetention(id, {
+        rawCapture: status.rawAvailable,
+        canonicalArchive,
+      }),
+    );
+  })
+  .get("/api/sessions/:id/quality", zValidator("param", IdParamSchema), async (c) => {
+    const { id } = c.req.valid("param");
+    if (!(await dependencies.sessionExists(id))) return c.json({ error: "Session not found" }, 404);
+
+    const status = await dependencies.getQualityRebuildStatus(id, ALL_DETECTOR_IDS);
+    const laps = await dependencies.getLapsForSession(id);
+    return c.json({
+      ...status,
+      laps: laps.map((lap) => ({
+        id: lap.id,
+        lapNumber: lap.lapNumber,
+        quality: lap.quality,
+        eligibility: lap.eligibility,
+        qualityGeneration: lap.qualityGeneration,
+      })),
+    });
+  })
+  .post("/api/sessions/:id/quality/rebuild", zValidator("param", IdParamSchema), async (c) => {
+    const { id } = c.req.valid("param");
+    if (!(await dependencies.sessionExists(id))) return c.json({ error: "Session not found" }, 404);
+
+    const status = await dependencies.getQualityRebuildStatus(id, ALL_DETECTOR_IDS);
+    if (status.action === "unavailable") {
+      return c.json({ error: "Source recording unavailable", status }, 409);
+    }
+    if (status.action === "reprocess") {
+      const result = await dependencies.reprocessSession(id);
+      dependencies.broadcastNotification({ type: "quality-updated", sessionId: id });
+      return c.json({ strategy: "reprocess" as const, status: await dependencies.getQualityRebuildStatus(id, ALL_DETECTOR_IDS), result });
+    }
+    const rebuilt = await dependencies.rebuildSessionEligibility(id);
+    dependencies.broadcastNotification({ type: "quality-updated", sessionId: id });
+    return c.json({ strategy: status.action === "current" ? ("none" as const) : ("eligibility" as const), status: rebuilt });
+  })
   .patch("/api/sessions/:id/notes", zValidator("param", IdParamSchema), zValidator("json", z.object({ notes: z.string().nullable() })), async (c) => {
     const { id } = c.req.valid("param");
     await updateSession(id, { notes: c.req.valid("json").notes });
@@ -94,22 +207,46 @@ export const sessionRoutes = new Hono()
     }
   })
   .post("/api/sessions/reprocess-stale", async (c) => {
-    const staleIds = await getStaleSessions(ALL_DETECTOR_IDS);
+    const staleIds = await dependencies.getStaleSessions(ALL_DETECTOR_IDS);
     const results = [];
     const skipped: { sessionId: number; reason: "raw-file-missing" }[] = [];
     for (const id of staleIds) {
       try {
-        const result = await reprocessSession(id);
-        wsManager.broadcastNotification({ type: "lap-reprocessed", ...result });
-        results.push(result);
+        const status = await dependencies.getQualityRebuildStatus(id, ALL_DETECTOR_IDS);
+        if (status.action === "reprocess") {
+          const result = await dependencies.reprocessSession(id);
+          dependencies.broadcastNotification({ type: "lap-reprocessed", ...result });
+          results.push({ sessionId: id, strategy: "reprocess" as const, result });
+        } else if (status.action === "rebuild_eligibility") {
+          const result = await dependencies.rebuildSessionEligibility(id);
+          dependencies.broadcastNotification({ type: "quality-updated", sessionId: id });
+          results.push({ sessionId: id, strategy: "eligibility" as const, result });
+        } else {
+          results.push({ sessionId: id, strategy: status.action, result: status });
+        }
       } catch (error) {
-        if (!(error instanceof SessionRawFileMissingError)) throw error;
-        console.warn(`[Reprocess] Skipping session ${id}: ${error.message}`);
-        skipped.push({ sessionId: id, reason: "raw-file-missing" });
+        if (error instanceof SessionRawFileMissingError) {
+          console.warn(`[Reprocess] Skipping session ${id}: ${error.message}`);
+          skipped.push({ sessionId: id, reason: "raw-file-missing" });
+        } else {
+          results.push({ sessionId: id, strategy: "failed" as const, error: "Processing failed" });
+        }
       }
     }
-    wsManager.setStaleSessionsNotification(null);
-    return c.json({ reprocessed: results.length, skipped, results });
+
+    const reprocessed = results.filter(({ strategy }) => strategy === "reprocess").length;
+    const failed = results.filter(({ strategy }) => strategy === "failed").length;
+    const remaining = await dependencies.countStaleSessions(ALL_DETECTOR_IDS);
+    if (failed === 0 && remaining === 0) {
+      dependencies.setStaleSessionsNotification(null);
+    } else if (remaining > 0) {
+      dependencies.setStaleSessionsNotification(staleSessionsNotification(remaining));
+    }
+
+    const body = { reprocessed, failed, remaining, skipped, results };
+    if (failed > 0) return c.json(body, 500);
+    if (remaining > 0) return c.json(body, 409);
+    return c.json(body);
   })
   .post("/api/sessions/bulk-delete", zValidator("json", z.object({ ids: z.array(z.number().int()) })), async (c) => {
     const { ids } = c.req.valid("json");
@@ -117,3 +254,6 @@ export const sessionRoutes = new Hono()
     for (const sessionId of ids) lapCount += await deleteSession(sessionId);
     return c.json({ deleted: lapCount, sessions: ids.length });
   });
+}
+
+export const sessionRoutes = createSessionRoutes();

--- a/server/routes/tracks/leaderboard-routes.ts
+++ b/server/routes/tracks/leaderboard-routes.ts
@@ -5,6 +5,7 @@ import { fmCarSpecsCatalog } from "../../../shared/racing/cars/fm";
 import { resolveCarName } from "../../../shared/racing/cars/resolve-name";
 import { tryGetServerGame } from "../../games/registry";
 import type { GameId } from "../../../shared/games/ids";
+import { isTimedLapEligibilityUsable } from "../../../shared/racing/quality/policies";
 import { TrackOrdinalParamSchema } from "./support";
 
 export const trackLeaderboardRoutes = new Hono()
@@ -23,7 +24,7 @@ export const trackLeaderboardRoutes = new Hono()
       // belt-and-braces so cross-game ordinal collisions (Forza track 2 ≠ AC
       // Evo track 2) can never leak into the wrong tracks page.
       const trackLaps = (await getLaps(gameId)).filter(
-        (l) => l.trackOrdinal === trackOrdinal && l.lapTime > 0 && l.gameId === gameId
+        (lap) => lap.trackOrdinal === trackOrdinal && isTimedLapEligibilityUsable(lap) && lap.gameId === gameId
       );
 
       // Derive class letter from PI value
@@ -107,6 +108,14 @@ export const trackLeaderboardRoutes = new Hono()
           sessionId: lap.sessionId,
           sectorTimes: lap.sectorTimes,
           isValid: lap.isValid,
+          phase: lap.phase,
+          conditions: lap.conditions,
+          paceEligibility: lap.paceEligibility,
+          eligibility: lap.eligibility,
+          quality: lap.quality,
+          qualityGeneration: lap.qualityGeneration,
+          qualityStale: lap.qualityStale,
+          source: lap.source,
           invalidReason: lap.invalidReason,
           division: fmCarSpecsCatalog.get(lap.carOrdinal)?.division ?? null,
           notes: lap.notes,

--- a/server/routes/tracks/outline-routes.ts
+++ b/server/routes/tracks/outline-routes.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { zValidator } from "@hono/zod-validator";
 import { OrdinalParamSchema, GameIdQuerySchema } from "@shared/platform/http/route-schemas";
+import { isTimedLapEligibilityUsable } from "@shared/racing/quality/policies";
 import { getLaps, getLapById } from "../../db/lap-read-queries";
 import {
   deleteRecordedOutline,
@@ -67,7 +68,7 @@ export const trackRecomputeOutlineRoutes = new Hono()
       // Multi-lap mode — average best laps
       const outlineGameId = c.req.query("gameId") as GameId | undefined;
       const allLaps = (await getLaps(outlineGameId)).filter(
-        (l) => l.trackOrdinal === trackOrdinal && l.lapTime > 0
+        (lap) => lap.trackOrdinal === trackOrdinal && isTimedLapEligibilityUsable(lap)
       );
       if (allLaps.length === 0) {
         return c.json({ error: "No laps found for this track" }, 404);

--- a/server/routes/tracks/support.ts
+++ b/server/routes/tracks/support.ts
@@ -16,6 +16,10 @@ import { GameIdSchema, type GameId } from "../../../shared/games/ids";
 import { getIRacingSvgTrackMap } from "../../games/iracing/track-map";
 import type { IRacingMapLabel } from "../../games/iracing/track-map-svg";
 import { lapPath } from "../../../shared/racing/tracks/path";
+import {
+  isEligibilitySnapshotCurrent,
+  isEligibilityUsable,
+} from "../../../shared/racing/quality/policies";
 
 // ─── Param schemas ──────────────────────────────────────────────────────────
 
@@ -140,7 +144,13 @@ export async function resolveTrackOutline(
   if (gameId === "iracing") {
     const laps = await getLapSummariesByTrack(ordinal, "iracing");
     for (const lap of laps) {
-      if (!lap.isValid) continue;
+      if (
+        !lap.isValid ||
+        !isEligibilitySnapshotCurrent(lap, ["normal-pace"]) ||
+        !isEligibilityUsable(lap.eligibility?.["normal-pace"])
+      ) {
+        continue;
+      }
       const saved = await getLapById(lap.lapId);
       if (!saved?.telemetry || saved.telemetry.length < 50) continue;
       const path = lapPath(saved.telemetry);

--- a/test/ai/chat/chat-generations.test.ts
+++ b/test/ai/chat/chat-generations.test.ts
@@ -16,20 +16,13 @@
 // process forever whenever this file ran before another file that loads those
 // agents (e.g. laps-issues-route.test.ts).
 import { describe, test, expect } from "bun:test";
-import {
-  parseThreadGeneration,
-  generationThreadId,
-  listThreadGenerations,
-  resolveActiveThread,
-  chatMemoryOptions,
-} from "../../../server/ai/chat-agent";
+import { parseThreadGeneration, generationThreadId, listThreadGenerations, resolveActiveThread, chatMemoryOptions, compareChatThreadId, parseCompareChatThreadId } from "../../../server/ai/chat-agent";
 
 function makeFakeMemory(existingThreadIds: string[]) {
   const threads = new Set(existingThreadIds);
   return {
     threads,
-    getThreadById: async ({ threadId }: { threadId: string }) =>
-      threads.has(threadId) ? { id: threadId } : null,
+    getThreadById: async ({ threadId }: { threadId: string }) => (threads.has(threadId) ? { id: threadId } : null),
   };
 }
 
@@ -105,5 +98,14 @@ describe("chatMemoryOptions", () => {
     expect(chatMemoryOptions("compare-5-6")).toEqual({
       memory: { thread: "compare-5-6", resource: "raceiq" },
     });
+  });
+});
+
+describe("compareChatThreadId", () => {
+  test("isolates chat history by quality identity while preserving canonical lap order", () => {
+    const original = compareChatThreadId(5, 6, "policy-1:quality-generation-1");
+    expect(compareChatThreadId(6, 5, "policy-1:quality-generation-1")).toBe(original);
+    expect(compareChatThreadId(5, 6, "policy-1:quality-generation-2")).not.toBe(original);
+    expect(parseCompareChatThreadId(generationThreadId(original, 2))).toEqual([5, 6]);
   });
 });

--- a/test/ai/prompts/quality-context.test.ts
+++ b/test/ai/prompts/quality-context.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecisionSet,
+  type LapQualitySummary,
+} from "../../../shared/racing/quality/contracts";
+import { buildQualityPromptContext } from "../../../server/ai/quality-context";
+
+function decisions(): Partial<EligibilityDecisionSet> {
+  return {
+    "corner-trace": {
+      policyId: "corner-trace",
+      policyVersion: ELIGIBILITY_POLICY_VERSION,
+      status: "eligible_with_warning",
+      confidence: { level: "medium", score: 0.81 },
+      reasons: [
+        {
+          code: "telemetry_gap_minor",
+          severity: "warning",
+          evidenceIds: ["gap:turn-5"],
+          timeRange: { startMs: 12_000, endMs: 12_200 },
+          distanceRange: { startFraction: 0.4, endFraction: 0.45 },
+          semanticIds: ["motion.speed", "inputs.brake"],
+        },
+      ],
+      evidenceIds: ["gap:turn-5"],
+    },
+  };
+}
+
+function quality(generation: string): LapQualitySummary {
+  return {
+    provenance: {
+      schemaVersion: QUALITY_SCHEMA_VERSION,
+      policyVersion: ELIGIBILITY_POLICY_VERSION,
+      configurationVersion: QUALITY_CONFIG_VERSION,
+      sourceGeneration: "sha256:quality-source",
+      outputGeneration: generation,
+    },
+  } as LapQualitySummary;
+}
+
+describe("AI quality prompt context", () => {
+  test("includes persisted decision, reason code, affected range, and generation", () => {
+    const generation = "sha256:quality-generation";
+    const context = buildQualityPromptContext(
+      { quality: quality(generation), eligibility: decisions(), qualityGeneration: generation },
+      ["corner-trace"],
+    );
+
+    expect(context).toContain("corner-trace: eligible_with_warning; confidence=medium");
+    expect(context).toContain("telemetry_gap_minor: Telemetry contains a short gap. (40-45% of lap)");
+    expect(context).toContain("quality-generation: sha256:quality-generation");
+    expect(context).toContain("avoid claims inside affected ranges");
+  });
+
+  test("marks missing policy evidence unknown instead of silently allowing it", () => {
+    const context = buildQualityPromptContext({}, ["transient-event"]);
+
+    expect(context).toContain("transient-event: unknown");
+    expect(context).toContain("quality_not_rebuilt");
+    expect(context).toContain("quality-generation: unknown");
+  });
+});

--- a/test/ai/prompts/tune-chat-prompt.test.ts
+++ b/test/ai/prompts/tune-chat-prompt.test.ts
@@ -120,7 +120,7 @@ describe("buildTuneChatSystemPrompt", () => {
       symptoms: null,
       currentSetupSummary: null,
     });
-    expect(prompt).toContain("no analysable lap yet");
+    expect(prompt).toContain("no policy-suitable analysable evidence yet");
     expect(prompt).toContain("no setup file available");
     expect(prompt).toContain("(no setup versions yet)");
   });

--- a/test/ai/tools/setup-engineer-warning-provenance.test.ts
+++ b/test/ai/tools/setup-engineer-warning-provenance.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { buildSetupEngineerLapSummaries } from "../../../mastra/tools/setup-engineer";
+import type { LapMeta } from "../../../shared/racing/sessions/types";
+import { ELIGIBILITY_POLICY_VERSION, type EligibilityReason } from "../../../shared/racing/quality/contracts";
+import { evaluateAllEligibility } from "../../../shared/racing/quality/policies";
+import { qualityPackets, summarize } from "../../support/lap-analysis/quality-model";
+
+const warning: EligibilityReason = {
+  code: "channel_simplified",
+  severity: "warning",
+  evidenceIds: ["source-channel-profile:steering"],
+  timeRange: null,
+  distanceRange: null,
+  semanticIds: ["inputs.steer"],
+};
+
+function warnedLap(id: number, lapTime: number): LapMeta {
+  const quality = summarize(qualityPackets(100));
+  const eligibility = evaluateAllEligibility(quality);
+  eligibility["corner-trace"] = {
+    ...eligibility["corner-trace"],
+    status: "eligible_with_warning",
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+    reasons: [warning],
+    evidenceIds: warning.evidenceIds,
+  };
+  return {
+    id,
+    sessionId: 1,
+    lapNumber: id,
+    lapTime,
+    isValid: true,
+    phase: "flying",
+    conditions: [],
+    paceEligibility: "eligible",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    quality,
+    eligibility,
+    qualityGeneration: quality.provenance.outputGeneration,
+    qualityStale: false,
+  };
+}
+
+describe("Setup Engineer lap warning provenance", () => {
+  test("reports warning status and reason codes for selected laps", () => {
+    const rows = buildSetupEngineerLapSummaries([warnedLap(1, 90), warnedLap(2, 90.1), warnedLap(3, 89.9)]);
+
+    expect(rows.every(({ analysisEligible }) => analysisEligible)).toBe(true);
+    expect(rows.map(({ eligibilityStatus }) => eligibilityStatus)).toEqual(["eligible_with_warning", "eligible_with_warning", "eligible_with_warning"]);
+    expect(rows.every(({ reasonCodes }) => reasonCodes.includes("channel_simplified"))).toBe(true);
+  });
+});

--- a/test/experiments/arms/auto-exclude.test.ts
+++ b/test/experiments/arms/auto-exclude.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { reconcileAutoExclusions,
-reconcileAutoExclusionsForLap,
-type ExclusionScopeLap,
-type LapExclusionWriter,
-type LapExperimentScopeReader, } from "../../../server/experiments/auto-exclude"
+import type { EligibilityDecisionSet, QualityReasonCode } from "../../../shared/racing/quality/contracts";
+import { evaluateAllEligibility } from "../../../shared/racing/quality/policies";
+import { QUALITY_REASON_META } from "../../../shared/racing/quality/reasons";
+import { qualityPackets, summarize } from "../../support/lap-analysis/quality-model";
+import { reconcileAutoExclusions, reconcileAutoExclusionsForLap, type ExclusionScopeLap, type LapExclusionWriter, type LapExperimentScopeReader } from "../../../server/experiments/auto-exclude";
 
 /** Auto-exclude fastest-5 curation
  *  (docs/architecture/setup-engineer.md).
@@ -44,22 +44,42 @@ class CapturingLapExclusionWriter implements LapExclusionWriter, LapExperimentSc
     return this.laps.get(lapId);
   }
 }
+const TEST_QUALITY = summarize(qualityPackets(200));
+const TEST_ELIGIBILITY = evaluateAllEligibility(TEST_QUALITY);
+
+function ineligibleNormalPace(reason: QualityReasonCode): EligibilityDecisionSet {
+  return {
+    ...TEST_ELIGIBILITY,
+    "normal-pace": {
+      ...TEST_ELIGIBILITY["normal-pace"],
+      status: "ineligible",
+      confidence: { level: "high", score: 1 },
+      reasons: [{ code: reason, severity: QUALITY_REASON_META[reason].defaultSeverity, evidenceIds: [], timeRange: null, distanceRange: null, semanticIds: [] }],
+      evidenceIds: [],
+    },
+  };
+}
 
 /** Convenience builder for a candidate lap in its initial unreconciled state. */
-function lap(
-  id: number,
-  lapTime: number,
-  overrides: Partial<ExclusionScopeLap> = {},
-): ExclusionScopeLap {
-  return {
+function lap(id: number, lapTime: number, overrides: Partial<ExclusionScopeLap> = {}): ExclusionScopeLap {
+  const built: ExclusionScopeLap = {
     id,
     lapTime,
     isValid: true,
+    phase: "flying",
+    conditions: [],
+    paceEligibility: "eligible",
     invalidReason: null,
     experimentExcluded: false,
     experimentExcludedSource: null,
+    quality: TEST_QUALITY,
+    eligibility: TEST_ELIGIBILITY,
     ...overrides,
   };
+  if ((!built.isValid || built.paceEligibility !== "eligible") && overrides.eligibility === undefined) {
+    built.eligibility = ineligibleNormalPace(built.isValid ? "non_pace_classification" : "structurally_invalid");
+  }
+  return built;
 }
 
 describe("reconcileAutoExclusions", () => {
@@ -120,12 +140,7 @@ describe("reconcileAutoExclusions", () => {
   });
 
   test("invalid lap → (1, 'auto'), never occupies a slot", async () => {
-    const laps = [
-      lap(1, 90),
-      lap(2, 91),
-      lap(3, 92),
-      lap(4, 999, { isValid: false, invalidReason: "off track" }),
-    ];
+    const laps = [lap(1, 90), lap(2, 91), lap(3, 92), lap(4, 999, { isValid: false, invalidReason: "off track" })];
     const writer = new CapturingLapExclusionWriter(laps);
     await reconcileAutoExclusions(writer, EXPERIMENT_ID, TUNE_ID);
     expect(writer.get(4)?.experimentExcluded).toBe(true);
@@ -136,18 +151,15 @@ describe("reconcileAutoExclusions", () => {
     expect(writer.get(3)?.experimentExcluded).toBe(false);
   });
 
-  test("pit-cycle lap → (1, 'auto')", async () => {
-    const laps = [
-      lap(1, 90),
-      lap(2, 91),
-      lap(3, 45, { invalidReason: "outlap" }), // fast time but pit-cycle, ineligible
-    ];
+  test("non-pace lap becomes auto-excluded", async () => {
+    const laps = [lap(1, 90), lap(2, 91), lap(3, 45, { phase: "out", paceEligibility: "excluded" }), lap(4, 92)];
     const writer = new CapturingLapExclusionWriter(laps);
     await reconcileAutoExclusions(writer, EXPERIMENT_ID, TUNE_ID);
     expect(writer.get(3)?.experimentExcluded).toBe(true);
     expect(writer.get(3)?.experimentExcludedSource).toBe("auto");
     expect(writer.get(1)?.experimentExcluded).toBe(false);
     expect(writer.get(2)?.experimentExcluded).toBe(false);
+    expect(writer.get(4)?.experimentExcluded).toBe(false);
   });
 
   test("manual exclude on a top-5 lap → stays excluded, sixth-fastest promoted in", async () => {
@@ -205,6 +217,7 @@ describe("reconcileAutoExclusions", () => {
     // Game re-validates lap 6 (fastest time of the set).
     writer.get(6)!.isValid = true;
     writer.get(6)!.invalidReason = null;
+    writer.get(6)!.eligibility = TEST_ELIGIBILITY;
 
     await reconcileAutoExclusions(writer, EXPERIMENT_ID, TUNE_ID);
 
@@ -216,10 +229,7 @@ describe("reconcileAutoExclusions", () => {
   });
 
   test("lap with null tune_id → pass skipped entirely", async () => {
-    const writer = new CapturingLapExclusionWriter(
-      [lap(1, 90), lap(2, 91)],
-      new Map([[42, { experimentId: 1, tuneId: null }]]),
-    );
+    const writer = new CapturingLapExclusionWriter([lap(1, 90), lap(2, 91)], new Map([[42, { experimentId: 1, tuneId: null }]]));
     await reconcileAutoExclusionsForLap(writer, 42);
     expect(writer.writes).toHaveLength(0);
   });

--- a/test/experiments/arms/curation.test.ts
+++ b/test/experiments/arms/curation.test.ts
@@ -3,7 +3,7 @@ import { compareArms } from "../../../server/experiments/comparison/compare";
 import { type CurationSpec, OUTCOME_METRICS } from "../../../server/experiments/comparison/metrics";
 import { metadataArm } from "../../support/experiments/arms";
 
-const FASTEST_5: CurationSpec = { mode: "fastest-n", n: 5, outlierRule: "none" };
+const FASTEST_5: CurationSpec = { mode: "fastest-n", n: 5, outlierRule: "none", requiredPolicyIds: ["normal-pace"] };
 function paceWith(curation: CurationSpec) {
   return { ...OUTCOME_METRICS.lapTimeSec, curation };
 }

--- a/test/experiments/arms/outcome-metrics.test.ts
+++ b/test/experiments/arms/outcome-metrics.test.ts
@@ -11,19 +11,26 @@ import {
   pickReferenceLap,
 } from "../../../server/experiments/comparison/metrics";
 import type { EvaluableLap } from "../../../shared/racing/laps/review-selection";
+import { qualityEvidence } from "../../support/experiments/arms";
 
 /** The policy no metric uses any more, kept explicit so its effects stay
  *  measurable. See `lapTimeSec`'s comment in server/experiments/comparison/metrics.ts. */
-const FASTEST_5: CurationSpec = { mode: "fastest-n", n: 5, outlierRule: "none" };
+const FASTEST_5: CurationSpec = { mode: "fastest-n", n: 5, outlierRule: "none", requiredPolicyIds: ["normal-pace"] };
 
 function lap(overrides: Partial<EvaluableLap> & { id: number }): EvaluableLap {
+  const isValid = overrides.isValid ?? true;
+  const paceEligibility = overrides.paceEligibility ?? "eligible";
   return {
     lapTime: 90,
-    isValid: true,
+    isValid,
     invalidReason: null,
+    phase: "flying",
+    conditions: [],
+    paceEligibility,
     experimentExcluded: false,
     experimentExcludedSource: null,
     ...overrides,
+    ...qualityEvidence(isValid && paceEligibility === "eligible"),
   };
 }
 
@@ -151,6 +158,24 @@ describe("curation policy is per-metric", () => {
       expect(pool.reasonById.get(2)).toBe("non-pace");
       expect(pool.reasonById.get(3)).toBe("non-pace");
     }
+  });
+
+  test("metadata metrics do not require unrelated trace eligibility", () => {
+    const timedLap = lap({ id: 1, lapTime: 90 });
+    const cornerTrace = timedLap.eligibility?.["corner-trace"];
+    expect(cornerTrace).toBeDefined();
+    timedLap.eligibility = {
+      ...timedLap.eligibility!,
+      "corner-trace": {
+        ...cornerTrace!,
+        status: "ineligible",
+      },
+    };
+
+    for (const metric of [OUTCOME_METRICS.lapTimeSec, OUTCOME_METRICS.consistencySpreadSec]) {
+      expect(curateLaps([timedLap], metric.curation).kept.map(({ id }) => id)).toEqual([1]);
+    }
+    expect(curateLaps([timedLap], OUTCOME_METRICS.lineSpreadScore.curation).kept).toEqual([]);
   });
 });
 

--- a/test/experiments/arms/outcomes.test.ts
+++ b/test/experiments/arms/outcomes.test.ts
@@ -3,7 +3,7 @@ import { compareArms } from "../../../server/experiments/comparison/compare";
 import { type CurationSpec, type MetadataOutcomeMetric, OUTCOME_METRICS } from "../../../server/experiments/comparison/metrics";
 import { metadataArm, normals } from "../../support/experiments/arms";
 
-const FASTEST_5: CurationSpec = { mode: "fastest-n", n: 5, outlierRule: "none" };
+const FASTEST_5: CurationSpec = { mode: "fastest-n", n: 5, outlierRule: "none", requiredPolicyIds: ["normal-pace"] };
 function paceWith(curation: CurationSpec): MetadataOutcomeMetric {
   return { ...OUTCOME_METRICS.lapTimeSec, curation };
 }

--- a/test/lap-analysis/clean-lap-aggregate.test.ts
+++ b/test/lap-analysis/clean-lap-aggregate.test.ts
@@ -1,12 +1,30 @@
 import { describe, test, expect } from "bun:test";
-import {
-  selectCleanLaps,
-  computeConsistency,
-  aggregateSymptoms,
-  baselineFallbackNote,
-} from "../../server/experiments/lap-evidence/aggregate";
+import { selectCleanLaps, computeConsistency, aggregateSymptoms, baselineFallbackNote } from "../../server/experiments/lap-evidence/aggregate";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import type { TuneSymptoms } from "../../server/ai/tune-symptoms";
+import type { EligibilityDecision, EligibilityDecisionSet, QualityReasonCode } from "../../shared/racing/quality/contracts";
+import { evaluateAllEligibility } from "../../shared/racing/quality/policies";
+import { QUALITY_REASON_META } from "../../shared/racing/quality/reasons";
+import { qualityPackets, summarize } from "../support/lap-analysis/quality-model";
+
+const quality = summarize(qualityPackets(200));
+const currentEligibility = evaluateAllEligibility(quality);
+
+function eligibility(normalStatus: EligibilityDecision["status"] = "eligible", normalReason?: QualityReasonCode): EligibilityDecisionSet {
+  const normalPace = currentEligibility["normal-pace"];
+  return {
+    ...currentEligibility,
+    "normal-pace": {
+      ...normalPace,
+      status: normalStatus,
+      confidence: { level: normalStatus === "unknown" ? "unknown" : "high", score: normalStatus === "unknown" ? null : 1 },
+      reasons: normalReason
+        ? [{ code: normalReason, severity: QUALITY_REASON_META[normalReason].defaultSeverity, evidenceIds: [], timeRange: null, distanceRange: null, semanticIds: [] }]
+        : [],
+      evidenceIds: [],
+    },
+  };
+}
 
 function lap(overrides: Partial<LapMeta> & { id: number }): LapMeta {
   return {
@@ -14,14 +32,16 @@ function lap(overrides: Partial<LapMeta> & { id: number }): LapMeta {
     lapNumber: overrides.id,
     lapTime: 90,
     isValid: true,
+    phase: "flying",
+    conditions: [],
+    paceEligibility: "eligible",
     createdAt: "2026-07-15T12:00:00.000Z",
     experimentId: 1,
     experimentVersionId: 1,
     experimentExcluded: false,
+    quality,
+    eligibility: eligibility(),
     ...overrides,
-    phase: overrides.phase ?? "flying",
-    conditions: overrides.conditions ?? [],
-    paceEligibility: overrides.paceEligibility ?? "eligible",
   };
 }
 
@@ -47,38 +67,54 @@ describe("selectCleanLaps", () => {
   test("marks a non-candidate lap as invalid", () => {
     const laps: LapMeta[] = [
       lap({ id: 1, lapTime: 90 }),
-      lap({ id: 2, lapTime: 0, isValid: false }),
+      lap({ id: 2, lapTime: 0, isValid: false, eligibility: eligibility("ineligible", "structurally_invalid") }),
+      lap({ id: 3, lapTime: 90.1 }),
+      lap({ id: 4, lapTime: 90.2 }),
     ];
 
     const { clean, breakdown } = selectCleanLaps(laps);
 
     expect(breakdown.find((r) => r.lapId === 2)?.reason).toBe("invalid");
-    expect(clean.map((l) => l.id)).toEqual([1]);
+    expect(clean.map((l) => l.id)).toEqual([1, 3, 4]);
   });
 
   test("marks a experimentExcluded lap as user-excluded", () => {
     const laps: LapMeta[] = [
       lap({ id: 1, lapTime: 90 }),
-      lap({ id: 2, lapTime: 90.1, experimentExcluded: true }),
+      lap({ id: 2, lapTime: 90.1, experimentExcluded: true, experimentExcludedSource: "manual" }),
+      lap({ id: 3, lapTime: 90.2 }),
+      lap({ id: 4, lapTime: 90.3 }),
     ];
 
     const { clean, breakdown } = selectCleanLaps(laps);
 
     expect(breakdown.find((r) => r.lapId === 2)?.reason).toBe("user-excluded");
-    expect(clean.map((l) => l.id)).toEqual([1]);
+    expect(clean.map((l) => l.id)).toEqual([1, 3, 4]);
   });
 
   test("emits one breakdown row per input lap, imported flag set from experimentVersionId", () => {
-    const laps: LapMeta[] = [
-      lap({ id: 1, lapTime: 90, experimentVersionId: null }),
-      lap({ id: 2, lapTime: 90.1, experimentVersionId: 5 }),
-    ];
+    const laps: LapMeta[] = [lap({ id: 1, lapTime: 90, experimentVersionId: null }), lap({ id: 2, lapTime: 90.1, experimentVersionId: 5 }), lap({ id: 3, lapTime: 90.2, experimentVersionId: 5 })];
 
     const { breakdown } = selectCleanLaps(laps);
 
-    expect(breakdown.length).toBe(2);
+    expect(breakdown.length).toBe(3);
     expect(breakdown.find((r) => r.lapId === 1)?.imported).toBe(true);
     expect(breakdown.find((r) => r.lapId === 2)?.imported).toBe(false);
+  });
+
+  test("carries exact policy reason codes without relabeling them as invalid", () => {
+    const laps: LapMeta[] = [
+      lap({ id: 1, lapTime: 90, eligibility: eligibility("ineligible", "traffic_context") }),
+      lap({ id: 2, lapTime: 90.1 }),
+      lap({ id: 3, lapTime: 90.2 }),
+      lap({ id: 4, lapTime: 90.3 }),
+    ];
+    const { clean, breakdown, setupDecision } = selectCleanLaps(laps);
+    const rejected = breakdown.find((row) => row.lapId === 1);
+    expect(rejected?.reason).toBe("non-pace");
+    expect(rejected?.reasonCodes).toEqual(["traffic_context"]);
+    expect(setupDecision.status).toBe("eligible");
+    expect(clean.map((item) => item.id)).toEqual([2, 3, 4]);
   });
 });
 
@@ -149,11 +185,7 @@ function tuneSymptoms(overrides: Partial<TuneSymptoms["aggregate"]>): TuneSympto
 
 describe("aggregateSymptoms", () => {
   test("majority balance vote across laps", () => {
-    const perLap = [
-      tuneSymptoms({ balance: "understeer" }),
-      tuneSymptoms({ balance: "understeer" }),
-      tuneSymptoms({ balance: "oversteer" }),
-    ];
+    const perLap = [tuneSymptoms({ balance: "understeer" }), tuneSymptoms({ balance: "understeer" }), tuneSymptoms({ balance: "oversteer" })];
 
     const result = aggregateSymptoms(perLap);
 
@@ -161,10 +193,7 @@ describe("aggregateSymptoms", () => {
   });
 
   test("tie in balance vote resolves to neutral", () => {
-    const perLap = [
-      tuneSymptoms({ balance: "understeer" }),
-      tuneSymptoms({ balance: "oversteer" }),
-    ];
+    const perLap = [tuneSymptoms({ balance: "understeer" }), tuneSymptoms({ balance: "oversteer" })];
 
     const result = aggregateSymptoms(perLap);
 
@@ -173,11 +202,7 @@ describe("aggregateSymptoms", () => {
 
   test("corner appearing in >= ceil(n/2) laps is included", () => {
     // 3 laps, ceil(3/2) = 2 — "Turn 1" appears in 2/3, "Turn 2" in 1/3.
-    const perLap = [
-      tuneSymptoms({ understeerCorners: ["Turn 1"] }),
-      tuneSymptoms({ understeerCorners: ["Turn 1", "Turn 2"] }),
-      tuneSymptoms({ understeerCorners: [] }),
-    ];
+    const perLap = [tuneSymptoms({ understeerCorners: ["Turn 1"] }), tuneSymptoms({ understeerCorners: ["Turn 1", "Turn 2"] }), tuneSymptoms({ understeerCorners: [] })];
 
     const result = aggregateSymptoms(perLap);
 

--- a/test/lap-analysis/lap-detector-ac.test.ts
+++ b/test/lap-analysis/lap-detector-ac.test.ts
@@ -4,11 +4,13 @@ import { LapDetectorAcc } from "../../server/games/acc/lap-detector";
 import { stopMaintenanceTasks } from "../../server/telemetry/live-pipeline";
 import { initGameAdapters } from "../../shared/games/init";
 import { initServerGameAdapters } from "../../server/games/init";
-import type { LapClassification } from "../../shared/racing/laps/classification";
 
 afterAll(() => stopMaintenanceTasks());
 import type { TelemetryPacket } from "../../shared/telemetry/types";
-
+import type { LapClassification } from "../../shared/racing/laps/classification";
+import type { PersistLapInput } from "../../server/db/lap-mutation-queries";
+import type { DbAdapter } from "../../server/telemetry/pipeline-ports";
+import type { EligibilityDecisionSet, LapQualitySummary } from "../../shared/racing/quality/contracts";
 initGameAdapters();
 initServerGameAdapters();
 
@@ -18,28 +20,29 @@ type CapturedLap = {
   lapTime: number;
   valid: boolean;
   invalidReason: string | null;
+  rawByteOffset: number | null;
+  rawFrameCount: number;
+  quality: LapQualitySummary;
+  eligibility: EligibilityDecisionSet;
 } & LapClassification;
 
-function makeFakeDb() {
+function makeFakeDb(): DbAdapter & { inserted: CapturedLap[] } {
   const inserted: CapturedLap[] = [];
   return {
     inserted,
     insertSession: async () => 1,
-    insertLap: async (
-      _sessionId: number,
-      lapNumber: number,
-      lapTime: number,
-      valid: boolean,
-      _rawByteOffset: unknown,
-      _rawFrameCount: unknown,
-      _profileId: unknown,
-      _tuneId: unknown,
-      invalidReason: string | null,
-      _sectors: unknown,
-      _versionIdentity: unknown,
-      classification: LapClassification,
-    ) => {
-      inserted.push({ lapNumber, lapTime, valid, invalidReason, ...classification });
+    insertLap: async (input: PersistLapInput) => {
+      inserted.push({
+        lapNumber: input.lapNumber,
+        lapTime: input.lapTime,
+        valid: input.isValid,
+        invalidReason: input.invalidReason,
+        rawByteOffset: input.rawByteOffset,
+        rawFrameCount: input.rawFrameCount,
+        quality: input.quality!,
+        eligibility: input.eligibility!,
+        ...input.classification,
+      });
       return inserted.length;
     },
     getTuneAssignment: async () => null,
@@ -48,7 +51,7 @@ function makeFakeDb() {
     // reconcileAutoExclusionsForLap (server/experiments/auto-exclude.ts) always
     // no-ops after seeing null/null here.
     getLapExperimentScope: async () => ({ experimentId: null, tuneId: null }),
-  } as any;
+  } as unknown as DbAdapter & { inserted: CapturedLap[] };
 }
 
 function packet(fields: Partial<TelemetryPacket>): TelemetryPacket {
@@ -94,39 +97,70 @@ describe("LapDetectorAc — reset detection", () => {
     expect(saved.length).toBe(1);
     expect(saved[0].lapNumber).toBe(1);
     expect(saved[0].lapTime).toBeCloseTo(90, 0);
+    expect(db.inserted[0].quality.sourceKind).toBe("native-live");
+    expect(db.inserted[0].quality.provenance.outputGeneration).toBeTruthy();
+    expect(db.inserted[0].eligibility["official-timing"].status).not.toBe("unknown");
   });
 
-  test("fires onLapComplete with lap event when a lap is emitted", async () => {
+  test("publishes first saved lap after completing its own issue eligibility", async () => {
     const db = makeFakeDb();
+    const callbackOrder: Array<"complete" | "saved"> = [];
+    let pendingIssueEligibility: EligibilityDecisionSet | null = null;
     const completeEvents: Array<{
       packetCount: number;
       lapDistStart: number;
       lapTime: number;
       isValid: boolean;
+      eligibility: EligibilityDecisionSet;
+    }> = [];
+    const savedEvents: Array<{
+      lapNumber: number;
+      lapTime: number;
+      eligibility: EligibilityDecisionSet;
+      issueEligibility: EligibilityDecisionSet | null;
     }> = [];
     const d = new LapDetectorAcc({
       db,
       callbacks: {
-        onLapComplete: (e) =>
+        onLapComplete: (event) => {
+          callbackOrder.push("complete");
+          pendingIssueEligibility = event.eligibility;
           completeEvents.push({
-            packetCount: e.packets.length,
-            lapDistStart: e.lapDistStart,
-            lapTime: e.lapTime,
-            isValid: e.isValid,
-          }),
+            packetCount: event.packets.length,
+            lapDistStart: event.lapDistStart,
+            lapTime: event.lapTime,
+            isValid: event.isValid,
+            eligibility: event.eligibility,
+          });
+        },
+        onLapSaved: (event) => {
+          callbackOrder.push("saved");
+          savedEvents.push({
+            lapNumber: event.lapNumber,
+            lapTime: event.lapTime,
+            eligibility: event.eligibility,
+            issueEligibility: pendingIssueEligibility,
+          });
+        },
       },
     });
 
-    // Drive one fake lap, then reset to trigger emission
     for (let t = 0; t <= 90; t += 1) {
       await d.feed(packet({ CurrentLap: t, DistanceTraveled: 1000 + t * 50, TimestampMS: t * 1000 }));
     }
     await d.feed(packet({ CurrentLap: 0.3, DistanceTraveled: 1000 + 90 * 50 + 30, TimestampMS: 91 * 1000 }));
 
-    expect(completeEvents.length).toBe(1);
+    expect(callbackOrder).toEqual(["complete", "saved"]);
+    expect(completeEvents).toHaveLength(1);
     expect(completeEvents[0].packetCount).toBeGreaterThan(0);
     expect(completeEvents[0].lapDistStart).toBe(1000);
     expect(completeEvents[0].lapTime).toBeCloseTo(90, 0);
+    expect(savedEvents).toHaveLength(1);
+    expect(savedEvents[0].lapNumber).toBe(1);
+    expect(savedEvents[0].lapTime).toBe(completeEvents[0].lapTime);
+    expect(savedEvents[0].eligibility).toBe(completeEvents[0].eligibility);
+    expect(savedEvents[0].issueEligibility).toBe(completeEvents[0].eligibility);
+    expect(savedEvents[0].issueEligibility?.["normal-pace"].status).toBe(savedEvents[0].eligibility["normal-pace"].status);
   });
 
   test("does not fire onLapComplete for silent incomplete-flush events", async () => {
@@ -148,7 +182,7 @@ describe("LapDetectorAc — reset detection", () => {
     expect(completeCount).toBe(0);
   });
 
-  test("saves partial initial lap as a valid classified out lap", async () => {
+  test("saves partial initial lap as invalid outlap when recording starts in pit mid-lap", async () => {
     const db = makeFakeDb();
     const d = new LapDetectorAcc({ db });
 
@@ -160,7 +194,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: t * 50,
           TimestampMS: t * 1000,
           acc: { pitStatus: "pit_lane" } as any,
-        })
+        }),
       );
     }
     // Driver exits the pit lane partway through and spends the rest of the pre-recording lap on track
@@ -171,7 +205,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: t * 50,
           TimestampMS: t * 1000,
           acc: { pitStatus: "out" } as any,
-        })
+        }),
       );
     }
     // First reset (end of that pre-recording lap) — on track now
@@ -181,7 +215,7 @@ describe("LapDetectorAc — reset detection", () => {
         DistanceTraveled: 90 * 50 + 30,
         TimestampMS: 91 * 1000,
         acc: { pitStatus: "out" } as any,
-      })
+      }),
     );
 
     // Full clean lap on track
@@ -192,7 +226,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: 90 * 50 + 30 + t * 50,
           TimestampMS: (91 + t) * 1000,
           acc: { pitStatus: "out" } as any,
-        })
+        }),
       );
     }
     await d.feed(
@@ -201,7 +235,7 @@ describe("LapDetectorAc — reset detection", () => {
         DistanceTraveled: 999999,
         TimestampMS: 999999,
         acc: { pitStatus: "out" } as any,
-      })
+      }),
     );
 
     // Two structurally valid laps: classified out lap, then normal pace lap.
@@ -249,23 +283,29 @@ describe("LapDetectorAc — reset detection", () => {
 
   test("rejects short-distance lap recordings without changing classification", async () => {
     const db = makeFakeDb();
-    const saved: Array<{ lapNumber: number; lapTime: number; isValid: boolean }> = [];
+    const saved: Array<{
+      isValid: boolean;
+      quality: LapQualitySummary;
+    }> = [];
     const d = new LapDetectorAcc({
       db,
       callbacks: {
-        onLapSaved: (n) => saved.push({ lapNumber: n.lapNumber, lapTime: n.lapTime, isValid: n.isValid }),
+        onLapSaved: (event) =>
+          saved.push({
+            isValid: event.isValid,
+            quality: event.quality,
+          }),
       },
     });
 
-    // 50 packets with DistanceTraveled increasing only ~50m total — fails the "lapDistance < 100" rule
     for (let t = 0; t <= 50; t += 1) {
-      await d.feed(packet({ CurrentLap: t * 2, DistanceTraveled: t * 1, TimestampMS: t * 100 }));
+      await d.feed(packet({ CurrentLap: t * 2, DistanceTraveled: t, TimestampMS: t * 100 }));
     }
-    // Reset
     await d.feed(packet({ CurrentLap: 0.1, DistanceTraveled: 52, TimestampMS: 51000 }));
 
     expect(saved).toHaveLength(1);
     expect(saved[0].isValid).toBe(false);
+    expect(saved[0].quality.facts.map(({ code }) => code)).toContain("partial_track_coverage");
     expect(db.inserted[0]).toMatchObject({
       valid: false,
       invalidReason: "telemetry distance too short",
@@ -275,7 +315,7 @@ describe("LapDetectorAc — reset detection", () => {
     });
   });
 
-  test("classifies ACC out laps without invalidating telemetry", async () => {
+  test("classifies ACC lap as out_lap without invalidating telemetry", async () => {
     const db = makeFakeDb();
     const d = new LapDetectorAcc({ db });
 
@@ -287,7 +327,7 @@ describe("LapDetectorAc — reset detection", () => {
         DistanceTraveled: 0,
         TimestampMS: 0,
         acc: { pitStatus: "pit_lane" } as any,
-      })
+      }),
     );
     // Next 40 packets: still in pit lane, creeping towards track
     for (let t = 1; t <= 40; t += 1) {
@@ -297,7 +337,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: t * 50,
           TimestampMS: t * 1000,
           acc: { pitStatus: "pit_lane" } as any,
-        })
+        }),
       );
     }
     // Car exits pit, on track for the rest of the lap
@@ -308,7 +348,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: t * 50,
           TimestampMS: t * 1000,
           acc: { pitStatus: "out" } as any,
-        })
+        }),
       );
     }
     // Lap boundary — reset
@@ -318,7 +358,7 @@ describe("LapDetectorAc — reset detection", () => {
         DistanceTraveled: 91 * 50,
         TimestampMS: 91 * 1000,
         acc: { pitStatus: "out" } as any,
-      })
+      }),
     );
 
     expect(db.inserted.length).toBe(1);
@@ -327,7 +367,7 @@ describe("LapDetectorAc — reset detection", () => {
     expect(db.inserted[0].invalidReason).toBeNull();
   });
 
-  test("classifies ACC in laps without invalidating telemetry", async () => {
+  test("classifies ACC lap as in_lap without invalidating telemetry", async () => {
     const db = makeFakeDb();
     const d = new LapDetectorAcc({ db });
 
@@ -339,7 +379,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: t * 50,
           TimestampMS: t * 1000,
           acc: { pitStatus: "out" } as any,
-        })
+        }),
       );
     }
     // Enters pit lane for the last ~30s of the lap
@@ -350,7 +390,7 @@ describe("LapDetectorAc — reset detection", () => {
           DistanceTraveled: t * 50,
           TimestampMS: t * 1000,
           acc: { pitStatus: "pit_lane" } as any,
-        })
+        }),
       );
     }
     // Lap boundary — reset, still in pit
@@ -360,7 +400,7 @@ describe("LapDetectorAc — reset detection", () => {
         DistanceTraveled: 91 * 50,
         TimestampMS: 91 * 1000,
         acc: { pitStatus: "pit_lane" } as any,
-      })
+      }),
     );
 
     expect(db.inserted.length).toBe(1);
@@ -368,18 +408,72 @@ describe("LapDetectorAc — reset detection", () => {
     expect(db.inserted[0]).toMatchObject({ phase: "in", conditions: [], paceEligibility: "excluded" });
     expect(db.inserted[0].invalidReason).toBeNull();
   });
+
+  test("keeps native-live and replay boundaries, measured channels, and policy decisions in parity", async () => {
+    async function detect(sourceKind: "native-live" | "raceiq-raw") {
+      const db = makeFakeDb();
+      const detector = new LapDetectorAcc({ db, sourceKind });
+      for (let tick = 0; tick <= 90; tick += 1) {
+        if (tick === 45) continue;
+        await detector.feed(packet({ CurrentLap: tick, DistanceTraveled: tick * 50, TimestampMS: tick * 1_000 }), tick * 100);
+      }
+      await detector.feed(packet({ CurrentLap: 0.3, DistanceTraveled: 4_530, TimestampMS: 91_000 }), 9_100);
+      return db.inserted[0];
+    }
+
+    const live = await detect("native-live");
+    const replay = await detect("raceiq-raw");
+    expect(replay).toMatchObject({
+      lapNumber: live.lapNumber,
+      lapTime: live.lapTime,
+      valid: live.valid,
+      phase: live.phase,
+      conditions: live.conditions,
+      paceEligibility: live.paceEligibility,
+      rawByteOffset: live.rawByteOffset,
+      rawFrameCount: live.rawFrameCount,
+    });
+    expect(replay.quality.gapSummary).toEqual(live.quality.gapSummary);
+    expect(replay.quality.trackDistanceCoverage).toBe(live.quality.trackDistanceCoverage);
+    expect(
+      replay.quality.channelQuality.map(({ semanticId, mappingStatus, coverage, freshnessCounts }) => ({
+        semanticId,
+        mappingStatus,
+        coverage,
+        freshnessCounts,
+      })),
+    ).toEqual(
+      live.quality.channelQuality.map(({ semanticId, mappingStatus, coverage, freshnessCounts }) => ({
+        semanticId,
+        mappingStatus,
+        coverage,
+        freshnessCounts,
+      })),
+    );
+    expect(Object.fromEntries(Object.entries(replay.eligibility).map(([policyId, decision]) => [policyId, decision.status]))).toEqual(
+      Object.fromEntries(Object.entries(live.eligibility).map(([policyId, decision]) => [policyId, decision.status])),
+    );
+  });
 });
 
-test("parseDump runs against the problem recording without throwing", async () => {
-  const result = await parseDump("acc", "test/artifacts/sessions/acc-2026-04-10T02-59-28-972Z.bin.gz");
-  expect(result.laps.length).toBeGreaterThan(0);
-}, { timeout: 30000 });
+test(
+  "parseDump runs against the problem recording without throwing",
+  async () => {
+    const result = await parseDump("acc", "test/artifacts/sessions/acc-2026-04-10T02-59-28-972Z.bin.gz");
+    expect(result.laps.length).toBeGreaterThan(0);
+  },
+  { timeout: 30000 },
+);
 
-test("session bin: laps 1+2 have no isValidLap=false, laps 3+4 contain isValidLap=false frames", async () => {
-  const result = await parseDump("acc", "test/artifacts/sessions/acc-2026-04-23T16-42-16-158Z.bin.gz");
-  const byLap = new Map(result.laps.map((l) => [l.lapNumber, l]));
-  expect(byLap.get(1)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(false);
-  expect(byLap.get(2)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(false);
-  expect(byLap.get(3)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(true);
-  expect(byLap.get(4)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(true);
-}, { timeout: 60000 });
+test(
+  "session bin: laps 1+2 have no isValidLap=false, laps 3+4 contain isValidLap=false frames",
+  async () => {
+    const result = await parseDump("acc", "test/artifacts/sessions/acc-2026-04-23T16-42-16-158Z.bin.gz");
+    const byLap = new Map(result.laps.map((l) => [l.lapNumber, l]));
+    expect(byLap.get(1)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(false);
+    expect(byLap.get(2)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(false);
+    expect(byLap.get(3)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(true);
+    expect(byLap.get(4)?.packets?.some((p) => p.acc?.isValidLap === false)).toBe(true);
+  },
+  { timeout: 60000 },
+);

--- a/test/lap-analysis/lap-insight-time-loss.test.ts
+++ b/test/lap-analysis/lap-insight-time-loss.test.ts
@@ -1,13 +1,79 @@
 import { describe, expect, test } from "bun:test";
 import { analyzeLap } from "@shared/racing/analysis/laps/insights/analyze";
+import { evaluateEligibility } from "@shared/racing/quality/policies";
 import { initGameAdapters } from "@shared/games/init";
 import { MIN_REPORTABLE_LOSS_S } from "@shared/racing/analysis/laps/time-loss";
+import type { ChannelQualitySummary, LapQualitySummary } from "../../shared/racing/quality/contracts";
 import type { TelemetryPacket } from "../../shared/telemetry/types";
 
 const RADIUS = 0.33;
 const STEP_MS = 16;
 const STEP_S = STEP_MS / 1000;
 
+const ANALYSIS_CHANNELS = [
+  "timing.distance-traveled",
+  "motion.speed",
+  "inputs.accel",
+  "inputs.brake",
+  "inputs.steer",
+  "tires.tire-slip-ratio",
+  "tires.tire-slip-angle",
+  "tires.wheel-rotation-speed",
+  "suspension.norm-suspension-travel",
+  "fuel.fuel",
+  "tire.temperature.average",
+  "tires.tire-wear",
+] as const;
+const ANALYSIS_QUALITY = {
+  lifecycleState: "exact",
+  complete: true,
+  structurallyValid: true,
+  timing: {
+    source: "simulator-last-lap",
+    lapTimeMs: 10_000,
+    peakTelemetryLapTimeMs: 10_000,
+    confirmed: true,
+  },
+  gapSummary: {
+    expectedCount: 100,
+    observedCount: 100,
+    totalMissingCount: 0,
+    totalMissingFraction: 0,
+    largestContiguousGapMs: 0,
+    countMethod: "native-sequence",
+  },
+  trackDistanceCoverage: 1,
+  worldPositionCoverage: 1,
+  channelQuality: ANALYSIS_CHANNELS.map(
+    (semanticId) =>
+      ({
+        semanticId,
+        channelFamily: semanticId.split(".")[0] as ChannelQualitySummary["channelFamily"],
+        mappingStatus: "direct",
+        canonicalUnit: null,
+        nativeUnit: null,
+        coverage: 1,
+        observedCount: 100,
+        expectedCount: 100,
+        expectedCadenceMs: STEP_MS,
+        observedCadenceMs: STEP_MS,
+        boundaryCoverage: { first500Ms: 1, last500Ms: 1 },
+        confidenceMean: 1,
+        freshnessCounts: { fresh: 100, stale: 0, unknown: 0 },
+        resolutionCounts: { ok: 100, missing: 0, stale: 0, invalid: 0, "not-applicable": 0, error: 0 },
+        issueIntervals: [],
+        limitations: [],
+        provenance: null,
+        sourceProfile: null,
+      }) satisfies ChannelQualitySummary,
+  ),
+  facts: [],
+  classification: {
+    phase: "flying",
+    conditions: [],
+    paceEligibility: "eligible",
+  },
+} as unknown as LapQualitySummary;
 
 initGameAdapters();
 interface Frame {
@@ -55,9 +121,66 @@ function find(insights: ReturnType<typeof analyzeLap>, id: string) {
   return insights.find((i) => i.id === id);
 }
 
+function analyzeFixtureLap(telemetry: TelemetryPacket[], gameId: Parameters<typeof analyzeLap>[1]) {
+  return analyzeLap(telemetry, gameId, ANALYSIS_QUALITY);
+}
+
+const LOCALIZED_ISSUE_RANGE = { startFraction: 0.2, endFraction: 0.4 };
+
+function qualityWithLocalizedIssue(semanticId: ChannelQualitySummary["semanticId"]): LapQualitySummary {
+  const quality = structuredClone(ANALYSIS_QUALITY);
+  const channel = quality.channelQuality.find((candidate) => candidate.semanticId === semanticId);
+  if (!channel) throw new Error(`Missing analysis channel ${semanticId}`);
+  channel.issueIntervals.push({
+    state: "missing",
+    freshness: "unknown",
+    timeRange: { startMs: 320, endMs: 640 },
+    distanceRange: LOCALIZED_ISSUE_RANGE,
+    count: 20,
+  });
+  return quality;
+}
+
+function qualityWithLocalizedWarning(): LapQualitySummary {
+  const quality = structuredClone(ANALYSIS_QUALITY);
+  quality.facts.push({
+    id: "test:localized-minor-gap",
+    code: "telemetry_gap_minor",
+    severity: "warning",
+    timeRange: { startMs: 320, endMs: 352 },
+    distanceRange: LOCALIZED_ISSUE_RANGE,
+    semanticIds: [],
+    channelFamilies: [],
+    provenance: quality.provenance,
+    eventIds: [],
+  });
+  return quality;
+}
+
+function qualityWithGlobalWarning(): LapQualitySummary {
+  const quality = structuredClone(ANALYSIS_QUALITY);
+  quality.timing.source = "telemetry-elapsed";
+  return quality;
+}
+
+function localizedInsightLap(): TelemetryPacket[] {
+  const telemetry = lap([{ n: 100, a: 0, accel: 128 }], 30);
+  for (let index = 0; index < telemetry.length; index++) {
+    const packet = telemetry[index]!;
+    packet.DistanceTraveled = index;
+    packet.EngineMaxRpm = 8_000;
+    packet.CurrentEngineRpm = 4_000;
+  }
+  return telemetry;
+}
+
+function markFrames(telemetry: TelemetryPacket[], start: number, end: number, mark: (packet: TelemetryPacket) => void): void {
+  for (let index = start; index <= end; index++) mark(telemetry[index]!);
+}
+
 describe("analyzeLap time-loss quantification", () => {
   test("coasting that is not corner entry is charged for the speed it bled", () => {
-    const insights = analyzeLap(
+    const insights = analyzeFixtureLap(
       lap([
         // Establish what the car can do: a long clean full-throttle pull.
         { n: 400, a: 4, accel: 255 },
@@ -78,7 +201,7 @@ describe("analyzeLap time-loss quantification", () => {
   });
 
   test("a coast that runs into braking is deliberate corner entry, not charged", () => {
-    const insights = analyzeLap(
+    const insights = analyzeFixtureLap(
       lap([
         { n: 400, a: 4, accel: 255 },
         { n: 100, a: -2, accel: 0 },
@@ -95,7 +218,7 @@ describe("analyzeLap time-loss quantification", () => {
   });
 
   test("detectors that only describe a symptom stay unquantified", () => {
-    const insights = analyzeLap(
+    const insights = analyzeFixtureLap(
       lap([
         { n: 400, a: 4, accel: 255 },
         { n: 100, a: -2, accel: 0 },
@@ -114,7 +237,7 @@ describe("analyzeLap time-loss quantification", () => {
   });
 
   test("a lap too short to analyse yields nothing rather than guesses", () => {
-    expect(analyzeLap(lap([{ n: 5, a: 0, accel: 255 }]), "fm-2023")).toEqual([]);
+    expect(analyzeFixtureLap(lap([{ n: 5, a: 0, accel: 255 }]), "fm-2023")).toEqual([]);
   });
 });
 
@@ -124,14 +247,14 @@ describe("analyzeLap wheel-state capabilities", () => {
   }
 
   test("retains lockup insights when wheel rotation is available", () => {
-    const insights = analyzeLap(lockedLap(), "fm-2023");
+    const insights = analyzeFixtureLap(lockedLap(), "fm-2023");
 
     expect(find(insights, "tire-lockup-FL")).toBeDefined();
     expect(find(insights, "driving-brake-traction-loss")).toBeDefined();
   });
 
   test("omits lockup insights when iRacing wheel rotation is unavailable", () => {
-    const insights = analyzeLap(lockedLap(), "iracing");
+    const insights = analyzeFixtureLap(lockedLap(), "iracing");
 
     expect(find(insights, "tire-lockup-FL")).toBeUndefined();
     expect(find(insights, "driving-brake-traction-loss")).toBeUndefined();
@@ -147,14 +270,119 @@ describe("analyzeLap fuel units", () => {
   }
 
   test("reports litre-based iRacing consumption in litres", () => {
-    const fuel = find(analyzeLap(fuelLap(40, 38.5), "iracing"), "mech-fuel");
+    const fuel = find(analyzeFixtureLap(fuelLap(40, 38.5), "iracing"), "mech-fuel");
 
     expect(fuel?.detail).toBe("Used 1.50 L — ~25.7 laps remaining");
   });
 
   test("retains percentage consumption for fractional-fuel games", () => {
-    const fuel = find(analyzeLap(fuelLap(0.8, 0.75), "fm-2023"), "mech-fuel");
+    const fuel = find(analyzeFixtureLap(fuelLap(0.8, 0.75), "fm-2023"), "mech-fuel");
 
     expect(fuel?.detail).toBe("Used 5.0% — ~15.0 laps remaining");
+  });
+});
+
+describe("analyzeLap localized insight eligibility", () => {
+  test("keeps global warning limitations while ranged warnings exclude affected events", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 22, 33, (packet) => {
+      packet.CurrentEngineRpm = packet.EngineMaxRpm;
+    });
+    markFrames(telemetry, 22, 27, (packet) => {
+      packet.WheelRotationSpeedFL = 0;
+    });
+    markFrames(telemetry, 60, 71, (packet) => {
+      packet.CurrentEngineRpm = packet.EngineMaxRpm;
+    });
+    markFrames(telemetry, 60, 65, (packet) => {
+      packet.WheelRotationSpeedFL = 0;
+    });
+    const globalQuality = qualityWithGlobalWarning();
+
+    const decision = evaluateEligibility("corner-trace", globalQuality);
+    const globalInsights = analyzeLap(telemetry, "fm-2023", globalQuality);
+    const rangedInsights = analyzeLap(telemetry, "fm-2023", qualityWithLocalizedWarning());
+
+    expect(decision.status).toBe("eligible_with_warning");
+    expect(decision.reasons).toContainEqual(
+      expect.objectContaining({
+        code: "lap_time_fallback",
+        timeRange: null,
+        distanceRange: null,
+      }),
+    );
+    expect(find(globalInsights, "driving-rev-limiter")?.frameIndices).toEqual([28, 66]);
+    expect(find(globalInsights, "tire-lockup-FL")?.frameIndices).toEqual([25, 63]);
+    expect(find(rangedInsights, "driving-rev-limiter")?.frameIndices).toEqual([66]);
+    expect(find(rangedInsights, "tire-lockup-FL")?.frameIndices).toEqual([63]);
+  });
+
+
+  test("analyzes corner events outside a policy-ineligible range and remaps source frames", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 60, 71, (packet) => {
+      packet.CurrentEngineRpm = packet.EngineMaxRpm;
+    });
+
+    const insight = find(analyzeLap(telemetry, "fm-2023", qualityWithLocalizedIssue("inputs.steer")), "driving-rev-limiter");
+
+    expect(insight?.frameIndices).toEqual([66]);
+  });
+
+  test("excludes corner warning ranges while retaining and remapping unaffected events", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 22, 33, (packet) => {
+      packet.CurrentEngineRpm = packet.EngineMaxRpm;
+    });
+    markFrames(telemetry, 60, 71, (packet) => {
+      packet.CurrentEngineRpm = packet.EngineMaxRpm;
+    });
+
+    const insight = find(analyzeLap(telemetry, "fm-2023", qualityWithLocalizedWarning()), "driving-rev-limiter");
+
+    expect(insight?.frameIndices).toEqual([66]);
+  });
+
+  test("does not emit corner insights confined to a policy-ineligible range", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 22, 33, (packet) => {
+      packet.CurrentEngineRpm = packet.EngineMaxRpm;
+    });
+
+    expect(find(analyzeLap(telemetry, "fm-2023", qualityWithLocalizedIssue("inputs.steer")), "driving-rev-limiter")).toBeUndefined();
+  });
+
+  test("analyzes transient events outside a policy-ineligible range and remaps source frames", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 60, 65, (packet) => {
+      packet.WheelRotationSpeedFL = 0;
+    });
+
+    const insight = find(analyzeLap(telemetry, "fm-2023", qualityWithLocalizedIssue("tires.wheel-rotation-speed")), "tire-lockup-FL");
+
+    expect(insight?.frameIndices).toEqual([63]);
+  });
+
+  test("excludes transient warning ranges while retaining and remapping unaffected events", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 22, 27, (packet) => {
+      packet.WheelRotationSpeedFL = 0;
+    });
+    markFrames(telemetry, 60, 65, (packet) => {
+      packet.WheelRotationSpeedFL = 0;
+    });
+
+    const insight = find(analyzeLap(telemetry, "fm-2023", qualityWithLocalizedWarning()), "tire-lockup-FL");
+
+    expect(insight?.frameIndices).toEqual([63]);
+  });
+
+  test("does not emit transient insights confined to a policy-ineligible range", () => {
+    const telemetry = localizedInsightLap();
+    markFrames(telemetry, 22, 27, (packet) => {
+      packet.WheelRotationSpeedFL = 0;
+    });
+
+    expect(find(analyzeLap(telemetry, "fm-2023", qualityWithLocalizedIssue("tires.wheel-rotation-speed")), "tire-lockup-FL")).toBeUndefined();
   });
 });

--- a/test/lap-analysis/recap/consistency-personal-best.test.ts
+++ b/test/lap-analysis/recap/consistency-personal-best.test.ts
@@ -23,8 +23,8 @@ describe("computeRecap", () => {
   test("pit transitions are excluded from every pace-derived recap metric", () => {
     const laps = [
       lap({ id: 1, lapNumber: 1, lapTime: 100, sectorTimes: [33, 33, 34] }),
-      lap({ id: 2, lapNumber: 2, lapTime: 120, sectorTimes: [1, 1, 118], invalidReason: "inlap" }),
-      lap({ id: 3, lapNumber: 3, lapTime: 190, sectorTimes: [1, 1, 188], invalidReason: "outlap" }),
+      lap({ id: 2, lapNumber: 2, lapTime: 120, sectorTimes: [1, 1, 118], phase: "in", paceEligibility: "excluded" }),
+      lap({ id: 3, lapNumber: 3, lapTime: 190, sectorTimes: [1, 1, 188], phase: "out", paceEligibility: "excluded" }),
       lap({ id: 4, lapNumber: 4, lapTime: 101, sectorTimes: [34, 33, 34] }),
       lap({ id: 5, lapNumber: 5, lapTime: 102, sectorTimes: [34, 34, 34] }),
     ];
@@ -39,7 +39,7 @@ describe("computeRecap", () => {
     expect(recap.theoretical?.bestSectorTimes).toEqual([33, 33, 34]);
     expect(recap.improvementSec).toBe(0);
     expect(recap.consistency?.stdDevSec).toBeCloseTo(0.816_497, 6);
-    expect(recap.sparkline.map((point) => point.lapId)).toEqual([1, 4, 5]);
+    expect(recap.sparkline.map((point) => point.lapId)).toEqual([1, 2, 3, 4, 5]);
   });
 
   test("a single absurd invalid lap does not inflate time or distance (real session 174 case)", () => {

--- a/test/lap-analysis/recap/core-pace.test.ts
+++ b/test/lap-analysis/recap/core-pace.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from "bun:test";
-import { baseSession, lap, run } from "../../support/lap-analysis/recap";
+import { baseSession, lap, normalPaceEligibility, run } from "../../support/lap-analysis/recap";
 
 describe("computeRecap", () => {
-  test("bestLapId points at the fastest VALID lap, for deep-linking to analyse", () => {
+  test("bestLapId points at fastest valid pace lap", () => {
     const laps = [
       lap({ id: 501, lapNumber: 1, lapTime: 100 }),
       lap({ id: 502, lapNumber: 2, lapTime: 95 }),
@@ -14,6 +14,76 @@ describe("computeRecap", () => {
     expect(recap.bestLapId).toBe(502);
   });
 
+  test("valid non-pace lap stays visible but cannot set pace metrics", () => {
+    const recap = run([
+      lap({ id: 501, lapNumber: 1, lapTime: 40, phase: "grid_start", paceEligibility: "excluded" }),
+      lap({ id: 502, lapNumber: 2, lapTime: 95 }),
+    ]);
+    expect(recap.lapsValid).toBe(1);
+    expect(recap.bestLapSec).toBe(95);
+    expect(recap.bestLapId).toBe(502);
+    expect(recap.sparkline).toEqual([
+      expect.objectContaining({ lapId: 501, lapNumber: 1, lapTimeSec: 40, isValid: true, phase: "grid_start", conditions: [], paceEligibility: "excluded" }),
+      expect.objectContaining({ lapId: 502, lapNumber: 2, lapTimeSec: 95, isValid: true, phase: "flying", conditions: [], paceEligibility: "eligible" }),
+    ]);
+  });
+
+  test("persisted normal-pace decisions override legacy classification for pace metrics", () => {
+    const recap = run([
+      lap({ id: 601, lapNumber: 1, lapTime: 90, paceEligibility: "eligible", eligibility: normalPaceEligibility("ineligible") }),
+      lap({ id: 602, lapNumber: 2, lapTime: 95, paceEligibility: "excluded", eligibility: normalPaceEligibility("eligible") }),
+    ]);
+    expect(recap.bestLapId).toBe(602);
+    expect(recap.bestLapSec).toBe(95);
+    expect(recap.sparkline[0]?.eligibility?.["normal-pace"].status).toBe("ineligible");
+    expect(recap.sparkline[1]?.eligibility?.["normal-pace"].status).toBe("eligible");
+  });
+
+  test("current quality evidence preserves pace metrics while stale and missing evidence cannot set them", () => {
+    const recap = run([
+      lap({ id: 701, lapNumber: 1, lapTime: 90, qualityGeneration: "sha256:stale-generation" }),
+      lap({
+        id: 702,
+        lapNumber: 2,
+        lapTime: 91,
+        quality: null,
+        qualityGeneration: null,
+        qualitySchemaVersion: null,
+        qualityPolicyVersion: null,
+        qualityConfigVersion: null,
+      }),
+      lap({ id: 703, lapNumber: 3, lapTime: 95 }),
+    ]);
+
+    expect(recap.lapsValid).toBe(1);
+    expect(recap.bestLapSec).toBe(95);
+    expect(recap.bestLapId).toBe(703);
+    expect(recap.timeOnTrackSec).toBe(95);
+  });
+
+  test("legacy eligibility without quality provenance cannot restore pace eligibility", () => {
+    const eligibility = normalPaceEligibility("eligible");
+    eligibility["normal-pace"] = { ...eligibility["normal-pace"], policyVersion: "0" };
+    const recap = run([
+      lap({
+        id: 704,
+        lapNumber: 1,
+        lapTime: 90,
+        eligibility,
+        quality: null,
+        qualityGeneration: null,
+        qualitySchemaVersion: null,
+        qualityPolicyVersion: null,
+        qualityConfigVersion: null,
+      }),
+      lap({ id: 705, lapNumber: 2, lapTime: 95 }),
+    ]);
+
+    expect(recap.lapsValid).toBe(1);
+    expect(recap.bestLapId).toBe(705);
+    expect(recap.bestLapSec).toBe(95);
+  });
+
   test("sparkline preserves lap ids when detector lap numbers repeat", () => {
     const recap = run([
       lap({ id: 45, lapNumber: 0, lapTime: 135.5, isValid: false }),
@@ -22,7 +92,7 @@ describe("computeRecap", () => {
     expect(recap.sparkline.map((point) => point.lapId)).toEqual([45, 54]);
   });
 
-  test("bestLapId is null when there is no valid lap", () => {
+  test("bestLapId is null when there is no valid pace lap", () => {
     const recap = run([lap({ id: 9, lapNumber: 1, lapTime: 100, isValid: false })]);
     expect(recap.bestLapId).toBeNull();
   });

--- a/test/routes/quality-routes.test.ts
+++ b/test/routes/quality-routes.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { ELIGIBILITY_POLICY_VERSION, LOCAL_PLAYER_EVIDENCE, QUALITY_CONFIG_VERSION, QUALITY_SCHEMA_VERSION } from "../../shared/racing/quality/contracts";
+import { RecordingQualityAccumulator, summarizeLapQuality } from "../../shared/racing/quality/measure";
+import { initGameAdapters } from "../../shared/games/init";
+import { initServerGameAdapters } from "../../server/games/init";
+import { DEFAULT_LAP_CLASSIFICATION } from "../../shared/racing/laps/classification";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+import type { TelemetryVersionIdentity } from "../../shared/telemetry/version";
+import { finalizeLapQualityGeneration, finalizeRecordingQualityGeneration } from "../../server/lap-analysis/quality-generation";
+import { db } from "../../server/db";
+import { laps, sessions } from "../../server/db/schema";
+import { lapRoutes } from "../../server/routes/laps";
+import { sessionRoutes } from "../../server/routes/session-routes";
+import { packet } from "../support/telemetry/resolver";
+
+initGameAdapters();
+initServerGameAdapters();
+
+const VERSION: TelemetryVersionIdentity = {
+  catalogVersion: "quality-api-catalog",
+  catalogHash: "quality-api-hash",
+  catalogSchemaVersion: "quality-api-schema",
+  parserVersion: "quality-api-parser",
+  resolverVersion: "quality-api-resolver",
+  derivationVersion: "quality-api-derivation",
+};
+
+const createdSessionIds: number[] = [];
+const createdRawDirectories: string[] = [];
+
+afterEach(async () => {
+  for (const sessionId of createdSessionIds) {
+    await db.delete(laps).where(eq(laps.sessionId, sessionId)).run();
+    await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
+  }
+  createdSessionIds.length = 0;
+  for (const directory of createdRawDirectories) rmSync(directory, { recursive: true, force: true });
+  createdRawDirectories.length = 0;
+});
+
+function telemetry(): TelemetryPacket[] {
+  return Array.from({ length: 201 }, (_, index) => {
+    const fraction = index / 200;
+    return packet("iracing", {
+      TimestampMS: index * 50,
+      DistanceTraveled: fraction * 5_000,
+      CurrentLap: fraction * 10,
+      LastLap: 10,
+      PositionX: 100 + fraction,
+      PositionZ: 200 + fraction,
+      Speed: 55,
+      Accel: 180,
+      Brake: 0,
+      Steer: 0,
+      Fuel: 50 - fraction,
+      TireTempFL: 80,
+      TireTempFR: 80,
+      TireTempRL: 80,
+      TireTempRR: 80,
+      TireWearFL: 0.9,
+      TireWearFR: 0.9,
+      TireWearRL: 0.9,
+      TireWearRR: 0.9,
+      TirePressureFrontLeft: 27,
+      TirePressureFrontRight: 27,
+      TirePressureRearLeft: 27,
+      TirePressureRearRight: 27,
+      TireSlipRatioFL: 0.01,
+      TireSlipRatioFR: 0.01,
+      TireSlipRatioRL: 0.01,
+      TireSlipRatioRR: 0.01,
+      TireSlipAngleFL: 0.01,
+      TireSlipAngleFR: 0.01,
+      TireSlipAngleRL: 0.01,
+      TireSlipAngleRR: 0.01,
+      WheelRotationSpeedFL: 100,
+      WheelRotationSpeedFR: 100,
+      WheelRotationSpeedRL: 100,
+      WheelRotationSpeedRR: 100,
+      NormSuspensionTravelFL: 0.5,
+      NormSuspensionTravelFR: 0.5,
+      NormSuspensionTravelRL: 0.5,
+      NormSuspensionTravelRR: 0.5,
+      iracing: {
+        sessionTick: index,
+        sessionNum: 0,
+        driverCarIdx: 1,
+        trackLengthM: 5_000,
+        lapDistanceM: fraction * 5_000,
+        lapDistancePct: fraction,
+        onPitRoad: false,
+        playerTrackSurface: 3,
+        incidents: 0,
+        trackWetness: 0,
+        carName: "Quality test car",
+        carClassName: "Quality test class",
+        trackName: "Quality test track",
+      },
+    });
+  });
+}
+
+async function seedQualitySession(): Promise<{ sessionId: number; lapId: number }> {
+  const packets = telemetry();
+  const recordingAccumulator = new RecordingQualityAccumulator("native-live", LOCAL_PLAYER_EVIDENCE, VERSION);
+  for (const sample of packets) recordingAccumulator.observe(sample);
+  const recordingQuality = finalizeRecordingQualityGeneration(
+    recordingAccumulator.finalize("complete", {
+      state: "verified",
+      sourceGeneration: "quality-api-archive",
+    }),
+  );
+  const draftQuality = summarizeLapQuality({
+    packets,
+    lapTime: 10,
+    timingSource: "simulator-history",
+    complete: true,
+    structurallyValid: true,
+    invalidReason: null,
+    classification: DEFAULT_LAP_CLASSIFICATION,
+    sourceKind: "native-live",
+    participant: LOCAL_PLAYER_EVIDENCE,
+    versionIdentity: VERSION,
+  });
+  const generated = finalizeLapQualityGeneration(draftQuality, recordingQuality.provenance.sourceGeneration, {
+    lapNumber: 1,
+    rawByteOffset: null,
+    rawFrameCount: packets.length,
+  });
+  const quality = generated.quality;
+  const sessionId = (
+    await db
+      .insert(sessions)
+      .values({
+        carOrdinal: 991_236,
+        trackOrdinal: 992_236,
+        gameId: "iracing",
+        source: "native-live",
+        recordingQuality,
+        qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+        lapDetectorVersion: "iracing_lapdetector_v5",
+        qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+        qualityConfigVersion: QUALITY_CONFIG_VERSION,
+        qualityGeneration: recordingQuality.provenance.outputGeneration,
+      })
+      .returning({ id: sessions.id })
+      .get()
+  ).id;
+  createdSessionIds.push(sessionId);
+  const lapId = (
+    await db
+      .insert(laps)
+      .values({
+        sessionId,
+        lapNumber: 1,
+        rawByteOffset: null,
+        rawFrameCount: packets.length,
+        lapTime: 10,
+        isValid: true,
+        quality,
+        eligibility: generated.eligibility,
+        qualityGeneration: quality.provenance.outputGeneration,
+        qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+        qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+        qualityConfigVersion: QUALITY_CONFIG_VERSION,
+      })
+      .returning({ id: laps.id })
+      .get()
+  ).id;
+  return { sessionId, lapId };
+}
+
+describe("quality diagnostics API", () => {
+  test("returns persisted lap evidence and policy decisions", async () => {
+    const { lapId } = await seedQualitySession();
+    const response = await lapRoutes.request(`/api/laps/${lapId}/quality`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.lapId).toBe(lapId);
+    expect(body.quality.provenance.schemaVersion).toBe(QUALITY_SCHEMA_VERSION);
+    expect(body.eligibility["normal-pace"].policyVersion).toBe(ELIGIBILITY_POLICY_VERSION);
+    expect(body.qualityGeneration).toBe(body.quality.provenance.outputGeneration);
+  });
+
+  test("returns session recording evidence, rebuild state, and lap generations", async () => {
+    const { sessionId, lapId } = await seedQualitySession();
+    const response = await sessionRoutes.request(`/api/sessions/${sessionId}/quality`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.action).toBe("current");
+    expect(body.recordingQuality.provenance.schemaVersion).toBe(QUALITY_SCHEMA_VERSION);
+    expect(body.laps).toEqual([expect.objectContaining({ id: lapId, qualityGeneration: expect.any(String) })]);
+  });
+
+  test("rebuilds stale policy decisions once without changing measured quality generation", async () => {
+    const { sessionId, lapId } = await seedQualitySession();
+    const before = await db.select({ generation: laps.qualityGeneration }).from(laps).where(eq(laps.id, lapId)).get();
+    await db.update(sessions).set({ qualityPolicyVersion: "stale-policy" }).where(eq(sessions.id, sessionId)).run();
+    await db.update(laps).set({ qualityPolicyVersion: "stale-policy" }).where(eq(laps.id, lapId)).run();
+
+    const staleResponse = await sessionRoutes.request(`/api/sessions/${sessionId}/quality`);
+    expect((await staleResponse.json()).action).toBe("rebuild_eligibility");
+
+    const rebuildResponse = await sessionRoutes.request(`/api/sessions/${sessionId}/quality/rebuild`, { method: "POST" });
+    expect(rebuildResponse.status).toBe(200);
+    const rebuilt = await rebuildResponse.json();
+    expect(rebuilt.strategy).toBe("eligibility");
+    expect(rebuilt.status.action).toBe("current");
+
+    const stored = await db.select({ generation: laps.qualityGeneration, policyVersion: laps.qualityPolicyVersion, eligibility: laps.eligibility }).from(laps).where(eq(laps.id, lapId)).get();
+    expect(stored?.generation).toBe(before?.generation);
+    expect(stored?.policyVersion).toBe(ELIGIBILITY_POLICY_VERSION);
+    expect(stored?.eligibility?.["corner-trace"].policyVersion).toBe(ELIGIBILITY_POLICY_VERSION);
+
+    const repeatResponse = await sessionRoutes.request(`/api/sessions/${sessionId}/quality/rebuild`, { method: "POST" });
+    expect((await repeatResponse.json()).strategy).toBe("none");
+  });
+
+  test("requires raw reprocessing when measurement configuration is stale", async () => {
+    const { sessionId, lapId } = await seedQualitySession();
+    await db.update(sessions).set({ qualityConfigVersion: "stale-config" }).where(eq(sessions.id, sessionId)).run();
+    await db.update(laps).set({ qualityConfigVersion: "stale-config" }).where(eq(laps.id, lapId)).run();
+
+    const unavailableResponse = await sessionRoutes.request(`/api/sessions/${sessionId}/quality/rebuild`, { method: "POST" });
+    expect(unavailableResponse.status).toBe(409);
+    expect(await unavailableResponse.json()).toMatchObject({
+      status: { action: "unavailable", stale: { configuration: true } },
+    });
+    expect((await db.select({ version: laps.qualityConfigVersion }).from(laps).where(eq(laps.id, lapId)).get())?.version).toBe("stale-config");
+
+    const rawDirectory = mkdtempSync(join(tmpdir(), "raceiq-config-stale-"));
+    createdRawDirectories.push(rawDirectory);
+    const rawFile = join(rawDirectory, "recording.bin");
+    writeFileSync(rawFile, new Uint8Array([0]));
+    await db.update(sessions).set({ rawFile }).where(eq(sessions.id, sessionId)).run();
+
+    const reprocessResponse = await sessionRoutes.request(`/api/sessions/${sessionId}/quality`);
+    expect(await reprocessResponse.json()).toMatchObject({
+      action: "reprocess",
+      rawAvailable: true,
+      stale: { configuration: true },
+    });
+  });
+
+  test("returns 404 when rebuilding quality for a missing session", async () => {
+    const response = await sessionRoutes.request("/api/sessions/2147483647/quality/rebuild", { method: "POST" });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Session not found" });
+  });
+
+  test("reports unavailable instead of inventing rebuilt quality without raw evidence", async () => {
+    const { sessionId } = await seedQualitySession();
+    await db.update(sessions).set({ qualitySchemaVersion: "stale-schema" }).where(eq(sessions.id, sessionId)).run();
+
+    const response = await sessionRoutes.request(`/api/sessions/${sessionId}/quality/rebuild`, { method: "POST" });
+    expect(response.status).toBe(409);
+    const body = await response.json();
+    expect(body.status).toMatchObject({ action: "unavailable", rawAvailable: false });
+  });
+
+  test("reports unavailable canonical metadata without inventing archive provenance", async () => {
+    const { sessionId, lapId } = await seedQualitySession();
+    const response = await sessionRoutes.request(`/api/sessions/${sessionId}/evidence-retention`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toMatchObject({
+      sessionId,
+      action: "raw_unavailable",
+      canDeleteRaw: false,
+      reasons: ["raw_redecode_required"],
+      availability: {
+        rawCapture: false,
+        canonicalArchive: {
+          state: "unavailable",
+          semanticIds: [],
+          eventIds: [],
+          provenance: null,
+        },
+      },
+    });
+    expect(body.laps).toEqual([expect.objectContaining({ lapId })]);
+  });
+
+  test("retains existing raw capture when canonical archive metadata is unavailable", async () => {
+    const { sessionId } = await seedQualitySession();
+    const directory = mkdtempSync(join(tmpdir(), "raceiq-retention-"));
+    createdRawDirectories.push(directory);
+    const rawFile = join(directory, "session.bin");
+    writeFileSync(rawFile, "raw-evidence");
+    await db.update(sessions).set({ rawFile }).where(eq(sessions.id, sessionId)).run();
+
+    const response = await sessionRoutes.request(`/api/sessions/${sessionId}/evidence-retention`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      sessionId,
+      action: "retain_raw",
+      canDeleteRaw: false,
+      reasons: ["raw_redecode_required"],
+      availability: {
+        rawCapture: true,
+        canonicalArchive: { state: "unavailable", semanticIds: [], eventIds: [], provenance: null },
+      },
+    });
+    expect(existsSync(rawFile)).toBe(true);
+  });
+
+  test("returns 404 for missing session evidence-retention assessment", async () => {
+    const response = await sessionRoutes.request("/api/sessions/2147483647/evidence-retention");
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Session not found" });
+  });
+
+  test("blocks AI preflight with a machine-readable decision when quality is unknown", async () => {
+    const sessionId = (
+      await db
+        .insert(sessions)
+        .values({
+          carOrdinal: 993_236,
+          trackOrdinal: 994_236,
+          gameId: "iracing",
+        })
+        .returning({ id: sessions.id })
+        .get()
+    ).id;
+    createdSessionIds.push(sessionId);
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: 1,
+          lapTime: 90,
+          isValid: true,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+
+    const response = await lapRoutes.request(`/api/laps/${lapId}/analyse`, { method: "POST" });
+    expect(response.status).toBe(422);
+    const body = await response.json();
+    expect(body.decision).toEqual(
+      expect.objectContaining({
+        policyId: "corner-trace",
+        status: "unknown",
+      }),
+    );
+    expect(body.decision.reasons.map((reason: { code: string }) => reason.code)).toContain("quality_not_rebuilt");
+  });
+});

--- a/test/routes/session-quality-route-semantics.test.ts
+++ b/test/routes/session-quality-route-semantics.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { QualityRebuildAction, QualityRebuildStatus } from "../../server/lap-analysis/quality-rebuild";
+import { createSessionRoutes, type SessionRouteDependencies } from "../../server/routes/session-routes";
+
+function status(sessionId: number, action: QualityRebuildAction): QualityRebuildStatus {
+  return {
+    sessionId,
+    action,
+    rawAvailable: action === "reprocess",
+    lapCount: 1,
+    recordingQuality: null,
+    qualityGeneration: null,
+    stale: {
+      detector: action !== "current",
+      schema: false,
+      policy: action === "rebuild_eligibility",
+      configuration: false,
+    },
+  };
+}
+
+function routes(overrides: Partial<SessionRouteDependencies> = {}) {
+  return createSessionRoutes({
+    sessionExists: async () => true,
+    getQualityRebuildStatus: async (sessionId) => status(sessionId, "current"),
+    getLapsForSession: async () => [],
+    reprocessSession: async (sessionId) => ({
+      sessionId,
+      lapsDetected: 1,
+      lapsUpdated: 1,
+      strategy: "in-place",
+    }),
+    rebuildSessionEligibility: async (sessionId) => status(sessionId, "current"),
+    getStaleSessions: async () => [],
+    countStaleSessions: async () => 0,
+    broadcastNotification: () => {},
+    setStaleSessionsNotification: () => {},
+    ...overrides,
+  });
+}
+
+describe("session quality route semantics", () => {
+  test("returns 404 only when session existence check reports missing", async () => {
+    const getQualityRebuildStatus = mock(async (sessionId: number) => status(sessionId, "current"));
+    const response = await routes({
+      sessionExists: async () => false,
+      getQualityRebuildStatus,
+    }).request("/api/sessions/42/quality");
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "Session not found" });
+    expect(getQualityRebuildStatus).not.toHaveBeenCalled();
+  });
+
+  test("keeps operational quality lookup failures as server failures", async () => {
+    const response = await routes({
+      getQualityRebuildStatus: async () => {
+        throw new Error("database unavailable");
+      },
+    }).request("/api/sessions/42/quality");
+
+    expect(response.status).toBe(500);
+  });
+
+  test("reports unavailable stale rebuilds and preserves stale health", async () => {
+    const setStaleSessionsNotification = mock((_payload: Record<string, unknown> | null) => {});
+    const response = await routes({
+      getStaleSessions: async () => [42],
+      getQualityRebuildStatus: async (sessionId) => status(sessionId, "unavailable"),
+      countStaleSessions: async () => 1,
+      setStaleSessionsNotification,
+    }).request("/api/sessions/reprocess-stale", { method: "POST" });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({
+      reprocessed: 0,
+      failed: 0,
+      remaining: 1,
+      results: [{ sessionId: 42, strategy: "unavailable" }],
+    });
+    expect(setStaleSessionsNotification).toHaveBeenCalledWith({
+      type: "stale-lap-detection",
+      sessionCount: 1,
+      currentVersion: expect.any(String),
+    });
+  });
+
+  test("reports partial bulk failures without clearing stale health", async () => {
+    const setStaleSessionsNotification = mock((_payload: Record<string, unknown> | null) => {});
+    const response = await routes({
+      getStaleSessions: async () => [41, 42],
+      getQualityRebuildStatus: async (sessionId) => status(sessionId, "reprocess"),
+      reprocessSession: async (sessionId) => {
+        if (sessionId === 42) throw new Error("database unavailable");
+        return { sessionId, lapsDetected: 1, lapsUpdated: 1, strategy: "in-place" };
+      },
+      countStaleSessions: async () => 1,
+      setStaleSessionsNotification,
+    }).request("/api/sessions/reprocess-stale", { method: "POST" });
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toMatchObject({
+      reprocessed: 1,
+      failed: 1,
+      remaining: 1,
+      results: [
+        { sessionId: 41, strategy: "reprocess" },
+        { sessionId: 42, strategy: "failed", error: "Processing failed" },
+      ],
+    });
+    expect(setStaleSessionsNotification).toHaveBeenCalledTimes(1);
+    expect(setStaleSessionsNotification).not.toHaveBeenCalledWith(null);
+  });
+
+  test("clears stale health only after every bulk rebuild succeeds", async () => {
+    const setStaleSessionsNotification = mock((_payload: Record<string, unknown> | null) => {});
+    const response = await routes({
+      getStaleSessions: async () => [41, 42],
+      getQualityRebuildStatus: async (sessionId) => status(sessionId, sessionId === 41 ? "reprocess" : "rebuild_eligibility"),
+      countStaleSessions: async () => 0,
+      setStaleSessionsNotification,
+    }).request("/api/sessions/reprocess-stale", { method: "POST" });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({
+      reprocessed: 1,
+      failed: 0,
+      remaining: 0,
+      results: [
+        { sessionId: 41, strategy: "reprocess" },
+        { sessionId: 42, strategy: "eligibility" },
+      ],
+    });
+    expect(setStaleSessionsNotification).toHaveBeenCalledWith(null);
+  });
+});

--- a/test/routes/track-quality-evidence.test.ts
+++ b/test/routes/track-quality-evidence.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { eq } from "drizzle-orm";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecisionSet,
+  type LapQualitySummary,
+} from "../../shared/racing/quality/contracts";
+import {
+  deleteRecordedOutline,
+} from "../../shared/racing/tracks/recording/outlines";
+import type { TelemetryPacket } from "../../shared/telemetry/types";
+import { db } from "../../server/db";
+import { laps, sessions } from "../../server/db/schema";
+import {
+  cacheDelete,
+  cacheSet,
+} from "../../server/db/telemetry-replay-storage";
+import { trackRoutes } from "../../server/routes/tracks";
+import { resolveTrackOutline } from "../../server/routes/tracks/support";
+import { normalPaceEligibility } from "../support/lap-analysis/recap";
+
+const createdSessionIds: number[] = [];
+const cachedLapIds: number[] = [];
+const recordedTrackOrdinals = new Set<number>();
+
+function quality(generation: string): LapQualitySummary {
+  return {
+    provenance: {
+      schemaVersion: QUALITY_SCHEMA_VERSION,
+      policyVersion: ELIGIBILITY_POLICY_VERSION,
+      configurationVersion: QUALITY_CONFIG_VERSION,
+      sourceGeneration: "sha256:track-route-source",
+      outputGeneration: generation,
+    },
+  } as LapQualitySummary;
+}
+
+function outlineTelemetry(): TelemetryPacket[] {
+  return Array.from({ length: 60 }, (_, index) => {
+    const angle = (index / 59) * Math.PI * 2;
+    return {
+      gameId: "iracing",
+      PositionX: Math.cos(angle) * 100,
+      PositionZ: Math.sin(angle) * 100,
+      TimestampMS: index * 100,
+      Speed: 30,
+      Yaw: angle,
+    } as TelemetryPacket;
+  });
+}
+
+async function insertOutlineCandidate(
+  trackOrdinal: number,
+  options: {
+    eligibility: EligibilityDecisionSet | null;
+    storedGeneration?: string;
+  },
+): Promise<number> {
+  const generation = `sha256:outline-${trackOrdinal}`;
+  const sessionId = (
+    await db
+      .insert(sessions)
+      .values({
+        gameId: "iracing",
+        carOrdinal: trackOrdinal + 1,
+        trackOrdinal,
+        source: "native-live",
+      })
+      .returning({ id: sessions.id })
+      .get()
+  ).id;
+  createdSessionIds.push(sessionId);
+  const lapId = (
+    await db
+      .insert(laps)
+      .values({
+        sessionId,
+        lapNumber: 1,
+        lapTime: 90,
+        isValid: true,
+        quality: quality(generation),
+        eligibility: options.eligibility,
+        qualityGeneration: options.storedGeneration ?? generation,
+        qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+        qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+        qualityConfigVersion: QUALITY_CONFIG_VERSION,
+      })
+      .returning({ id: laps.id })
+      .get()
+  ).id;
+  cacheSet(lapId, outlineTelemetry());
+  cachedLapIds.push(lapId);
+  recordedTrackOrdinals.add(trackOrdinal);
+  return lapId;
+}
+
+afterEach(async () => {
+  for (const lapId of cachedLapIds) cacheDelete(lapId);
+  cachedLapIds.length = 0;
+  for (const ordinal of recordedTrackOrdinals) {
+    deleteRecordedOutline(ordinal, "iracing");
+  }
+  recordedTrackOrdinals.clear();
+  for (const sessionId of createdSessionIds) await db.delete(sessions).where(eq(sessions.id, sessionId)).run();
+  createdSessionIds.length = 0;
+});
+
+describe("GET /api/tracks/:trackOrdinal/all-laps", () => {
+  test("returns quality evidence needed by Track Detail badges", async () => {
+    const generation = "sha256:track-route-quality";
+    const sessionId = (await db.insert(sessions).values({ gameId: "iracing", carOrdinal: 9_231_101, trackOrdinal: 9_231_102, source: "native-live" }).returning({ id: sessions.id }).get()).id;
+    createdSessionIds.push(sessionId);
+    const lapId = (
+      await db
+        .insert(laps)
+        .values({
+          sessionId,
+          lapNumber: 1,
+          lapTime: 90,
+          isValid: true,
+          quality: quality(generation),
+          qualityGeneration: generation,
+          qualitySchemaVersion: QUALITY_SCHEMA_VERSION,
+          qualityPolicyVersion: ELIGIBILITY_POLICY_VERSION,
+          qualityConfigVersion: QUALITY_CONFIG_VERSION,
+        })
+        .returning({ id: laps.id })
+        .get()
+    ).id;
+
+    const response = await trackRoutes.request(`/api/tracks/9231102/all-laps?gameId=iracing`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Array<Record<string, unknown>>;
+    expect(body).toContainEqual(
+      expect.objectContaining({
+        lapId,
+        source: "native-live",
+        qualityGeneration: generation,
+        qualityStale: true,
+        quality: expect.objectContaining({ provenance: expect.objectContaining({ outputGeneration: generation }) }),
+      }),
+    );
+  });
+});
+
+describe("resolveTrackOutline iRacing persistence fallback", () => {
+  test("seeds generated outline from current normal-pace-eligible evidence", async () => {
+    const trackOrdinal = 9_231_201;
+    await insertOutlineCandidate(trackOrdinal, {
+      eligibility: normalPaceEligibility("eligible"),
+    });
+
+    const resolved = await resolveTrackOutline(trackOrdinal, "iracing");
+
+    expect(resolved).toEqual(
+      expect.objectContaining({
+        source: "generated",
+        recorded: true,
+        points: expect.any(Array),
+      }),
+    );
+    expect(resolved?.points.length).toBeGreaterThanOrEqual(50);
+  });
+
+  test("rejects missing, stale, and normal-pace-ineligible persisted evidence", async () => {
+    const trackOrdinal = 9_231_202;
+    await insertOutlineCandidate(trackOrdinal, {
+      eligibility: normalPaceEligibility("ineligible"),
+    });
+    await insertOutlineCandidate(trackOrdinal, {
+      eligibility: normalPaceEligibility("eligible"),
+      storedGeneration: "sha256:stale-outline-generation",
+    });
+    await insertOutlineCandidate(trackOrdinal, {
+      eligibility: null,
+    });
+
+    expect(await resolveTrackOutline(trackOrdinal, "iracing")).toBeNull();
+  });
+});

--- a/test/setups/engineer/setup-engineer-apply-guard.test.ts
+++ b/test/setups/engineer/setup-engineer-apply-guard.test.ts
@@ -26,16 +26,15 @@ import * as RealTestQueries from "../../../server/db/experiment-version-queries"
 import * as RealSessionQueries from "../../../server/db/experiment-queries";
 import * as RealChatAgent from "../../../server/ai/chat-agent";
 import * as RealAppliedMarkdown from "../../../server/setups/applied-change-markdown";
-import * as RealRepresentativeLap from "../../../server/experiments/representative-lap";
 import * as RealTrackConditions from "../../../server/ai/track-conditions";
 import * as RealSetupLineage from "../../../server/experiments/setup-lineage";
 import * as RealLapReadQueries from "../../../server/db/lap-read-queries";
 import * as RealExperimentLapQueries from "../../../server/db/experiment-lap-queries";
 import * as RealActionQueries from "../../../server/db/experiment-action-queries";
-import * as RealUndo from "../../../server/experiments/undo"
+import * as RealUndo from "../../../server/experiments/undo";
 import * as RealConsult from "../../../server/ai/consult-lap-analyst";
 import * as RealCleanLap from "../../../server/experiments/lap-evidence/aggregate";
-import * as RealComparison from "../../../server/lap-analysis/comparison"
+import * as RealComparison from "../../../server/lap-analysis/comparison";
 import * as RealSettings from "../../../server/runtime/config/settings";
 import * as RealMastraModel from "../../../mastra/model";
 
@@ -93,12 +92,27 @@ mock.module("../../../server/setups/io", () => ({
 mock.module("../../../server/db/experiment-version-queries", () => ({
   ...RealTestQueries,
   createExperimentVersion: gate(RealTestQueries.createExperimentVersion, createExperimentVersion),
-  deleteTestSubtree: gate(RealTestQueries.deleteTestSubtree, mock(async () => {})),
-  getExperimentVersion: gate(RealTestQueries.getExperimentVersion, mock(async () => ({ id: 1, version: 1 }))),
-  getExperimentVersionsByLabel: gate(RealTestQueries.getExperimentVersionsByLabel, mock(async () => null)),
-  resolveActiveTestId: gate(RealTestQueries.resolveActiveTestId, mock(async () => 1)),
+  deleteTestSubtree: gate(
+    RealTestQueries.deleteTestSubtree,
+    mock(async () => {}),
+  ),
+  getExperimentVersion: gate(
+    RealTestQueries.getExperimentVersion,
+    mock(async () => ({ id: 1, version: 1 })),
+  ),
+  getExperimentVersionsByLabel: gate(
+    RealTestQueries.getExperimentVersionsByLabel,
+    mock(async () => null),
+  ),
+  resolveActiveTestId: gate(
+    RealTestQueries.resolveActiveTestId,
+    mock(async () => 1),
+  ),
   setExperimentVersionNote: gate(RealTestQueries.setExperimentVersionNote, setExperimentVersionNote),
-  setExperimentVersionNotes: gate(RealTestQueries.setExperimentVersionNotes, mock(async () => {})),
+  setExperimentVersionNotes: gate(
+    RealTestQueries.setExperimentVersionNotes,
+    mock(async () => {}),
+  ),
 }));
 mock.module("../../../server/db/experiment-queries", () => ({
   ...RealSessionQueries,
@@ -106,34 +120,53 @@ mock.module("../../../server/db/experiment-queries", () => ({
 }));
 mock.module("../../../server/ai/chat-agent", () => ({
   ...RealChatAgent,
-  saveAssistantChatMessage: gate(RealChatAgent.saveAssistantChatMessage, mock(async () => {})),
-  getChatMemory: gate(RealChatAgent.getChatMemory, mock(() => null)),
+  saveAssistantChatMessage: gate(
+    RealChatAgent.saveAssistantChatMessage,
+    mock(async () => {}),
+  ),
+  getChatMemory: gate(
+    RealChatAgent.getChatMemory,
+    mock(() => null),
+  ),
 }));
 mock.module("../../../server/setups/applied-change-markdown", () => ({
   ...RealAppliedMarkdown,
-  buildAppliedChangesMarkdown: gate(RealAppliedMarkdown.buildAppliedChangesMarkdown, mock(() => "")),
-}));
-mock.module("../../../server/experiments/representative-lap", () => ({
-  ...RealRepresentativeLap,
-  computeSessionSymptoms: gate(RealRepresentativeLap.computeSessionSymptoms, mock(async () => [])),
-  computeSessionTrackConditions: gate(RealRepresentativeLap.computeSessionTrackConditions, mock(async () => null)),
+  buildAppliedChangesMarkdown: gate(
+    RealAppliedMarkdown.buildAppliedChangesMarkdown,
+    mock(() => ""),
+  ),
 }));
 mock.module("../../../server/ai/track-conditions", () => ({
   ...RealTrackConditions,
-  formatTrackConditions: gate(RealTrackConditions.formatTrackConditions, mock(() => "")),
+  formatTrackConditions: gate(
+    RealTrackConditions.formatTrackConditions,
+    mock(() => ""),
+  ),
 }));
 mock.module("../../../server/experiments/setup-lineage", () => ({
   ...RealSetupLineage,
-  loadActiveExperimentContext: gate(RealSetupLineage.loadActiveExperimentContext, mock(async () => fakeCtx)),
+  loadActiveExperimentContext: gate(
+    RealSetupLineage.loadActiveExperimentContext,
+    mock(async () => fakeCtx),
+  ),
 }));
 mock.module("../../../server/db/lap-read-queries", () => ({
   ...RealLapReadQueries,
-  getLapById: gate(RealLapReadQueries.getLapById, mock(async () => null)),
+  getLapById: gate(
+    RealLapReadQueries.getLapById,
+    mock(async () => null),
+  ),
 }));
 mock.module("../../../server/db/experiment-lap-queries", () => ({
   ...RealExperimentLapQueries,
-  setLapExperimentExcluded: gate(RealExperimentLapQueries.setLapExperimentExcluded, mock(async () => {})),
-  getLapsForExperiment: gate(RealExperimentLapQueries.getLapsForExperiment, mock(async () => [])),
+  setLapExperimentExcluded: gate(
+    RealExperimentLapQueries.setLapExperimentExcluded,
+    mock(async () => {}),
+  ),
+  getLapsForExperiment: gate(
+    RealExperimentLapQueries.getLapsForExperiment,
+    mock(async () => []),
+  ),
 }));
 mock.module("../../../server/db/experiment-action-queries", () => ({
   ...RealActionQueries,
@@ -141,32 +174,50 @@ mock.module("../../../server/db/experiment-action-queries", () => ({
 }));
 mock.module("../../../server/experiments/undo", () => ({
   ...RealUndo,
-  undoLastAction: gate(RealUndo.undoLastAction, mock(async () => ({ ok: true }))),
+  undoLastAction: gate(
+    RealUndo.undoLastAction,
+    mock(async () => ({ ok: true })),
+  ),
 }));
 mock.module("../../../server/ai/consult-lap-analyst", () => ({
   ...RealConsult,
-  consultLapAnalystForSession: gate(RealConsult.consultLapAnalystForSession, mock(async () => ({ ok: true, text: "" }))),
+  consultLapAnalystForSession: gate(
+    RealConsult.consultLapAnalystForSession,
+    mock(async () => ({ ok: true, text: "" })),
+  ),
 }));
 mock.module("../../../server/experiments/lap-evidence/aggregate", () => ({
   ...RealCleanLap,
-  loadCleanLapAggregate: gate(RealCleanLap.loadCleanLapAggregate, mock(async () => null)),
+  loadCleanLapAggregate: gate(
+    RealCleanLap.loadCleanLapAggregate,
+    mock(async () => null),
+  ),
 }));
 mock.module("../../../server/lap-analysis/comparison", () => ({
   ...RealComparison,
-  compareLaps: gate(RealComparison.compareLaps, mock(() => ({}))),
+  compareLaps: gate(
+    RealComparison.compareLaps,
+    mock(() => ({})),
+  ),
 }));
 mock.module("../../../server/runtime/config/settings", () => ({
   ...RealSettings,
-  loadSettings: gate(RealSettings.loadSettings, mock(() => ({ ai: {} }))),
+  loadSettings: gate(
+    RealSettings.loadSettings,
+    mock(() => ({ ai: {} })),
+  ),
 }));
 mock.module("../../../mastra/model", () => ({
   ...RealMastraModel,
-  getMastraModelId: gate(RealMastraModel.getMastraModelId, mock(() => "fake/model")),
+  getMastraModelId: gate(
+    RealMastraModel.getMastraModelId,
+    mock(() => "fake/model"),
+  ),
 }));
 
 const { setupEngineerTools } = await import("../../../mastra/tools/setup-engineer");
 
-const requestContext = { get: (k: string) => ({ gameId: "acc", sessionId: 61 } as any)[k] };
+const requestContext = { get: (k: string) => (({ gameId: "acc", sessionId: 61 }) as any)[k] };
 
 describe("apply_changes — no-op guard when every change is skipped", () => {
   test("returns ok:false with skipped reasons and creates NO version", async () => {
@@ -203,10 +254,7 @@ describe("record_driver_notes — driver confirmation guard", () => {
   test("refuses to write the driver note without driverConfirmed", async () => {
     setExperimentVersionNote.mockClear();
 
-    const result: any = await setupEngineerTools.recordDriverNotesTool.execute!(
-      { note: "understeer on entry into T1", driverConfirmed: false },
-      { requestContext } as any,
-    );
+    const result: any = await setupEngineerTools.recordDriverNotesTool.execute!({ note: "understeer on entry into T1", driverConfirmed: false }, { requestContext } as any);
 
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/confirm|approve/i);
@@ -216,10 +264,7 @@ describe("record_driver_notes — driver confirmation guard", () => {
   test("writes the note once the driver has confirmed it", async () => {
     setExperimentVersionNote.mockClear();
 
-    const result: any = await setupEngineerTools.recordDriverNotesTool.execute!(
-      { note: "understeer on entry into T1", driverConfirmed: true },
-      { requestContext } as any,
-    );
+    const result: any = await setupEngineerTools.recordDriverNotesTool.execute!({ note: "understeer on entry into T1", driverConfirmed: true }, { requestContext } as any);
 
     expect(result.ok).toBe(true);
     expect(setExperimentVersionNote).toHaveBeenCalledTimes(1);

--- a/test/support/experiments/arms.ts
+++ b/test/support/experiments/arms.ts
@@ -3,6 +3,15 @@ import type { ArmLap } from "../../../server/experiments/comparison/metrics";
 import type { FrameLapMeta, LapFrameLoader } from "../../../server/experiments/comparison/stream";
 import type { Corner } from "../../../server/lap-analysis/corners";
 import type { EvaluableLap } from "../../../shared/racing/laps/review-selection";
+import {
+  ELIGIBILITY_POLICY_VERSION,
+  QUALITY_CONFIG_VERSION,
+  QUALITY_SCHEMA_VERSION,
+  type EligibilityDecision,
+  type EligibilityDecisionSet,
+  type EligibilityStatus,
+  type LapQualitySummary,
+} from "../../../shared/racing/quality/contracts";
 import type { TelemetryPacket } from "../../../shared/telemetry/types";
 
 /** Deterministic synthetic corner shared by frame-based arm suites. */
@@ -10,6 +19,42 @@ export const SYNTHETIC_CORNERS: Corner[] = [{ index: 1, label: "T1", distanceSta
 export const FRAMES_PER_LAP = 121;
 const LAP_TIME_OFFSETS = [0.32, 0.05, 0.71, 0.18, 0.94, 0.43, 0.6, 0.27, 0.85, 0.11];
 export const CORNERS = SYNTHETIC_CORNERS;
+
+const TEST_QUALITY = {
+  lifecycleState: "exact",
+  complete: true,
+  structurallyValid: true,
+  facts: [],
+  provenance: {
+    schemaVersion: QUALITY_SCHEMA_VERSION,
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+    configurationVersion: QUALITY_CONFIG_VERSION,
+    sourceGeneration: "sha256:experiment-arm-source",
+    outputGeneration: "sha256:experiment-arm-quality",
+  },
+} as unknown as LapQualitySummary;
+
+function policyDecision(policyId: EligibilityDecision["policyId"], status: EligibilityStatus): EligibilityDecision {
+  return {
+    status,
+    policyId,
+    policyVersion: ELIGIBILITY_POLICY_VERSION,
+    confidence: { level: status === "eligible" ? "high" : "low", score: status === "eligible" ? 1 : 0 },
+    reasons: [],
+    evidenceIds: [],
+  };
+}
+
+export function qualityEvidence(isValid: boolean): Pick<EvaluableLap, "quality" | "eligibility"> {
+  const status = isValid ? "eligible" : "ineligible";
+  return {
+    quality: TEST_QUALITY,
+    eligibility: {
+      "normal-pace": policyDecision("normal-pace", status),
+      "corner-trace": policyDecision("corner-trace", status),
+    } as EligibilityDecisionSet,
+  };
+}
 
 /** Straight-line lap (600m along Z) with one corner at 200..300m. */
 export function syntheticLap(lateralOffsetM: number, brakeShiftM: number): TelemetryPacket[] {
@@ -49,6 +94,7 @@ export function metadataArm(lapTimes: number[], labelPrefix = "arm"): { label: s
       invalidReason: null,
       experimentExcluded: false,
       experimentExcludedSource: null,
+      ...qualityEvidence(true),
     };
     return { lap, telemetry: null };
   });
@@ -82,10 +128,7 @@ export function normals(n: number, meanV: number, sd: number, seed: number): num
 }
 
 /** Build a frame-bearing arm using deterministic synthetic packets. */
-export function telemetryArm(
-  specs: { lateral: number; brakeShift: number }[],
-  label = "telemetry-arm",
-): ArmInput {
+export function telemetryArm(specs: { lateral: number; brakeShift: number }[], label = "telemetry-arm"): ArmInput {
   const laps: ArmLap[] = specs.map((spec, i) => ({
     lap: {
       id: nextMetadataId++,
@@ -94,6 +137,7 @@ export function telemetryArm(
       invalidReason: null,
       experimentExcluded: false,
       experimentExcludedSource: null,
+      ...qualityEvidence(true),
     },
     telemetry: syntheticLap(spec.lateral, spec.brakeShift),
   }));
@@ -124,6 +168,7 @@ export function buildStreamingArm(specs: LapSpec[], firstId = 1) {
       invalidReason: null,
       experimentExcluded: false,
       experimentExcludedSource: null,
+      ...qualityEvidence(spec.isValid ?? true),
     };
     metas.push({ ...lap, lapNumber: i + 1, createdAt: `2026-01-01T00:0${i % 10}:00Z`, rawFrameCount });
     if (rawFrameCount > 0) frames.set(id, syntheticLap(spec.lateral, spec.brakeShift));


### PR DESCRIPTION
Replacement for closed #272 after reviewer remediation.

Part 6 of 8 for #231

Parent: #271. Base: `issue-229/05-import-replay`.

## Behavior
- Gate AI, comparison, experiment, recap, setup, and route consumers with policy-specific current-session quality.
- Keep explicit stale or unsuitable requests actionable without mutating cached analysis or chat state.

## Focused verification
- `Focused route, AI provenance, experiment curation, lap analysis, setup guard, and final detector policy suites.`
- `bun run typecheck`