### PR TITLE
docs: fix local AI guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The database is created automatically on first run. No cloud account or external
 
 AI analysis is optional. Add your API key in the RaceIQ settings panel — multiple providers are supported. Analysis is sent directly to the provider's API, no intermediary server.
 
-Want to run AI entirely on your own PC? See the [Local AI](guides/local-ai.md) guide.
+Want to run AI entirely on your own PC? See the [Local AI setup guide](https://github.com/SpeedHQ/RaceIQ/blob/main/docs/user-guides/local-ai.md).
 
 ## Sponsorship
 


### PR DESCRIPTION
## Summary
- Point README Local AI setup link to docs/user-guides/local-ai.md
- Use canonical GitHub URL so link resolves from README

## Verification
- git diff --check
- Verified guide URL resolves
- Pre-commit lint and typecheck passed