### PR TITLE
fix(ci): remove duplicate bench permissions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,11 +13,6 @@ concurrency:
   group: bench-${{ github.head_ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-
 jobs:
   bench:
     runs-on: blacksmith-2vcpu-ubuntu-2204


### PR DESCRIPTION
## Summary
- remove duplicate top-level permissions block from bench workflow
- restore GitHub Actions workflow parsing

## Verification
- Ruby YAML parse
- git diff --check
- pre-commit lint and typecheck