### PR TITLE
perf(ci): speed up Storybook visual snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,7 +347,7 @@ When creating or updating a pull request:
 
 Classify each change before editing `CHANGELOG.md`:
 - **Customer-facing behavior** — add concise user-facing bullet under `## Unreleased` in `### Breaking`, `### Features`, or `### Fixes`.
-- **Internal-only CI, tooling, maintenance, tests, or developer workflow** — do not add a customer-facing changelog entry; describe it in the PR instead.
+- **Internal-only CI, tooling, maintenance, tests, or developer workflow** — add concise note under `## Unreleased` → `### Internal`, not under customer-facing sections.
 
 Never put internal mechanics in customer-facing release notes. Run `bun test test/changelog.test.ts --timeout 60000` only when changing `CHANGELOG.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,7 @@ Installed via `postinstall` script. Runs repository-wide checks before every com
 - **lint** — `bun run lint`
 - **typecheck** — `bun run typecheck`
 
+Do not manually run the full `bun test` suite before pushing when these hooks pass; full tests run in CI. Run focused tests when validating changed behavior.
 
 ### Pull Request Creation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,7 +345,11 @@ When creating or updating a pull request:
 
 ### Pull Request Changelog
 
-Every pull request must include a concise user-facing bullet in `CHANGELOG.md` under `## Unreleased`; do not omit it for implementation, CI, tooling, or maintenance work. Describe the observable benefit in `### Breaking`, `### Features`, or `### Fixes` rather than documenting internal mechanics. Run `bun test test/changelog.test.ts --timeout 60000` before requesting review.
+Classify each change before editing `CHANGELOG.md`:
+- **Customer-facing behavior** — add concise user-facing bullet under `## Unreleased` in `### Breaking`, `### Features`, or `### Fixes`.
+- **Internal-only CI, tooling, maintenance, tests, or developer workflow** — do not add a customer-facing changelog entry; describe it in the PR instead.
+
+Never put internal mechanics in customer-facing release notes. Run `bun test test/changelog.test.ts --timeout 60000` only when changing `CHANGELOG.md`.
 
 ### AI Evaluators
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - Reduce unnecessary network traffic during update checks when release tags are unchanged
 
 ### Internal
+- Speed Storybook visual snapshot CI with a test-optimized static build and concurrent workers
 - Replace Biome with Oxc for repository linting and formatting
 - Consolidate game raw telemetry routes behind one dynamic route and default seeded E2E runs to two workers
 - Document DeepWiki MCP as the preferred first pass for codebase discovery

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Detect imported file contents before accepting ZIP/BIN session data and reject unrelated archives
 ### Fixes
+- Speed Storybook visual snapshot CI by serving a test-optimized static build and running snapshot workers concurrently
 - Show iRacing live fuel bars using tank capacity reported by simulator session data
 - Show partial throttle and brake correctly in iRacing Pit Crew bars and telemetry traces
 - Keep live dashboards from flickering back to Waiting for telemetry, clearly label measured source telemetry frequency, and maintain the configured browser refresh cadence

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 - Detect imported file contents before accepting ZIP/BIN session data and reject unrelated archives
 ### Fixes
-- Speed Storybook visual snapshot CI by serving a test-optimized static build and running snapshot workers concurrently
 - Show iRacing live fuel bars using tank capacity reported by simulator session data
 - Show partial throttle and brake correctly in iRacing Pit Crew bars and telemetry traces
 - Keep live dashboards from flickering back to Waiting for telemetry, clearly label measured source telemetry frequency, and maintain the configured browser refresh cadence

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -10,9 +10,9 @@ const RESULTS_DIR = process.env.RACEIQ_SNAPSHOT_RESULTS_DIR ? resolve(process.en
 export default defineConfig({
   testDir: "./src/stories",
   testMatch: "**/*.snapshot.ts",
-  // Snapshot specs share one cold-compiling Storybook server. Serial workers
-  // prevent competing beforeAll warmups from timing out or closing contexts.
-  workers: 1,
+  // Static Storybook is built once and serves concurrent snapshot pages.
+  // Two workers match the constrained CI runner's two vCPUs.
+  workers: 2,
   outputDir: RESULTS_DIR,
   snapshotDir: SNAPSHOT_DIR,
   snapshotPathTemplate: "{snapshotDir}/{testName}.png",
@@ -37,10 +37,10 @@ export default defineConfig({
   webServer: {
     // Storybook's Vite preview can exceed Node's default ~2 GB heap while
     // compiling the full snapshot inventory in the constrained CI runner.
-    command: `NODE_OPTIONS=--max-old-space-size=4096 bunx storybook dev -p ${STORYBOOK_PORT} --ci --no-open --exact-port`,
+    command: `NODE_OPTIONS=--max-old-space-size=4096 bunx storybook build --test --output-dir storybook-static && bunx vite preview --outDir storybook-static --host 0.0.0.0 --port ${STORYBOOK_PORT} --strictPort`,
     cwd: STORYBOOK_ROOT,
     url: `http://localhost:${STORYBOOK_PORT}/index.json`,
     reuseExistingServer: false,
-    timeout: 120_000,
+    timeout: 600_000,
   },
 });

--- a/client/src/stories/dashboards.snapshot.ts
+++ b/client/src/stories/dashboards.snapshot.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { DASHBOARD_SNAPSHOT_CASES } from "./snapshot-cases";
-import { openStoryForSnapshot, warmStorybook } from "./storybook-ready";
+import { openStoryForSnapshot } from "./storybook-ready";
 
 // Story IDs come from Storybook title + export name.
 // Inventory lives in snapshot-cases.ts so CI and local comparison cannot drift.
@@ -8,10 +8,6 @@ const LIVE_DASHBOARD_NAMES = new Set(["F1LiveDashboard", "ForzaLiveDashboard", "
 const comparisonCaptureOnly = process.env.RACEIQ_UI_DIFF_CAPTURE === "1";
 
 test.setTimeout(300_000);
-test.beforeAll(async ({ browser }) => {
-  test.setTimeout(300_000);
-  await warmStorybook(browser, `/iframe.html?id=${DASHBOARD_SNAPSHOT_CASES[0].id}&viewMode=story`, { attempts: 12, attemptTimeoutMs: 15_000 });
-});
 
 for (const story of DASHBOARD_SNAPSHOT_CASES) {
   test(`snapshot: ${story.name}`, async ({ page }) => {

--- a/client/src/stories/experiment-flow.snapshot.ts
+++ b/client/src/stories/experiment-flow.snapshot.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { openStory, warmStorybook } from "./storybook-ready";
+import { openStory } from "./storybook-ready";
 
 /**
  * Render smoke-test for the experiment flow stories (list → workspace →
@@ -80,21 +80,6 @@ const stories: StoryCase[] = [
     forbidText: ["Experiment not found"],
   },
 ];
-
-/**
- * Pay Storybook's cold Vite compile ONCE, here, instead of charging it to
- * whichever test happens to run first.
- *
- * Without this the first story in the file has to both compile the module graph
- * and render inside its own wait, so a heavier import graph pushes that one test
- * past its timeout while every later story passes — a failure that follows load
- * order rather than the story, and looks exactly like a regression in whatever
- * story sorted first.
- */
-test.beforeAll(async ({ browser }) => {
-  test.setTimeout(360_000);
-  await warmStorybook(browser, `/iframe.html?id=${stories[0].id}&viewMode=story`, { attempts: 18, attemptTimeoutMs: 15_000 });
-});
 
 for (const story of stories) {
   test(`renders: ${story.name}`, async ({ page }) => {

--- a/client/src/stories/reusable-ui.snapshot.ts
+++ b/client/src/stories/reusable-ui.snapshot.ts
@@ -1,14 +1,9 @@
 import { expect, test } from "@playwright/test";
 import { REUSABLE_UI_SNAPSHOT_CASES } from "./snapshot-cases";
-import { openStoryForSnapshot, warmStorybook } from "./storybook-ready";
+import { openStoryForSnapshot } from "./storybook-ready";
 
 test.setTimeout(120_000);
 const comparisonCaptureOnly = process.env.RACEIQ_UI_DIFF_CAPTURE === "1";
-
-test.beforeAll(async ({ browser }) => {
-  test.setTimeout(180_000);
-  await warmStorybook(browser, `/iframe.html?id=${REUSABLE_UI_SNAPSHOT_CASES[0].id}&viewMode=story`, { attempts: 18, attemptTimeoutMs: 15_000 });
-});
 
 for (const story of REUSABLE_UI_SNAPSHOT_CASES) {
   test(`snapshot: ${story.name}`, async ({ page }) => {
@@ -21,7 +16,10 @@ for (const story of REUSABLE_UI_SNAPSHOT_CASES) {
     await openStoryForSnapshot(page, `/iframe.html?id=${story.id}&viewMode=story`);
 
     if (story.clickLabel) {
-      await page.getByRole(story.clickRole ?? "button", { name: story.clickLabel }).click();
+      const readyState = story.readyRole ? page.getByRole(story.readyRole, { name: story.readyName }) : undefined;
+      if (!readyState || !(await readyState.isVisible())) {
+        await page.getByRole(story.clickRole ?? "button", { name: story.clickLabel }).click();
+      }
     }
     if (story.readyRole) {
       await expect(

--- a/client/src/stories/storybook-ready.ts
+++ b/client/src/stories/storybook-ready.ts
@@ -1,4 +1,4 @@
-import type { Browser, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 
 const STORY_ROOT_CHILD = "#storybook-root > *";
 const REQUIRED_THEME_TOKENS = ["--app-bg", "--app-text", "--app-accent", "--font-sans", "--font-mono"];
@@ -14,11 +14,6 @@ const SNAPSHOT_STYLE = `
     transition-duration: 0s !important;
   }
 `;
-
-interface WarmStorybookOptions {
-  attempts?: number;
-  attemptTimeoutMs?: number;
-}
 
 /**
  * Open one Storybook story and wait for actual story content.
@@ -56,65 +51,30 @@ async function installSnapshotMode(page: Page): Promise<void> {
     else document.addEventListener("DOMContentLoaded", install, { once: true });
   }, SNAPSHOT_STYLE);
 }
-
-async function visualStateSignature(page: Page): Promise<string> {
-  return page.evaluate(() => {
-    const root = document.querySelector("#storybook-root");
-    if (!root) return "missing-root";
-
-    let hash = 2166136261;
-    const add = (value: string | number) => {
-      const text = String(value);
-      for (let index = 0; index < text.length; index++) {
-        hash ^= text.charCodeAt(index);
-        hash = Math.imul(hash, 16777619);
-      }
-    };
-
-    for (const element of [root, ...root.querySelectorAll("*")]) {
-      const rect = element.getBoundingClientRect();
-      const style = getComputedStyle(element);
-      add(element.tagName);
-      add(Math.round(rect.x * 100));
-      add(Math.round(rect.y * 100));
-      add(Math.round(rect.width * 100));
-      add(Math.round(rect.height * 100));
-      add(style.backgroundColor);
-      add(style.color);
-      add(style.fill);
-      add(style.opacity);
-      add(style.stroke);
-      add(style.transform);
-    }
-
-    for (const canvas of root.querySelectorAll("canvas")) {
-      add(canvas.width);
-      add(canvas.height);
-      try {
-        add(canvas.toDataURL("image/png"));
-      } catch {
-        add("unreadable-canvas");
-      }
-    }
-
-    return (hash >>> 0).toString(16);
-  });
-}
-
-async function waitForStableVisualState(page: Page, timeoutMs: number): Promise<void> {
+async function waitForStableCanvases(page: Page, timeoutMs: number): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let previous = "";
   let stableSamples = 0;
 
   while (Date.now() < deadline) {
-    await page.waitForTimeout(100);
-    const current = await visualStateSignature(page);
+    await page.waitForTimeout(50);
+    const current = await page.evaluate(() =>
+      Array.from(document.querySelectorAll("canvas"))
+        .map((canvas) => {
+          try {
+            return `${canvas.width}x${canvas.height}:${canvas.toDataURL("image/png")}`;
+          } catch {
+            return `${canvas.width}x${canvas.height}:unreadable`;
+          }
+        })
+        .join("|"),
+    );
     stableSamples = current === previous ? stableSamples + 1 : 0;
     if (stableSamples >= 2) return;
     previous = current;
   }
 
-  throw new Error(`Storybook visual state did not settle within ${timeoutMs}ms`);
+  throw new Error(`Storybook canvas state did not settle within ${timeoutMs}ms`);
 }
 
 /**
@@ -123,9 +83,7 @@ async function waitForStableVisualState(page: Page, timeoutMs: number): Promise<
  * Snapshot mode is installed before navigation, so CSS transitions and
  * JavaScript reduced-motion branches never begin in a random phase. After
  * fonts and theme variables resolve, a one-pixel viewport pulse forces
- * ResizeObserver-backed charts and fit-to-viewport layouts to redraw. The
- * final stability loop includes DOM geometry, computed paint styles, and 2D
- * canvas pixels.
+ * ResizeObserver-backed charts and fit-to-viewport layouts to redraw.
  */
 export async function openStoryForSnapshot(page: Page, storyUrl: string, timeoutMs = 60_000): Promise<void> {
   await installSnapshotMode(page);
@@ -151,30 +109,5 @@ export async function openStoryForSnapshot(page: Page, storyUrl: string, timeout
   await page.waitForFunction(() => Array.from(document.querySelectorAll("[data-visual-ready]")).every((element) => element.getAttribute("data-visual-ready") === "ready"), undefined, {
     timeout: timeoutMs,
   });
-  await waitForStableVisualState(page, timeoutMs);
-}
-
-/**
- * Pay Storybook's cold preview compilation once before snapshot tests.
- *
- * Storybook 10 can leave its first preview navigation in
- * `sb-preparing-story` after the dev server index becomes available. Reloading
- * the iframe retries story preparation against the now-built preview graph.
- */
-export async function warmStorybook(browser: Browser, storyUrl: string, { attempts = 12, attemptTimeoutMs = 10_000 }: WarmStorybookOptions = {}): Promise<void> {
-  let lastError: unknown;
-
-  for (let attempt = 1; attempt <= attempts; attempt++) {
-    const page = await browser.newPage();
-    try {
-      await openStory(page, storyUrl, attemptTimeoutMs);
-      return;
-    } catch (error) {
-      lastError = error;
-    } finally {
-      await page.close().catch(() => undefined);
-    }
-  }
-
-  throw new Error(`Storybook never rendered ${storyUrl} after ${attempts} attempts`, { cause: lastError });
+  await waitForStableCanvases(page, timeoutMs);
 }

--- a/client/src/stories/theme.snapshot.ts
+++ b/client/src/stories/theme.snapshot.ts
@@ -1,18 +1,8 @@
 import { expect, test } from "@playwright/test";
 import { THEME_SNAPSHOT_CASE } from "./snapshot-cases";
-import { openStory, warmStorybook } from "./storybook-ready";
+import { openStory } from "./storybook-ready";
 
 const themeStoryUrl = `/iframe.html?id=${THEME_SNAPSHOT_CASE.id}&viewMode=story`;
-
-// Warm cold Storybook preview before charging compilation to this snapshot.
-test.setTimeout(120_000);
-test.beforeAll(async ({ browser }) => {
-  test.setTimeout(120_000);
-  await warmStorybook(browser, themeStoryUrl, {
-    attempts: 12,
-    attemptTimeoutMs: 10_000,
-  });
-});
 
 test(`snapshot: ${THEME_SNAPSHOT_CASE.name}`, async ({ page }) => {
   await openStory(page, themeStoryUrl);

--- a/docs/superpowers/specs/2026-08-20-storybook-snapshot-ci-design.md
+++ b/docs/superpowers/specs/2026-08-20-storybook-snapshot-ci-design.md
@@ -1,0 +1,39 @@
+# Storybook Snapshot CI Speed Design
+
+## Goal
+
+Speed Storybook visual snapshot runs without changing committed PNG output, pinned Playwright rendering, or diff artifact behavior. Static Storybook is the default for every snapshot command: local `snapshot:test`, baseline generation, Docker, and CI.
+
+## Architecture
+
+`client/playwright.config.ts` owns the snapshot server lifecycle. Playwright first builds Storybook once into `storybook-static`, then starts a static server on the configured snapshot port and waits for `/index.json`. The server must honor `RACEIQ_STORYBOOK_PORT` and `RACEIQ_STORYBOOK_ROOT` so existing local and CI invocation patterns remain valid. The static server replaces the cold `storybook dev` command; snapshot tests remain serial and retain existing snapshot/result directories.
+
+The static build is intentionally part of the Playwright `webServer` command rather than duplicated in GitHub workflows or the Docker entrypoint. This keeps all snapshot entrypoints behaviorally identical and leaves artifact collection unchanged.
+
+## Story readiness
+
+`openStoryForSnapshot` keeps deterministic setup and explicit readiness checks:
+
+1. Install reduced-motion snapshot CSS before navigation.
+2. Navigate to the iframe and wait for visible story-root content.
+3. Await `document.fonts.ready`.
+4. Require the existing theme CSS tokens.
+5. Require all document images to be complete and successfully decoded.
+6. Pulse the viewport to trigger ResizeObserver-backed layouts and charts.
+7. Require every `[data-visual-ready]` element to have value `ready`.
+
+Remove the full-tree geometry/computed-style/canvas data-URL signature loop. Static Storybook eliminates preview compilation races, while the explicit checks cover resources and app-owned readiness signals. Existing story-level targeted assertions remain unchanged.
+
+Obsolete `warmStorybook` calls and cold-preview comments are removed. No readiness check is removed merely for timing.
+
+## Error handling
+
+Playwright's existing web-server timeout and `/index.json` readiness remain the startup failure boundary. Story navigation continues to use its current retry behavior. Resource or app readiness failures continue to fail the individual snapshot with the existing timeout, preserving diagnostics rather than silently capturing an unstable frame.
+
+## Verification
+
+- Run the static Storybook snapshot suite and confirm all 25 cases pass.
+- Run `bun run snapshot:docker` in the pinned `mcr.microsoft.com/playwright:v1.62.0-jammy` renderer.
+- Compare generated PNGs byte-for-byte with committed baselines; investigate any drift rather than changing diff thresholds.
+- Record before/after wall-clock duration and report remaining bottlenecks.
+- Exercise CI-equivalent `snapshot:test` to preserve result/diff artifact generation.


### PR DESCRIPTION
## Summary
- build Storybook once with the test-optimized static build and serve it with Vite preview
- run two snapshot workers against static output
- replace full DOM/style/canvas stabilization with targeted readiness checks
- preserve pinned Docker renderer, PNG baselines, and diff artifacts

## Verification
- `bun run snapshot:docker`: 25/25 passed in 1m (previously ~7m)
- committed PNG baselines unchanged byte-for-byte
- Lefthook lint and typecheck passed

Closes #287