### PR TITLE
feat(strategy): consume policy-specific lap evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - Keep every recorded experiment lap available for inspection in Tune Review while limiting aggregate setup evaluation to its curated evidence pool
 - Preserve telemetry warning reasons in setup-analysis decisions and Setup Engineer lap summaries
 - Clear displayed comparison analysis and conversations when either lap quality generation changes
+- Collect recent fuel and tire history independently so several fuel-only laps cannot prevent older tire data from seeding strategy estimates, and vice versa
+- Regenerate cached driver profiles when underlying lap quality or eligibility changes
 - Make stale-session reprocessing recoverable with retry and dismissal actions, accessible progress states, and clear failure feedback
 - Skip unavailable raw captures during stale-session reprocessing instead of failing the entire maintenance run
 - Keep newly started session captures from being removed by concurrent storage cleanup

--- a/server/driver-profile/README.md
+++ b/server/driver-profile/README.md
@@ -6,7 +6,7 @@ Build deterministic, game-scoped driver fingerprints from stored laps and genera
 
 ## Structure
 
-- `load.ts` loads the newest usable telemetry and aligns metadata, insights, and style summaries.
+- `load.ts` loads newest telemetry accepted by shared `driver-profile` eligibility and aligns metadata, insights, style summaries, and quality generation.
 - `detectors.ts` aggregates per-lap findings and derives ranked weaknesses and style axes.
 - `trend.ts` normalizes pace within game/car/track contexts and compares recent and previous windows.
 - `fingerprint.ts` assembles the stable persisted fingerprint contract.
@@ -16,7 +16,7 @@ Build deterministic, game-scoped driver fingerprints from stored laps and genera
 
 ## Boundaries and invariants
 
-Fingerprints are global to one selected game. Trend input is newest-first; detector results remain paired with lap metadata before deterministic lap-id sorting. Missing measurements stay `null`, detector frequencies are per-lap, and unquantified weaknesses remain separate from time-loss rankings. Prompt text contains trend evidence only. Runner writes a result only when its lap-pool key is still current and no newer successful run exists.
+Fingerprints are global to one selected game. Input laps must pass the shared `driver-profile` decision; local validity or ad hoc pace filters are not substitutes. Trend input is newest-first, and detector results remain paired with lap metadata before deterministic lap-id sorting. Missing measurements stay `null`, detector frequencies are per-lap, and unquantified weaknesses remain separate from time-loss rankings. Prompt text contains trend evidence only. Runner writes a result only when its lap-pool key and quality generation are still current and no newer successful run exists.
 
 Database access, telemetry decoding, AI providers, settings, and HTTP routing stay outside this domain's pure calculation modules.
 

--- a/server/driver-profile/fingerprint.ts
+++ b/server/driver-profile/fingerprint.ts
@@ -10,15 +10,8 @@ import type { LapInsight } from "../../shared/racing/analysis/laps/insights/type
 import type { GameId } from "../../shared/games/ids";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import type { Confidence } from "../experiments/lap-evidence/aggregate";
-import {
-  computeStyleAxes,
-  MIN_LAPS_FOR_STYLE,
-  rankWeaknesses,
-  rollUpDetectors,
-  type DetectorStat,
-  type RankedWeakness,
-  type StyleAxes,
-} from "./detectors";
+import type { EligibilityDecision } from "../../shared/racing/quality/contracts";
+import { computeStyleAxes, MIN_LAPS_FOR_STYLE, rankWeaknesses, rollUpDetectors, type DetectorStat, type RankedWeakness, type StyleAxes } from "./detectors";
 import { buildDriverTrend, type DriverTrend } from "./trend";
 
 type ProfileScopeKind = "car-track" | "global";
@@ -42,6 +35,7 @@ export interface DriverFingerprint {
   scope: ProfileScope;
   laps: LapPoolReport;
   confidence: Confidence;
+  eligibility: EligibilityDecision | null;
   style: StyleAxes | null;
   trend: DriverTrend;
   weaknesses: RankedWeakness[];
@@ -57,17 +51,13 @@ function confidenceFor(lapCount: number): Confidence {
   return "very-low";
 }
 
-export function emptyFingerprint(
-  scope: ProfileScope,
-  laps: Partial<LapPoolReport> = {},
-  notes: string[] = [],
-  trend: DriverTrend = buildDriverTrend([]),
-): DriverFingerprint {
+export function emptyFingerprint(scope: ProfileScope, laps: Partial<LapPoolReport> = {}, notes: string[] = [], trend: DriverTrend = buildDriverTrend([])): DriverFingerprint {
   return {
     ok: trend.recent.total > 0,
     scope,
     laps: { lapIds: [], analyzed: 0, candidates: 0, droppedNoTelemetry: 0, ...laps },
     confidence: "very-low",
+    eligibility: null,
     style: null,
     trend,
     weaknesses: [],
@@ -82,6 +72,7 @@ export function emptyFingerprint(
  * Sorting by lap id makes output stable when input order differs.
  */
 export function buildDriverFingerprint(input: {
+  eligibility?: EligibilityDecision | null;
   scope: ProfileScope;
   laps: readonly LapMeta[];
   perLapInsights: readonly (readonly LapInsight[])[];
@@ -93,9 +84,7 @@ export function buildDriverFingerprint(input: {
   const { scope } = input;
   const notes = [...(input.notes ?? [])];
   const trend = input.trend ?? buildDriverTrend(input.laps);
-  const paired = input.laps
-    .map((lap, i) => ({ lap, insights: input.perLapInsights[i] ?? [], style: input.perLapStyle?.[i] }))
-    .sort((a, b) => a.lap.id - b.lap.id);
+  const paired = input.laps.map((lap, i) => ({ lap, insights: input.perLapInsights[i] ?? [], style: input.perLapStyle?.[i] })).sort((a, b) => a.lap.id - b.lap.id);
   const laps = paired.map((p) => p.lap);
   const perLapInsights = paired.map((p) => p.insights);
   const styleSummaries = paired.map((p) => p.style).filter((s): s is LapStyleSummary => s !== undefined);
@@ -130,6 +119,7 @@ export function buildDriverFingerprint(input: {
       droppedNoTelemetry: pool.droppedNoTelemetry ?? 0,
     },
     confidence: confidenceFor(lapCount),
+    eligibility: input.eligibility ?? null,
     style,
     trend,
     weaknesses,

--- a/server/driver-profile/load.ts
+++ b/server/driver-profile/load.ts
@@ -2,6 +2,7 @@ import { summariseLapStyle, type LapStyleSummary } from "../../shared/racing/ana
 import { analyzeLap } from "../../shared/racing/analysis/laps/insights/analyze";
 import type { LapInsight } from "../../shared/racing/analysis/laps/insights/types";
 import type { GameId } from "../../shared/games/ids";
+import { evaluateGroupEligibility, isEligibilityUsable, selectDriverProfileEligibleLaps } from "../../shared/racing/quality/policies";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import { getLapMetaForProfileScope, getLapsByIds } from "../db/lap-read-queries";
 import { buildDriverFingerprint, emptyFingerprint, type DriverFingerprint, type ProfileScope } from "./fingerprint";
@@ -14,12 +15,32 @@ const MIN_TELEMETRY_FRAMES = 30;
 export async function loadDriverProfile(opts: { gameId: GameId }): Promise<DriverFingerprint> {
   const scope: ProfileScope = { kind: "global", gameId: opts.gameId, carOrdinal: null, trackOrdinal: null };
   const pool = await getLapMetaForProfileScope(opts.gameId);
+  const groupPool = pool.flatMap((lap) =>
+    lap.quality && lap.eligibility
+      ? [
+          {
+            lapId: lap.id,
+            lapTime: lap.lapTime,
+            createdAt: lap.createdAt,
+            carTrackKey: `${lap.gameId ?? opts.gameId}:${lap.carOrdinal ?? "unknown"}:${lap.trackOrdinal ?? "unknown"}`,
+            quality: lap.quality,
+            eligibility: lap.eligibility,
+          },
+        ]
+      : [],
+  );
+  const profileDecision = evaluateGroupEligibility("driver-profile", groupPool);
+  const selectedIds = new Set(selectDriverProfileEligibleLaps(groupPool).map((lap) => lap.lapId));
+  const candidates = isEligibilityUsable(profileDecision) ? pool.filter((lap) => selectedIds.has(lap.id)) : [];
   const trend = buildDriverTrend(pool);
-  if (pool.length === 0) {
-    return emptyFingerprint(scope, { candidates: 0 }, ["No laps recorded for this scope."], trend);
+  if (candidates.length === 0) {
+    return {
+      ...emptyFingerprint(scope, { candidates: 0 }, ["No policy-eligible laps recorded for this scope."], trend),
+      eligibility: profileDecision,
+    };
   }
 
-  const selected = pool.slice(0, DRIVER_TREND_WINDOW_LAPS);
+  const selected = candidates.slice(0, DRIVER_TREND_WINDOW_LAPS);
   const loaded = await getLapsByIds(selected.map((lap) => lap.id));
   const metaById = new Map(selected.map((lap) => [lap.id, lap]));
   const laps: LapMeta[] = [];
@@ -35,7 +56,7 @@ export async function loadDriverProfile(opts: { gameId: GameId }): Promise<Drive
     }
     const lapGame = meta.gameId ?? opts.gameId;
     laps.push(meta);
-    perLapInsights.push(analyzeLap(lap.telemetry, lapGame));
+    perLapInsights.push(analyzeLap(lap.telemetry, lapGame, meta.quality));
     perLapStyle.push(summariseLapStyle(lap.telemetry, lapGame));
   }
 
@@ -45,6 +66,7 @@ export async function loadDriverProfile(opts: { gameId: GameId }): Promise<Drive
     perLapInsights,
     perLapStyle,
     trend,
-    pool: { candidates: pool.length, droppedNoTelemetry },
+    eligibility: profileDecision,
+    pool: { candidates: candidates.length, droppedNoTelemetry },
   });
 }

--- a/server/driver-profile/runner.ts
+++ b/server/driver-profile/runner.ts
@@ -2,16 +2,13 @@ import { createHash } from "node:crypto";
 
 import type { GameId } from "../../shared/games/ids";
 import { tryGetGame } from "../../shared/games/registry";
+import type { LapMeta } from "../../shared/racing/sessions/types";
 import { loadSettings } from "../runtime/config/settings";
 import { getSecret } from "../runtime/platform/keystore";
 import { toClientAiError, type ClientAiError } from "../ai/provider-error";
 import { driverProfilerAgent } from "../ai/agents";
 import { buildDriverProfilerPrompt } from "./prompt";
-import {
-  getDriverProfileSummaryJsonSchema,
-  parseDriverProfileSummary,
-  type DriverProfileSummary,
-} from "../ai/schemas";
+import { getDriverProfileSummaryJsonSchema, parseDriverProfileSummary, type DriverProfileSummary } from "../ai/schemas";
 import { buildGoogleProviderOptions } from "../ai/google-provider-options";
 import type { DriverFingerprint } from "./fingerprint";
 import { loadDriverProfile } from "./load";
@@ -51,9 +48,13 @@ const BACKGROUND_LAP_BATCH = 5;
 export const DRIVER_PROFILE_DEFAULT_OUTPUT_TOKENS = 5_000;
 export const DRIVER_PROFILE_MAX_OUTPUT_TOKENS = 32_768;
 
-export function driverProfilePoolKey(lapIds: readonly number[]): string {
+export function driverProfilePoolKey(laps: readonly Pick<LapMeta, "id" | "qualityGeneration" | "qualityStale">[]): string {
+  const evidence = laps
+    .slice(0, 60)
+    .sort((left, right) => left.id - right.id)
+    .map((lap) => [lap.id, lap.qualityGeneration ?? null, lap.qualityStale ?? null]);
   return createHash("sha1")
-    .update(`driver-trend-summary-v1|${lapIds.slice(0, 60).sort((a, b) => a - b).join(",")}`)
+    .update(`driver-trend-summary-v2|${JSON.stringify(evidence)}`)
     .digest("hex")
     .slice(0, 16);
 }
@@ -79,11 +80,7 @@ function normalizedError(err: unknown): { message: string; details: ClientAiErro
 export function logDriverProfileFailure(runId: number, model: string, error: string): void {
   console.error(`[AI] Driver profile run ${runId} failed (model=${model}): ${error}`);
 }
-export function logDriverProfileOutput(
-  runId: number,
-  model: string,
-  result: { text?: unknown; object?: unknown; reasoning?: unknown; finishReason?: unknown; usage?: unknown },
-): void {
+export function logDriverProfileOutput(runId: number, model: string, result: { text?: unknown; object?: unknown; reasoning?: unknown; finishReason?: unknown; usage?: unknown }): void {
   let output = typeof result.text === "string" ? result.text : "";
   if (!output && typeof result.reasoning === "string") output = `[reasoning-only] ${result.reasoning}`;
   if (result.object !== undefined) {
@@ -95,17 +92,9 @@ export function logDriverProfileOutput(
   }
   const finishReason = typeof result.finishReason === "string" ? result.finishReason : "<unknown>";
   const usage = result.usage === undefined ? "<none>" : JSON.stringify(result.usage);
-  console.error(
-    `[AI] Driver profile run ${runId} raw output (model=${model}, finishReason=${finishReason}, usage=${usage}, resultKeys=${Object.keys(result).join(",")}): ${output || "<empty>"}`,
-  );
+  console.error(`[AI] Driver profile run ${runId} raw output (model=${model}, finishReason=${finishReason}, usage=${usage}, resultKeys=${Object.keys(result).join(",")}): ${output || "<empty>"}`);
 }
-async function failDriverProfileRun(
-  scope: DriverProfileScope,
-  runId: number,
-  fingerprint: DriverFingerprint,
-  error: string,
-  durationMs: number,
-): Promise<DriverProfileRunResult> {
+async function failDriverProfileRun(scope: DriverProfileScope, runId: number, fingerprint: DriverFingerprint, error: string, durationMs: number): Promise<DriverProfileRunResult> {
   await updateDriverProfileRun(runId, scopeKey(scope), "running", {
     status: "failed",
     error,
@@ -116,10 +105,7 @@ async function failDriverProfileRun(
   return { status: "failed", run: await getDriverProfileRun(runId), fingerprint, error };
 }
 
-async function providerConfiguration(): Promise<
-  | { ok: true; provider: "gemini" | "openai" | "local"; model: string; thinkingBudget: number | null }
-  | { ok: false; reason: string }
-> {
+async function providerConfiguration(): Promise<{ ok: true; provider: "gemini" | "openai" | "local"; model: string; thinkingBudget: number | null } | { ok: false; reason: string }> {
   const settings = loadSettings();
   const provider = settings.driverProfileProvider;
   if (!provider) return { ok: false, reason: "No driver-profile AI provider is configured." };
@@ -140,9 +126,7 @@ async function providerConfiguration(): Promise<
   return {
     ok: true,
     provider,
-    model:
-      settings.driverProfileModel ||
-      (provider === "openai" ? "gpt-4o-mini" : provider === "local" ? "local-model" : "gemini-flash-latest"),
+    model: settings.driverProfileModel || (provider === "openai" ? "gpt-4o-mini" : provider === "local" ? "local-model" : "gemini-flash-latest"),
     thinkingBudget: settings.driverProfileThinkingBudget,
   };
 }
@@ -153,20 +137,15 @@ export async function getDriverProfileConfiguration(): Promise<{
 }> {
   const settings = loadSettings();
   const config = await providerConfiguration();
-  return config.ok
-    ? { enabled: settings.driverProfileBackgroundEnabled, configured: true }
-    : { enabled: settings.driverProfileBackgroundEnabled, configured: false, reason: config.reason };
+  return config.ok ? { enabled: settings.driverProfileBackgroundEnabled, configured: true } : { enabled: settings.driverProfileBackgroundEnabled, configured: false, reason: config.reason };
 }
 
-async function runDriverProfileInternal(
-  scope: DriverProfileScope,
-  options: DriverProfileRunOptions,
-): Promise<DriverProfileRunResult> {
+async function runDriverProfileInternal(scope: DriverProfileScope, options: DriverProfileRunOptions): Promise<DriverProfileRunResult> {
   const config = await providerConfiguration();
   if (!config.ok) return { status: "not-configured", run: null, error: config.reason };
 
   const candidates = await getLapMetaForProfileScope(scope.gameId);
-  const poolKey = driverProfilePoolKey(candidates.map((lap) => lap.id));
+  const poolKey = driverProfilePoolKey(candidates);
   const existing = await findDriverProfileRunByScopePool(scope, poolKey);
   if (existing && (existing.status === "queued" || existing.status === "running")) {
     if (!options.force) return { status: existing.status, run: existing };
@@ -188,13 +167,7 @@ async function runDriverProfileInternal(
   try {
     fingerprint = await loadDriverProfile({ gameId: scope.gameId });
     if (!fingerprint.ok) {
-      return await failDriverProfileRun(
-        scope,
-        runId,
-        fingerprint,
-        "Not enough valid laps to build a driver profile.",
-        Date.now() - startedAt,
-      );
+      return await failDriverProfileRun(scope, runId, fingerprint, "Not enough valid laps to build a driver profile.", Date.now() - startedAt);
     }
 
     const prompt = buildDriverProfilerPrompt({
@@ -214,29 +187,15 @@ async function runDriverProfileInternal(
             },
           },
         } as never,
-        google: buildGoogleProviderOptions(
-          config.model,
-          getDriverProfileSummaryJsonSchema() as Record<string, unknown>,
-          config.thinkingBudget,
-        ) as never,
+        google: buildGoogleProviderOptions(config.model, getDriverProfileSummaryJsonSchema() as Record<string, unknown>, config.thinkingBudget) as never,
       },
     });
 
     const parsed = parseDriverProfileSummary(typeof result.text === "string" ? result.text : "");
     if (!parsed.success) {
       logDriverProfileOutput(runId, config.model, result);
-      logDriverProfileFailure(
-        runId,
-        config.model,
-        "Model produced output that did not match the expected driver profile summary shape.",
-      );
-      return await failDriverProfileRun(
-        scope,
-        runId,
-        fingerprint,
-        "Model produced output that did not match the expected driver profile summary shape.",
-        Date.now() - startedAt,
-      );
+      logDriverProfileFailure(runId, config.model, "Model produced output that did not match the expected driver profile summary shape.");
+      return await failDriverProfileRun(scope, runId, fingerprint, "Model produced output that did not match the expected driver profile summary shape.", Date.now() - startedAt);
     }
 
     const summary = parsed.data;
@@ -253,24 +212,12 @@ async function runDriverProfileInternal(
     // A background generation can finish after more laps arrive. Never let it
     // replace a cache or successful run produced for the newer pool.
     const latestCandidates = await getLapMetaForProfileScope(scope.gameId);
-    if (driverProfilePoolKey(latestCandidates.map((lap) => lap.id)) !== poolKey) {
-      return await failDriverProfileRun(
-        scope,
-        runId,
-        fingerprint,
-        "Profile data changed while generation was running; stale result discarded.",
-        usage.durationMs,
-      );
+    if (driverProfilePoolKey(latestCandidates) !== poolKey) {
+      return await failDriverProfileRun(scope, runId, fingerprint, "Profile data changed while generation was running; stale result discarded.", usage.durationMs);
     }
     const history = await listDriverProfileRuns(scope, 100);
     if (history.some((item) => item.id > runId && item.status === "succeeded")) {
-      return await failDriverProfileRun(
-        scope,
-        runId,
-        fingerprint,
-        "A newer successful profile run already exists; stale result discarded.",
-        usage.durationMs,
-      );
+      return await failDriverProfileRun(scope, runId, fingerprint, "A newer successful profile run already exists; stale result discarded.", usage.durationMs);
     }
 
     await saveDriverProfile(scope, {
@@ -310,10 +257,7 @@ async function runDriverProfileInternal(
   }
 }
 
-export function runDriverProfile(
-  scope: DriverProfileScope,
-  options: DriverProfileRunOptions = {},
-): Promise<DriverProfileRunResult> {
+export function runDriverProfile(scope: DriverProfileScope, options: DriverProfileRunOptions = {}): Promise<DriverProfileRunResult> {
   const key = scopeKey(scope);
   const active = activeRuns.get(key);
   if (active) return active;
@@ -345,14 +289,17 @@ export function notifyDriverProfileLap(gameId: GameId): void {
   if (!settings.driverProfileBackgroundEnabled) return;
   void getLapMetaForProfileScope(gameId)
     .then((globalLaps) => {
-      scheduleScope({ gameId }, driverProfilePoolKey(globalLaps.map((lap) => lap.id)));
+      scheduleScope({ gameId }, driverProfilePoolKey(globalLaps));
     })
     .catch((err) => {
       console.error("[AI] Failed to schedule background driver profile:", err);
     });
 }
 
-export async function getDriverProfileRunStatus(scope: DriverProfileScope, limit = 50): Promise<{
+export async function getDriverProfileRunStatus(
+  scope: DriverProfileScope,
+  limit = 50,
+): Promise<{
   state: DriverProfileState;
   enabled: boolean;
   configured: boolean;
@@ -366,7 +313,7 @@ export async function getDriverProfileRunStatus(scope: DriverProfileScope, limit
   return {
     enabled: config.enabled,
     configured: config.configured,
-    state: !config.configured ? "not-configured" : latest?.status ?? (!config.enabled ? "disabled" : "succeeded"),
+    state: !config.configured ? "not-configured" : (latest?.status ?? (!config.enabled ? "disabled" : "succeeded")),
     reason: config.reason,
     latest,
     runs,

--- a/server/driver-profile/trend.ts
+++ b/server/driver-profile/trend.ts
@@ -1,4 +1,5 @@
 import { repeatabilityStats } from "../../shared/racing/laps/stint-stats";
+import { isTimedLapEligibilityUsable } from "../../shared/racing/quality/policies";
 import type { LapMeta } from "../../shared/racing/sessions/types";
 import { median, round4 } from "./math";
 
@@ -60,17 +61,18 @@ function direction(delta: number | null, improveAt: number, declineAt: number): 
 function trendWindow(laps: readonly LapMeta[], benchmarks: ReadonlyMap<string, number>): DriverTrendWindow {
   let valid = 0;
   const comparableContexts = new Set<string>();
-  const chartLaps = laps.map((lap) => {
-    if (lap.isValid) valid++;
-    const context = trendContextKey(lap);
-    const benchmark = benchmarks.get(context);
-    if (benchmark !== undefined) comparableContexts.add(context);
-    const relativePacePct =
-      benchmark !== undefined && Number.isFinite(lap.lapTime) && lap.lapTime > 0
-        ? Math.max(0, (lap.lapTime / benchmark - 1) * 100)
-        : null;
-    return { id: lap.id, createdAt: lap.createdAt, isValid: lap.isValid, relativePacePct };
-  }).reverse();
+  const chartLaps = laps
+    .map((lap) => {
+      if (lap.isValid) valid++;
+      const context = trendContextKey(lap);
+      const benchmark = benchmarks.get(context);
+      const eligibleForPace = isTimedLapEligibilityUsable(lap);
+      if (eligibleForPace && benchmark !== undefined) comparableContexts.add(context);
+      const relativePacePct =
+        eligibleForPace && benchmark !== undefined && Number.isFinite(lap.lapTime) && lap.lapTime > 0 ? Math.max(0, (lap.lapTime / benchmark - 1) * 100) : null;
+      return { id: lap.id, createdAt: lap.createdAt, isValid: lap.isValid, relativePacePct };
+    })
+    .reverse();
   const paceValues = chartLaps.flatMap((lap) => (lap.relativePacePct === null ? [] : [lap.relativePacePct]));
   const repeatability = repeatabilityStats(paceValues.map((pace) => 1 + pace / 100));
   return {
@@ -87,24 +89,19 @@ function trendWindow(laps: readonly LapMeta[], benchmarks: ReadonlyMap<string, n
   };
 }
 
-function adviceFor(
-  recent: DriverTrendWindow,
-  previous: DriverTrendWindow,
-  paceDirection: TrendDirection,
-  consistencyDirection: TrendDirection,
-): DriverTrendAdvice[] {
+function adviceFor(recent: DriverTrendWindow, previous: DriverTrendWindow, paceDirection: TrendDirection, consistencyDirection: TrendDirection): DriverTrendAdvice[] {
   const missingMetric =
-    recent.normalized < 2 ||
-    previous.normalized < 2 ||
-    recent.consistency === null ||
-    previous.consistency === null ||
-    recent.medianPacePct === null ||
-    previous.medianPacePct === null;
+    recent.normalized < 2 || previous.normalized < 2 || recent.consistency === null || previous.consistency === null || recent.medianPacePct === null || previous.medianPacePct === null;
   let primary: DriverTrendAdvice;
   if (missingMetric) {
     primary = { id: "build-baseline", tone: "neutral", title: "Keep building the baseline", detail: "A trend needs both recent and previous windows to contain comparable pace data." };
   } else if (paceDirection === "improving" && consistencyDirection === "improving") {
-    primary = { id: "keep-approach", tone: "positive", title: "Your improvement looks repeatable", detail: "Pace and consistency moved together. Keep the approach stable instead of chasing a larger change." };
+    primary = {
+      id: "keep-approach",
+      tone: "positive",
+      title: "Your improvement looks repeatable",
+      detail: "Pace and consistency moved together. Keep the approach stable instead of chasing a larger change.",
+    };
   } else if (paceDirection === "improving" && consistencyDirection === "declining") {
     primary = { id: "stabilize-pace", tone: "caution", title: "Consolidate the new speed", detail: "Pace improved while repeatability fell. Hold the current pace until consistency returns." };
   } else if (consistencyDirection === "improving" && (paceDirection === "steady" || paceDirection === "declining")) {
@@ -112,25 +109,36 @@ function adviceFor(
   } else if (consistencyDirection === "declining" && paceDirection !== "improving") {
     primary = { id: "reset-baseline", tone: "caution", title: "Reset to a repeatable baseline", detail: "Pace and repeatability are not moving together. Reduce variation before pushing again." };
   } else {
-    primary = { id: "hold-steady", tone: "neutral", title: "Performance is stable", detail: "Neither pace nor consistency moved enough to call a trend. Change one thing at a time and keep building evidence." };
+    primary = {
+      id: "hold-steady",
+      tone: "neutral",
+      title: "Performance is stable",
+      detail: "Neither pace nor consistency moved enough to call a trend. Change one thing at a time and keep building evidence.",
+    };
   }
   const advice = [primary];
   if (recent.cleanRate !== null && previous.cleanRate !== null && recent.cleanRate - previous.cleanRate <= -0.05) {
-    advice.push({ id: "protect-validity", tone: "caution", title: "Protect validity before pushing harder", detail: "Dirty-lap rate worsened. Keep the current pace inside the valid-lap envelope before adding more risk." });
+    advice.push({
+      id: "protect-validity",
+      tone: "caution",
+      title: "Protect validity before pushing harder",
+      detail: "Dirty-lap rate worsened. Keep the current pace inside the valid-lap envelope before adding more risk.",
+    });
   }
   return advice;
 }
 
 export function buildDriverTrend(candidatesNewestFirst: readonly LapMeta[]): DriverTrend {
+  const trendLaps = candidatesNewestFirst.filter((lap) => Number.isFinite(lap.lapTime) && lap.lapTime > 0);
+  const benchmarkCandidates = trendLaps.filter((lap) => isTimedLapEligibilityUsable(lap));
   const benchmarks = new Map<string, number>();
-  for (const lap of candidatesNewestFirst) {
-    if (!lap.isValid || !Number.isFinite(lap.lapTime) || lap.lapTime <= 0) continue;
+  for (const lap of benchmarkCandidates) {
     const key = trendContextKey(lap);
     const current = benchmarks.get(key);
     if (current === undefined || lap.lapTime < current) benchmarks.set(key, lap.lapTime);
   }
-  const recent = trendWindow(candidatesNewestFirst.slice(0, DRIVER_TREND_WINDOW_LAPS), benchmarks);
-  const previous = trendWindow(candidatesNewestFirst.slice(DRIVER_TREND_WINDOW_LAPS, DRIVER_TREND_WINDOW_LAPS * 2), benchmarks);
+  const recent = trendWindow(trendLaps.slice(0, DRIVER_TREND_WINDOW_LAPS), benchmarks);
+  const previous = trendWindow(trendLaps.slice(DRIVER_TREND_WINDOW_LAPS, DRIVER_TREND_WINDOW_LAPS * 2), benchmarks);
   const consistencyDelta = recent.consistency !== null && previous.consistency !== null ? round4(recent.consistency - previous.consistency) : null;
   const paceDeltaPct = recent.medianPacePct !== null && previous.medianPacePct !== null ? round4(recent.medianPacePct - previous.medianPacePct) : null;
   const spreadDeltaPct = recent.spreadPct !== null && previous.spreadPct !== null ? round4(recent.spreadPct - previous.spreadPct) : null;

--- a/server/live-strategy/README.md
+++ b/server/live-strategy/README.md
@@ -6,7 +6,7 @@ Computes live sector timing and pit-strategy estimates from normalized telemetry
 
 ## Structure
 
-- `sector-tracker.ts` resolves curated or game-native sector layouts, tracks sector transitions, and compares live pace with the fastest valid reference lap.
+- `sector-tracker.ts` resolves curated or game-native sector layouts, tracks sector transitions, and compares live pace with the fastest timed lap accepted by shared normal-pace eligibility.
 - `pit-tracker.ts` estimates fuel range and tire life from bounded lap histories and optional distance-based wear curves.
 - `tracker-math.ts` contains shared rolling-window, interpolation, threshold, and sector-boundary operations.
 
@@ -14,9 +14,9 @@ Computes live sector timing and pit-strategy estimates from normalized telemetry
 
 - `server/telemetry` owns packet ordering, session reset order, valid-lap callbacks, and WebSocket publication. Trackers must not reorder or persist packets.
 - Sector layouts come from `server/tracks` or the active game adapter. Native layouts and authoritative track lengths remain authoritative; ACC sector transitions use its native sector index.
-- Pit history seeding reads laps through `server/db`, but the active game policy decides whether fuel and tire histories are comparable. Estimates preserve five-lap fuel, three-lap tire, three-curve wear, and existing outlier windows.
+- Pit history seeding reads laps through `server/db`; timed `fuel-burn` and `tire-analysis` eligibility select evidence, while active game policy decides comparability. Sector references update from completed live laps accepted by `normal-pace` eligibility. Estimates preserve five-lap fuel, three-lap tire, three-curve wear, and existing outlier windows.
 - Lap boundaries, teleport recovery, threshold rounding, and unavailable-value sentinels are observable behavior. Keep reset and fallback semantics unchanged.
 
 ## Testing
 
-Focused coverage lives in `test/sector-tracker.test.ts` and `test/pit-tracker.test.ts`. Use their test seams for deterministic tracker state, and cover boundary packets, reference interpolation, rolling histories, outlier rejection, and reset transitions when behavior changes.
+Focused coverage lives in `test/live-strategy/sector-tracker.test.ts` and `test/live-strategy/pit-tracker.test.ts`. Use their test seams for deterministic tracker state, and cover boundary packets, reference interpolation, rolling histories, outlier rejection, and reset transitions when behavior changes.

--- a/server/race-results/README.md
+++ b/server/race-results/README.md
@@ -17,7 +17,7 @@ Materialize durable race outcomes from captured telemetry, arbitrate conflicting
 
 ## Boundaries and invariants
 
-Telemetry packets enter through `source.ts`; database and raw-capture access is confined to reconciliation and aggregate read paths. Authority precedence is simulator final, canonical derivation, simulator live, then validated ML. Evidence outside its claim scope, policy, confidence, or age bounds is rejected before ranking. Fallback classification is created only when no classification claim exists. Pit events remain sequence-sorted and densely renumbered before persistence. Aggregate reads use persisted results only and count confirmed outcomes where required.
+Telemetry packets enter through `source.ts`; database and raw-capture access is confined to reconciliation and aggregate read paths. Authority precedence is simulator final, canonical derivation, simulator live, then validated ML. Evidence outside its claim scope, policy, confidence, or age bounds is rejected before ranking. Fallback classification is created only when no classification claim exists. Pit events remain sequence-sorted and densely renumbered before persistence. Quality linkage compares event and packet timestamps only when their game-specific clock domains match; otherwise it requires matching lap numbers. Aggregate reads use persisted results only and count confirmed outcomes where required.
 
 ## Testing
 

--- a/server/race-results/aggregates.ts
+++ b/server/race-results/aggregates.ts
@@ -1,5 +1,5 @@
-import { getRecentSessionResults } from "../db/session-result-queries";
-import type { RaceResult } from "../../shared/racing/results/types";
+import { getRecentSessionResults, loadRaceResultLapQuality } from "../db/session-result-queries";
+import type { RaceResult, RaceResultEligibilityStatusCounts, RaceResultLapQualityEvidence, RaceResultPolicyQualityAggregate } from "../../shared/racing/results/types";
 import { and, eq, sql } from "drizzle-orm";
 import type { GameId } from "../../shared/games/ids";
 import type { RaceResultAggregate } from "../../shared/racing/results/types";
@@ -12,6 +12,23 @@ export interface ResultAggregateScope {
   gameId: GameId;
   carOrdinal?: number;
   trackOrdinal?: number;
+}
+function summarizePolicyQuality(evidence: readonly RaceResultLapQualityEvidence[], policy: "officialTiming" | "normalPace"): RaceResultPolicyQualityAggregate {
+  const statuses: RaceResultEligibilityStatusCounts = {
+    eligible: 0,
+    eligible_with_warning: 0,
+    ineligible: 0,
+    unknown: 0,
+  };
+  const reasons: RaceResultPolicyQualityAggregate["reasons"] = {};
+  for (const lap of evidence) {
+    const decision = lap[policy];
+    statuses[decision.status] += 1;
+    for (const reason of decision.reasons) {
+      reasons[reason.code] = (reasons[reason.code] ?? 0) + 1;
+    }
+  }
+  return { statuses, reasons };
 }
 
 export async function getRaceResultAggregate(scope: ResultAggregateScope): Promise<RaceResultAggregate> {
@@ -48,6 +65,14 @@ export async function getRaceResultAggregate(scope: ResultAggregateScope): Promi
     .innerJoin(sessions, eq(sessionResults.sessionId, sessions.id))
     .where(and(...filters))
     .all();
+  const sessionRows = await db
+    .select({ id: sessions.id })
+    .from(sessionResults)
+    .innerJoin(sessions, eq(sessionResults.sessionId, sessions.id))
+    .where(and(...filters))
+    .all();
+  const lapQualityBySession = await loadRaceResultLapQuality(sessionRows.map(({ id }) => id));
+  const lapQuality = sessionRows.flatMap(({ id }) => lapQualityBySession.get(id) ?? []);
   const value = (input: number | null | undefined) => Number(input ?? 0);
   return {
     gameId: scope.gameId,
@@ -69,10 +94,15 @@ export async function getRaceResultAggregate(scope: ResultAggregateScope): Promi
     qualifyingToRaceMovement: null,
     tyreStrategyAvailable: value(row?.tyreAvailable) > 0,
     fuelStrategyAvailable: value(row?.fuelAvailable) > 0,
+    lapQuality: {
+      total: lapQuality.length,
+      officialTiming: summarizePolicyQuality(lapQuality, "officialTiming"),
+      normalPace: summarizePolicyQuality(lapQuality, "normalPace"),
+    },
   };
 }
 
 export async function getRecentRaceResults(gameId: GameId, limit = 10): Promise<RaceResult[]> {
   const boundedLimit = Math.max(1, Math.min(50, Math.trunc(limit)));
-  return await getRecentSessionResults(gameId, boundedLimit) as RaceResult[];
+  return (await getRecentSessionResults(gameId, boundedLimit)) as RaceResult[];
 }

--- a/server/race-results/reconcile.ts
+++ b/server/race-results/reconcile.ts
@@ -5,6 +5,7 @@ import { getLapsByIds } from "../db/lap-read-queries";
 import { getLapsForSession } from "../db/lap-reprocessing-queries";
 import { getSessions } from "../db/session-queries";
 import { getSessionResult, getStaleRaceResultSessionIds, upsertSessionResult } from "../db/session-result-queries";
+import { linkSessionQualityEvents } from "../db/quality-event-queries";
 import { getSessionRawFile, getSessionTelemetry } from "../db/telemetry-replay-storage";
 import { deriveRaceResult, normalizeSessionType } from "./derive";
 import { extractRaceSource } from "./source";
@@ -114,7 +115,8 @@ export async function reconcileSessionResult(sessionId: number, gameId: GameId):
     canonicalInput: canonicalInputIdentity(sessionId, packets),
   };
   const existing = await getSessionResult(sessionId, gameId);
-  const unchanged = existing != null &&
+  const unchanged =
+    existing != null &&
     existing.processorVersion === RACE_RESULT_PROCESSOR_ID &&
     existing.sessionType === derived.sessionType &&
     existing.classification === derived.classification &&
@@ -132,7 +134,8 @@ export async function reconcileSessionResult(sessionId: number, gameId: GameId):
     existing.events.length === derived.events.length &&
     existing.events.every((event, index) => {
       const expected = derived.events[index];
-      return expected != null &&
+      return (
+        expected != null &&
         event.sequence === expected.sequence &&
         event.eventType === (expected.eventType ?? "pit") &&
         event.positionBefore === (expected.positionBefore ?? null) &&
@@ -146,25 +149,30 @@ export async function reconcileSessionResult(sessionId: number, gameId: GameId):
         event.fuelAfter === expected.fuelAfter &&
         event.linkage === expected.linkage &&
         JSON.stringify(event.tyreChange) === JSON.stringify(expected.tyreChange) &&
-        JSON.stringify(event.source) === JSON.stringify(expected.source);
+        JSON.stringify(event.source) === JSON.stringify(expected.source)
+      );
     });
-  await upsertSessionResult({
-    sessionId,
-    processorVersion: RACE_RESULT_PROCESSOR_ID,
-    sessionType: derived.sessionType,
-    classification: derived.classification,
-    outcomeStatus: derived.outcomeStatus,
-    finishingPosition: derived.finishingPosition,
-    qualifyingPosition: derived.qualifyingPosition,
-    isPodium: derived.isPodium,
-    isFastestLap: derived.isFastestLap,
-    pitCount: derived.pitCount,
-    tyreStrategy: derived.tyreStrategy,
-    fuelStrategy: derived.fuelStrategy,
-    provenance: derived.provenance,
-    evidence: derived.evidence,
-    reasons: derived.reasons,
-  }, derived.events.map(toStoredPitEvent));
+  await upsertSessionResult(
+    {
+      sessionId,
+      processorVersion: RACE_RESULT_PROCESSOR_ID,
+      sessionType: derived.sessionType,
+      classification: derived.classification,
+      outcomeStatus: derived.outcomeStatus,
+      finishingPosition: derived.finishingPosition,
+      qualifyingPosition: derived.qualifyingPosition,
+      isPodium: derived.isPodium,
+      isFastestLap: derived.isFastestLap,
+      pitCount: derived.pitCount,
+      tyreStrategy: derived.tyreStrategy,
+      fuelStrategy: derived.fuelStrategy,
+      provenance: derived.provenance,
+      evidence: derived.evidence,
+      reasons: derived.reasons,
+    },
+    derived.events.map(toStoredPitEvent),
+  );
+  await linkSessionQualityEvents(sessionId);
 
   const status = unchanged ? "unchanged" : derived.outcomeStatus === "confirmed" ? "enriched" : "ambiguous";
   return { sessionId, status, eventCount: derived.events.length, reasons: derived.reasons };
@@ -180,12 +188,7 @@ export function reconcileSessionResultAfterLap(sessionId: number, gameId: GameId
   return pending;
 }
 
-export async function backfillRaceResults(options: {
-  gameId: GameId;
-  limit: number;
-  afterSessionId?: number;
-  eligibleSessionIds?: ReadonlySet<number>;
-}): Promise<BackfillReport> {
+export async function backfillRaceResults(options: { gameId: GameId; limit: number; afterSessionId?: number; eligibleSessionIds?: ReadonlySet<number> }): Promise<BackfillReport> {
   const limit = Math.max(1, Math.min(100, Math.trunc(options.limit)));
   const sessions = (await getSessions(options.gameId))
     .filter((session) => options.eligibleSessionIds?.has(session.id) ?? true)
@@ -205,16 +208,9 @@ export async function backfillRaceResults(options: {
   return { processed: results.length, enriched: counts.enriched, unchanged: counts.unchanged, skipped: counts.skipped, ambiguous: counts.ambiguous, errors: counts.error, results };
 }
 
-
 /** Reconcile only missing results or rows written by an older processor. */
-export async function backfillStaleRaceResults(options: {
-  gameId: GameId;
-  limit: number;
-  afterSessionId?: number;
-}): Promise<BackfillReport> {
-  const eligibleSessionIds = new Set(
-    await getStaleRaceResultSessionIds(RACE_RESULT_PROCESSOR_ID),
-  );
+export async function backfillStaleRaceResults(options: { gameId: GameId; limit: number; afterSessionId?: number }): Promise<BackfillReport> {
+  const eligibleSessionIds = new Set(await getStaleRaceResultSessionIds(RACE_RESULT_PROCESSOR_ID));
   return backfillRaceResults({ ...options, eligibleSessionIds });
 }
 export async function backfillAllRaceResults(): Promise<void> {

--- a/shared/racing/results/types.ts
+++ b/shared/racing/results/types.ts
@@ -1,22 +1,11 @@
 import type { GameId } from "@shared/games/ids";
-import type { EligibilityDecision } from "@shared/racing/quality/contracts";
+import type { EligibilityDecision, EligibilityStatus, QualityReasonCode } from "@shared/racing/quality/contracts";
 
 export type RaceResultSourceStatus = "direct" | "derived" | "simplified" | "unavailable";
 export type RaceResultOutcomeStatus = "confirmed" | "provisional" | "unavailable";
-export type RaceResultStatus =
-  | "finished"
-  | "dnf"
-  | "disqualified"
-  | "not-classified"
-  | "retired"
-  | "qualifying"
-  | "unknown";
+export type RaceResultStatus = "finished" | "dnf" | "disqualified" | "not-classified" | "retired" | "qualifying" | "unknown";
 
-export type RaceResultAuthorityStrategy =
-  | "highest-authority"
-  | "preserve-alternatives"
-  | "require-consensus"
-  | "abstain-on-conflict";
+export type RaceResultAuthorityStrategy = "highest-authority" | "preserve-alternatives" | "require-consensus" | "abstain-on-conflict";
 
 export type RaceResultEvidenceKind = "deterministic" | "ml" | "human";
 
@@ -152,13 +141,25 @@ export interface RaceResultEvidence {
   conflicts: string[];
   decisions?: Record<string, RaceResultAuthorityDecision>;
 }
-
 export interface RaceResultLapQualityEvidence {
   lapId: number;
   lapNumber: number;
   qualityGeneration: string | null;
   officialTiming: EligibilityDecision;
   normalPace: EligibilityDecision;
+}
+
+export type RaceResultEligibilityStatusCounts = Record<EligibilityStatus, number>;
+
+export interface RaceResultPolicyQualityAggregate {
+  statuses: RaceResultEligibilityStatusCounts;
+  reasons: Partial<Record<QualityReasonCode, number>>;
+}
+
+export interface RaceResultLapQualityAggregate {
+  total: number;
+  officialTiming: RaceResultPolicyQualityAggregate;
+  normalPace: RaceResultPolicyQualityAggregate;
 }
 
 export interface RaceResult {
@@ -179,6 +180,7 @@ export interface RaceResult {
   reasons: string[];
   outcomeStatus: RaceResultOutcomeStatus;
   evidence: RaceResultEvidence;
+  lapQuality: RaceResultLapQualityEvidence[];
   events: Array<{
     eventType?: "pit" | "position-change";
     sequence: number;
@@ -217,4 +219,5 @@ export interface RaceResultAggregate {
   confirmed: number;
   provisional: number;
   unavailable: number;
+  lapQuality: RaceResultLapQualityAggregate;
 }

--- a/test/driver-profile/runner.test.ts
+++ b/test/driver-profile/runner.test.ts
@@ -1,13 +1,7 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 
-import {
-  DRIVER_PROFILE_DEFAULT_OUTPUT_TOKENS,
-  driverProfilePoolKey,
-  logDriverProfileFailure,
-  logDriverProfileOutput,
-  notifyDriverProfileLap,
-} from "../../server/driver-profile/runner";
+import { DRIVER_PROFILE_DEFAULT_OUTPUT_TOKENS, driverProfilePoolKey, logDriverProfileFailure, logDriverProfileOutput, notifyDriverProfileLap } from "../../server/driver-profile/runner";
 import { driverRoutes } from "../../server/routes/driver-routes";
 
 describe("driver profile runner", () => {
@@ -65,19 +59,24 @@ describe("driver profile runner", () => {
     expect((await driverRoutes.request("/api/drivers/profile", { method: "DELETE", headers })).status).toBe(404);
   });
 
-  test("pool key is versioned and includes only newest 60 IDs before sorting", () => {
-    const newest = Array.from({ length: 60 }, (_, index) => 1000 - index);
-    const withOldTail = [...newest, 1, 2, 3];
+  test("pool key includes quality identity for the newest 60 laps before sorting", () => {
+    const lap = (id: number, qualityGeneration = `sha256:quality-${id}`, qualityStale = false) => ({
+      id,
+      qualityGeneration,
+      qualityStale,
+    });
+    const newest = Array.from({ length: 60 }, (_, index) => lap(1000 - index));
+    const withOldTail = [...newest, lap(1), lap(2), lap(3)];
     expect(driverProfilePoolKey(newest)).toBe(driverProfilePoolKey(withOldTail));
-    expect(driverProfilePoolKey(newest)).not.toBe(driverProfilePoolKey([999, ...newest.slice(1)]));
+    expect(driverProfilePoolKey(newest)).not.toBe(driverProfilePoolKey([lap(999), ...newest.slice(1)]));
+    expect(driverProfilePoolKey(newest)).not.toBe(driverProfilePoolKey([{ ...newest[0]!, qualityGeneration: "sha256:rebuilt" }, ...newest.slice(1)]));
+    expect(driverProfilePoolKey(newest)).not.toBe(driverProfilePoolKey([{ ...newest[0]!, qualityStale: true }, ...newest.slice(1)]));
   });
   test("logs handled profile failures with run and model context", () => {
     const error = spyOn(console, "error").mockImplementation(() => {});
     try {
       logDriverProfileFailure(5, "qwen/qwen3.5-9b", "Model output did not match summary schema.");
-      expect(error).toHaveBeenCalledWith(
-        "[AI] Driver profile run 5 failed (model=qwen/qwen3.5-9b): Model output did not match summary schema.",
-      );
+      expect(error).toHaveBeenCalledWith("[AI] Driver profile run 5 failed (model=qwen/qwen3.5-9b): Model output did not match summary schema.");
     } finally {
       error.mockRestore();
     }
@@ -89,9 +88,7 @@ describe("driver profile runner", () => {
     const error = spyOn(console, "error").mockImplementation(() => {});
     try {
       logDriverProfileOutput(6, "qwen/qwen3.5-9b", { text: "", object: { headline: "x", extra: true } });
-      expect(error).toHaveBeenCalledWith(
-        '[AI] Driver profile run 6 raw output (model=qwen/qwen3.5-9b, finishReason=<unknown>, usage=<none>, resultKeys=text,object): {"headline":"x","extra":true}',
-      );
+      expect(error).toHaveBeenCalledWith('[AI] Driver profile run 6 raw output (model=qwen/qwen3.5-9b, finishReason=<unknown>, usage=<none>, resultKeys=text,object): {"headline":"x","extra":true}');
     } finally {
       error.mockRestore();
     }

--- a/test/driver-profile/trend-provenance.test.ts
+++ b/test/driver-profile/trend-provenance.test.ts
@@ -18,31 +18,30 @@ describe("normalized driver trend", () => {
     expect(trend.recent.laps.find((x) => x.id === 70)?.relativePacePct).toBeCloseTo((100.7 / 100.01 - 1) * 100, 8);
   });
 
-  test("keeps dirty laps, lowers clean rate, and includes them in normalized spread", () => {
-    const clean = Array.from({ length: 60 }, (_, i) => lap(60 - i, { lapTime: 100 }));
-    for (let i = 0; i < 16; i++) {
-      clean[i].isValid = false;
-      clean[i].lapTime = 130;
-    }
-    const trend = buildDriverTrend(clean);
+  test("keeps dirty laps in totals and clean rate without including them in normalized pace", () => {
+    const laps = Array.from({ length: 60 }, (_, i) => lap(60 - i, { lapTime: i < 16 ? 130 : 100, isValid: i >= 16 }));
+    const trend = buildDriverTrend(laps);
     expect(trend.recent.laps.map((x) => x.id)).toContain(60);
     expect(trend.recent.dirty).toBe(16);
     expect(trend.recent.cleanRate).toBeCloseTo(14 / 30, 8);
-    expect(trend.recent.normalized).toBe(30);
-    expect(trend.recent.medianPacePct).toBeGreaterThan(0);
-    expect(trend.recent.spreadPct).toBeGreaterThan(0);
-    expect(trend.recent.consistency).toBeLessThan(100);
+    expect(trend.recent.normalized).toBe(14);
+    expect(trend.recent.medianPacePct).toBe(0);
+    expect(trend.recent.spreadPct).toBe(0);
+    expect(trend.recent.consistency).toBe(100);
   });
 
-  test("invalid shortcut faster than valid benchmark clamps relative pace at zero", () => {
+  test("invalid shortcut remains visible without contributing a pace sample", () => {
     const laps = [
       lap(3, { lapTime: 90, isValid: false }),
       lap(2, { lapTime: 100, isValid: true }),
       lap(1, { lapTime: 110, isValid: true }),
     ];
     const trend = buildDriverTrend(laps);
-    expect(trend.recent.laps.find((x) => x.id === 3)?.relativePacePct).toBe(0);
-    expect(trend.recent.medianPacePct).toBe(0);
+    expect(trend.recent.total).toBe(3);
+    expect(trend.recent.dirty).toBe(1);
+    expect(trend.recent.laps.find((x) => x.id === 3)?.relativePacePct).toBeNull();
+    expect(trend.recent.normalized).toBe(2);
+    expect(trend.recent.medianPacePct).toBe(5);
   });
 
   test("normalizes mixed 90-second and 200-second contexts to percentages", () => {
@@ -58,7 +57,7 @@ describe("normalized driver trend", () => {
     expect(JSON.stringify(trend)).not.toContain("200");
   });
 
-  test("benchmarks stay isolated per game context", () => {
+  test("benchmarks stay isolated per game context without assigning pace to invalid laps", () => {
     const trend = buildDriverTrend([
       lap(4, { gameId: "fm-2023", lapTime: 90, isValid: false }),
       lap(3, { gameId: "fm-2023", lapTime: 100 }),
@@ -66,8 +65,23 @@ describe("normalized driver trend", () => {
       lap(1, { gameId: "acc", lapTime: 200 }),
     ]);
     expect(trend.recent.contexts).toBe(2);
-    expect(trend.recent.laps.find((x) => x.id === 4)?.relativePacePct).toBe(0);
-    expect(trend.recent.laps.find((x) => x.id === 2)?.relativePacePct).toBe(0);
+    expect(trend.recent.laps.find((x) => x.id === 4)?.relativePacePct).toBeNull();
+    expect(trend.recent.laps.find((x) => x.id === 2)?.relativePacePct).toBeNull();
+    expect(trend.recent.normalized).toBe(2);
+  });
+
+  test("structurally valid non-pace lap remains clean and visible without contributing pace", () => {
+    const trend = buildDriverTrend([
+      lap(3, { lapTime: 80, isValid: true, phase: "out", paceEligibility: "excluded" }),
+      lap(2, { lapTime: 100 }),
+      lap(1, { lapTime: 110 }),
+    ]);
+    expect(trend.recent.total).toBe(3);
+    expect(trend.recent.valid).toBe(3);
+    expect(trend.recent.cleanRate).toBe(1);
+    expect(trend.recent.laps.find((x) => x.id === 3)?.relativePacePct).toBeNull();
+    expect(trend.recent.normalized).toBe(2);
+    expect(trend.recent.medianPacePct).toBe(5);
   });
 
   test("missing valid benchmark keeps lap totals and produces null pace", () => {

--- a/test/race-results/race-results-storage.test.ts
+++ b/test/race-results/race-results-storage.test.ts
@@ -1,14 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { insertSession } from "../../server/db/session-queries";
 import { db } from "../../server/db";
-import { laps } from "../../server/db/schema";
+import { compareAnalyses, lapAnalyses, laps } from "../../server/db/schema";
+import { finalizeLapQualityGeneration } from "../../server/lap-analysis/quality-generation";
 import { countStaleRaceResults, getSessionResult, getStaleRaceResultSessionIds, replacePitEvents, upsertSessionResult, type SessionResultInput } from "../../server/db/session-result-queries";
-import { getRecentRaceResults } from "../../server/race-results/aggregates";
+import { getRaceResultAggregate, getRecentRaceResults } from "../../server/race-results/aggregates";
 import { initServerGameAdapters } from "../../server/games/init";
 import { RACE_RESULT_PROCESSOR_ID, backfillRaceResults, backfillStaleRaceResults, reconcileSessionResult } from "../../server/race-results/reconcile";
 import { sessionRoutes } from "../../server/routes/session-routes";
 import type { RaceResultEvidence, RaceResultProvenance } from "../../shared/racing/results/types";
+import type { LapCondition, LapPhase } from "../../shared/racing/laps/classification";
+import type { EligibilityDecision, QualityReasonCode } from "../../shared/racing/quality/contracts";
+import { qualityPackets, summarize } from "../support/lap-analysis/quality-model";
 
 const evidence: RaceResultEvidence = {
   fieldStatus: {
@@ -38,13 +42,71 @@ const provenance: RaceResultProvenance = {
   authorityPolicyId: "race-result-outcome-authority",
   authorityPolicyVersion: "1",
 };
+const qualityFixturePackets = qualityPackets(100);
+function currentLapQuality(lapNumber: number, phase: LapPhase, conditions: LapCondition[]) {
+  return finalizeLapQualityGeneration(
+    summarize(qualityFixturePackets, {
+      classification: { phase, conditions, paceEligibility: "excluded" },
+    }),
+    "legacy",
+    {
+      lapNumber,
+      rawByteOffset: null,
+      rawFrameCount: qualityFixturePackets.length,
+    },
+  );
+}
+function withOnlyReason(decision: EligibilityDecision, code: QualityReasonCode): EligibilityDecision {
+  const reasons = decision.reasons.filter((reason) => reason.code === code);
+  return {
+    ...decision,
+    reasons,
+    evidenceIds: reasons.flatMap((reason) => reason.evidenceIds),
+  };
+}
 
 describe("persisted race result metadata", () => {
   test("upserts one result and replaces ordered pit events on rerun", async () => {
+    const expectedLap3Quality = currentLapQuality(3, "in", ["caution"]);
+    const expectedLap4Quality = currentLapQuality(4, "out", ["slow_zone"]);
     const sessionId = await insertSession(99, 88, "f1-2025", "race");
     await db.insert(laps).values([
-      { sessionId, lapNumber: 3, lapTime: 100, isValid: true },
-      { sessionId, lapNumber: 4, lapTime: 140, isValid: true },
+      {
+        sessionId,
+        lapNumber: 3,
+        lapTime: 100,
+        isValid: true,
+        conditions: ["caution"],
+        paceEligibility: "excluded",
+        rawFrameCount: qualityFixturePackets.length,
+        quality: expectedLap3Quality.quality,
+        eligibility: {
+          ...expectedLap3Quality.eligibility,
+          "normal-pace": withOnlyReason(expectedLap3Quality.eligibility["normal-pace"], "caution_context"),
+        },
+        qualitySchemaVersion: expectedLap3Quality.quality.provenance.schemaVersion,
+        qualityPolicyVersion: expectedLap3Quality.quality.provenance.policyVersion,
+        qualityConfigVersion: expectedLap3Quality.quality.provenance.configurationVersion,
+        qualityGeneration: expectedLap3Quality.quality.provenance.outputGeneration,
+      },
+      {
+        sessionId,
+        lapNumber: 4,
+        lapTime: 140,
+        isValid: true,
+        conditions: ["slow_zone"],
+        paceEligibility: "excluded",
+        rawFrameCount: qualityFixturePackets.length,
+        quality: expectedLap4Quality.quality,
+        eligibility: {
+          ...expectedLap4Quality.eligibility,
+          "normal-pace": withOnlyReason(expectedLap4Quality.eligibility["normal-pace"], "non_pace_classification"),
+        },
+        qualitySchemaVersion: expectedLap4Quality.quality.provenance.schemaVersion,
+        qualityPolicyVersion: expectedLap4Quality.quality.provenance.policyVersion,
+        qualityConfigVersion: expectedLap4Quality.quality.provenance.configurationVersion,
+        qualityGeneration: expectedLap4Quality.quality.provenance.outputGeneration,
+      },
     ]);
     const input: SessionResultInput = {
       sessionId,
@@ -66,19 +128,211 @@ describe("persisted race result metadata", () => {
     const second = await upsertSessionResult(input);
     expect(second.id).toBe(first.id);
     await replacePitEvents(first.id, [
-      { sequence: 2, lapNumber: 8, elapsedSeconds: 80, durationSeconds: 2.1, service: "fuel", tyreChange: null, fuelAdded: 5, fuelBefore: 10, fuelAfter: 15, linkage: "linked", source: { test: true } },
-      { sequence: 1, lapNumber: 3, elapsedSeconds: 30, durationSeconds: null, service: "tyres", tyreChange: { to: "medium" }, fuelAdded: null, fuelBefore: null, fuelAfter: null, linkage: "linked", source: { test: true } },
+      {
+        sequence: 2,
+        lapNumber: 8,
+        elapsedSeconds: 80,
+        durationSeconds: 2.1,
+        service: "fuel",
+        tyreChange: null,
+        fuelAdded: 5,
+        fuelBefore: 10,
+        fuelAfter: 15,
+        linkage: "linked",
+        source: { test: true },
+      },
+      {
+        sequence: 1,
+        lapNumber: 3,
+        elapsedSeconds: 30,
+        durationSeconds: null,
+        service: "tyres",
+        tyreChange: { to: "medium" },
+        fuelAdded: null,
+        fuelBefore: null,
+        fuelAfter: null,
+        linkage: "linked",
+        source: { test: true },
+      },
     ]);
     const result = await getSessionResult(sessionId, "f1-2025");
     expect(result?.id).toBe(first.id);
     expect(result?.events.map((event) => event.sequence)).toEqual([1, 2]);
     expect(result?.events[1]?.fuelAdded).toBe(5);
     expect(result?.provenance).toEqual(provenance);
-    const pitLaps = await db.select({ lapNumber: laps.lapNumber, isValid: laps.isValid, invalidReason: laps.invalidReason }).from(laps).where(eq(laps.sessionId, sessionId)).orderBy(laps.lapNumber).all();
-    expect(pitLaps).toEqual([
-      { lapNumber: 3, isValid: false, invalidReason: "inlap" },
-      { lapNumber: 4, isValid: false, invalidReason: "outlap" },
+    expect(
+      result?.lapQuality.map(({ lapNumber, qualityGeneration, officialTiming, normalPace }) => ({
+        lapNumber,
+        qualityGeneration,
+        officialTiming: officialTiming.status,
+        normalPace: normalPace.status,
+        reasons: normalPace.reasons.map(({ code }) => code),
+      })),
+    ).toEqual([
+      {
+        lapNumber: 3,
+        qualityGeneration: expectedLap3Quality.quality.provenance.outputGeneration,
+        officialTiming: "eligible",
+        normalPace: "ineligible",
+        reasons: ["caution_context"],
+      },
+      {
+        lapNumber: 4,
+        qualityGeneration: expectedLap4Quality.quality.provenance.outputGeneration,
+        officialTiming: "eligible",
+        normalPace: "ineligible",
+        reasons: ["non_pace_classification"],
+      },
     ]);
+    const aggregate = await getRaceResultAggregate({
+      gameId: "f1-2025",
+      carOrdinal: 99,
+      trackOrdinal: 88,
+    });
+    expect(aggregate.lapQuality).toMatchObject({
+      total: 2,
+      officialTiming: {
+        statuses: { eligible: 2, eligible_with_warning: 0, ineligible: 0, unknown: 0 },
+      },
+      normalPace: {
+        statuses: { eligible: 0, eligible_with_warning: 0, ineligible: 2, unknown: 0 },
+        reasons: { caution_context: 1, non_pace_classification: 1 },
+      },
+    });
+    const pitLaps = await db
+      .select({ lapNumber: laps.lapNumber, isValid: laps.isValid, phase: laps.phase, conditions: laps.conditions, paceEligibility: laps.paceEligibility, invalidReason: laps.invalidReason })
+      .from(laps)
+      .where(eq(laps.sessionId, sessionId))
+      .orderBy(laps.lapNumber)
+      .all();
+    expect(pitLaps).toEqual([
+      { lapNumber: 3, isValid: true, phase: "in", conditions: ["caution"], paceEligibility: "excluded", invalidReason: null },
+      { lapNumber: 4, isValid: true, phase: "out", conditions: ["slow_zone"], paceEligibility: "excluded", invalidReason: null },
+    ]);
+  });
+  test("regenerates pit-cycle quality and invalidates dependent analysis caches", async () => {
+    const sessionId = await insertSession(199, 188, "f1-2025", "race");
+    const packets = qualityPackets(100);
+    const generatedByLap = [1, 2, 3, 4].map((lapNumber) =>
+      finalizeLapQualityGeneration(summarize(packets), "legacy", {
+        lapNumber,
+        rawByteOffset: lapNumber * 1_000,
+        rawFrameCount: packets.length,
+      }),
+    );
+    const insertedLaps = await db
+      .insert(laps)
+      .values(
+        generatedByLap.map((generated, index) => ({
+          sessionId,
+          lapNumber: index + 1,
+          lapTime: 100 + index,
+          isValid: true,
+          rawByteOffset: (index + 1) * 1_000,
+          rawFrameCount: packets.length,
+          quality: generated.quality,
+          eligibility: generated.eligibility,
+          qualitySchemaVersion: generated.quality.provenance.schemaVersion,
+          qualityPolicyVersion: generated.quality.provenance.policyVersion,
+          qualityConfigVersion: generated.quality.provenance.configurationVersion,
+          qualityGeneration: generated.quality.provenance.outputGeneration,
+        })),
+      )
+      .returning({ id: laps.id, lapNumber: laps.lapNumber, qualityGeneration: laps.qualityGeneration })
+      .all();
+    const byLapNumber = new Map(insertedLaps.map((lap) => [lap.lapNumber, lap]));
+    await db.insert(lapAnalyses).values(insertedLaps.map((lap) => ({ lapId: lap.id, analysis: `lap ${lap.lapNumber}` })));
+    await db.insert(compareAnalyses).values([
+      { lapAId: byLapNumber.get(1)!.id, lapBId: byLapNumber.get(3)!.id, kind: "inputs", analysis: "affected" },
+      { lapAId: byLapNumber.get(3)!.id, lapBId: byLapNumber.get(4)!.id, kind: "inputs", analysis: "unaffected" },
+    ]);
+    const result = await upsertSessionResult({
+      sessionId,
+      sessionType: "race",
+      classification: "finished",
+      outcomeStatus: "confirmed",
+      finishingPosition: 4,
+      qualifyingPosition: 6,
+      isPodium: false,
+      isFastestLap: false,
+      pitCount: 1,
+      tyreStrategy: null,
+      fuelStrategy: null,
+      provenance,
+      evidence,
+      reasons: [],
+    });
+
+    await replacePitEvents(result.id, [
+      {
+        sequence: 1,
+        lapNumber: 1,
+        elapsedSeconds: 100,
+        durationSeconds: 20,
+        service: "tyres",
+        tyreChange: { to: "medium" },
+        fuelAdded: null,
+        fuelBefore: null,
+        fuelAfter: null,
+        linkage: "linked",
+        source: { test: true },
+      },
+    ]);
+
+    const storedLaps = await db
+      .select({
+        id: laps.id,
+        lapNumber: laps.lapNumber,
+        phase: laps.phase,
+        paceEligibility: laps.paceEligibility,
+        quality: laps.quality,
+        eligibility: laps.eligibility,
+        qualityGeneration: laps.qualityGeneration,
+      })
+      .from(laps)
+      .where(eq(laps.sessionId, sessionId))
+      .orderBy(laps.lapNumber)
+      .all();
+    for (const lapNumber of [1, 2]) {
+      const stored = storedLaps.find((lap) => lap.lapNumber === lapNumber)!;
+      expect(stored.phase).toBe(lapNumber === 1 ? "in" : "out");
+      expect(stored.paceEligibility).toBe("excluded");
+      expect(stored.quality?.classification).toMatchObject({
+        phase: lapNumber === 1 ? "in" : "out",
+        paceEligibility: "excluded",
+      });
+      expect(stored.eligibility?.["official-timing"].status).toBe("eligible");
+      expect(stored.eligibility?.["normal-pace"]).toMatchObject({
+        status: "ineligible",
+        reasons: [expect.objectContaining({ code: "non_pace_classification" })],
+      });
+      expect(stored.qualityGeneration).not.toBe(byLapNumber.get(lapNumber)?.qualityGeneration);
+      expect(stored.qualityGeneration).toBe(stored.quality!.provenance.outputGeneration);
+    }
+    for (const lapNumber of [3, 4]) {
+      const stored = storedLaps.find((lap) => lap.lapNumber === lapNumber)!;
+      expect(stored.qualityGeneration).toBe(byLapNumber.get(lapNumber)!.qualityGeneration);
+      expect(stored.eligibility?.["normal-pace"].status).toBe("eligible");
+    }
+
+    const cachedLapIds = await db
+      .select({ lapId: lapAnalyses.lapId })
+      .from(lapAnalyses)
+      .where(inArray(lapAnalyses.lapId, insertedLaps.map(({ id }) => id)))
+      .orderBy(lapAnalyses.lapId)
+      .all();
+    expect(cachedLapIds.map(({ lapId }) => lapId)).toEqual([byLapNumber.get(3)!.id, byLapNumber.get(4)!.id]);
+    const cachedComparisons = await db
+      .select({ lapAId: compareAnalyses.lapAId, lapBId: compareAnalyses.lapBId })
+      .from(compareAnalyses)
+      .where(
+        and(
+          inArray(compareAnalyses.lapAId, insertedLaps.map(({ id }) => id)),
+          inArray(compareAnalyses.lapBId, insertedLaps.map(({ id }) => id)),
+        ),
+      )
+      .all();
+    expect(cachedComparisons).toEqual([{ lapAId: byLapNumber.get(3)!.id, lapBId: byLapNumber.get(4)!.id }]);
   });
   test("counts and lists only results from older processor versions", async () => {
     const staleSessionId = await insertSession(12, 13, "f1-2025", "race");
@@ -104,12 +358,8 @@ describe("persisted race result metadata", () => {
     await upsertSessionResult(input(staleSessionId, "race-result-v0"));
     await upsertSessionResult(input(currentSessionId, RACE_RESULT_PROCESSOR_ID));
     expect(await countStaleRaceResults(RACE_RESULT_PROCESSOR_ID)).toBeGreaterThanOrEqual(2);
-    const staleIds = await getStaleRaceResultSessionIds(
-      RACE_RESULT_PROCESSOR_ID,
-    );
-    expect(staleIds).toEqual(
-      expect.arrayContaining([staleSessionId, resultlessSessionId]),
-    );
+    const staleIds = await getStaleRaceResultSessionIds(RACE_RESULT_PROCESSOR_ID);
+    expect(staleIds).toEqual(expect.arrayContaining([staleSessionId, resultlessSessionId]));
     expect(staleIds).not.toContain(currentSessionId);
   });
 
@@ -179,12 +429,8 @@ describe("persisted race result metadata", () => {
       afterSessionId: accSessionId - 1,
     });
 
-    expect(
-      (await getSessionResult(f1SessionId, "f1-2025"))?.processorVersion,
-    ).toBe(RACE_RESULT_PROCESSOR_ID);
-    expect(
-      (await getSessionResult(accSessionId, "acc"))?.processorVersion,
-    ).toBe(RACE_RESULT_PROCESSOR_ID);
+    expect((await getSessionResult(f1SessionId, "f1-2025"))?.processorVersion).toBe(RACE_RESULT_PROCESSOR_ID);
+    expect((await getSessionResult(accSessionId, "acc"))?.processorVersion).toBe(RACE_RESULT_PROCESSOR_ID);
   });
 
   test("startup backfill skips results from the current processor", async () => {
@@ -216,7 +462,6 @@ describe("persisted race result metadata", () => {
     expect(report.processed).toBe(0);
     expect(report.results).toEqual([]);
   });
-
 
   test("does not expose a result across game scope", async () => {
     const sessionId = await insertSession(99, 88, "acc", "race");
@@ -266,5 +511,4 @@ describe("persisted race result metadata", () => {
     expect(results.map((result) => result.sessionId)).not.toContain(oldest + 1);
     expect(results.map((result) => result.sessionId)).not.toContain(oldest + 2);
   });
-
 });

--- a/test/support/driver-profile/factories.ts
+++ b/test/support/driver-profile/factories.ts
@@ -2,25 +2,53 @@ import type { ProfileScope } from "../../../server/driver-profile/fingerprint";
 import type { LapStyleSummary } from "../../../shared/racing/analysis/laps/driving-style";
 import type { LapInsight } from "../../../shared/racing/analysis/laps/insights/types";
 import type { LapMeta } from "../../../shared/racing/sessions/types";
+import { ELIGIBILITY_POLICY_VERSION, QUALITY_CONFIG_VERSION, QUALITY_SCHEMA_VERSION, type EligibilityDecisionSet, type LapQualitySummary } from "../../../shared/racing/quality/contracts";
 
 export const SCOPE: ProfileScope = { kind: "car-track", gameId: "fm-2023", carOrdinal: 100, trackOrdinal: 200 };
 export const GLOBAL_SCOPE: ProfileScope = { kind: "global", gameId: "fm-2023", carOrdinal: null, trackOrdinal: null };
 
 export function lap(id: number, over: Partial<LapMeta> = {}): LapMeta {
-  return {
+  const qualityGeneration = `sha256:test-quality-${id}`;
+  const value: LapMeta = {
     id,
     sessionId: 1,
     lapNumber: id,
     lapTime: 90 + (id % 5) * 0.1,
     isValid: true,
+    phase: "flying",
+    conditions: [],
+    paceEligibility: "eligible",
     createdAt: "2026-01-01T00:00:00.000Z",
     gameId: "fm-2023",
     carOrdinal: 100,
     trackOrdinal: 200,
+    quality: {
+      provenance: {
+        schemaVersion: QUALITY_SCHEMA_VERSION,
+        policyVersion: ELIGIBILITY_POLICY_VERSION,
+        configurationVersion: QUALITY_CONFIG_VERSION,
+        sourceGeneration: `sha256:test-source-${id}`,
+        outputGeneration: qualityGeneration,
+      },
+    } as unknown as LapQualitySummary,
+    qualityGeneration,
+    qualityStale: false,
     ...over,
-    phase: over.phase ?? "flying",
-    conditions: over.conditions ?? [],
-    paceEligibility: over.paceEligibility ?? "eligible",
+  };
+  if (over.eligibility) return value;
+  const usable = value.isValid && value.paceEligibility === "eligible";
+  return {
+    ...value,
+    eligibility: {
+      "normal-pace": {
+        status: usable ? "eligible" : "ineligible",
+        policyId: "normal-pace",
+        policyVersion: ELIGIBILITY_POLICY_VERSION,
+        confidence: { level: "high", score: 1 },
+        reasons: usable ? [] : [{ code: "structurally_invalid", severity: "error", evidenceIds: [`lap:${id}:validity`], timeRange: null, distanceRange: null, semanticIds: [] }],
+        evidenceIds: usable ? [] : [`lap:${id}:validity`],
+      },
+    } as unknown as EligibilityDecisionSet,
   };
 }
 


### PR DESCRIPTION
Replacement for closed #273 after reviewer remediation.

Part 7 of 8 for #231

Parent: #272. Base: `issue-229/06-server-consumers`.

## Behavior
- Collect recent fuel and tire evidence independently so missing or refueled fuel cannot discard usable tire history.
- Regenerate driver profiles and race-result aggregates when quality or eligibility identity changes.

## Focused verification
- `Focused live strategy, driver profile, and race-result suites.`
- `bun run typecheck`