### PR TITLE
test: enforce shard coverage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Check test shard coverage
+        run: bun run test:shards
+
       - name: Lint server, shared, scripts, tests, and client
         run: bun run lint
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 ### Internal
 - Speed Vite development startup with compact locale modules, no development declarations, cached unchanged compiles, and pinned Inlang compiler modules
 - Parallelize Bun unit and integration test execution with dedicated suites and isolated databases
+- Reject ordinary tests that are missing from or duplicated across unit and integration shards in local hooks and CI
 - Keep benchmark comparison checks green for fork pull requests when comment permissions are read-only
 - Speed Storybook visual snapshot CI with a test-optimized static build and concurrent workers
 - Replace Biome with Oxc for repository linting and formatting

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,9 @@
 pre-commit:
   parallel: false
   jobs:
+    - name: test shards
+      run: bun run test:shards
+
     - name: lint
       run: bun run lint
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:seed": "bun scripts/data/seed-db.ts",
+    "test:shards": "bun scripts/test/check-shards.ts",
     "test:unit": "bun scripts/test/run-suite.ts unit",
     "test:integration": "bun scripts/test/run-suite.ts integration",
     "test": "bun run test:unit && bun run test:integration",

--- a/scripts/test/check-shards.ts
+++ b/scripts/test/check-shards.ts
@@ -1,0 +1,97 @@
+import { existsSync, readFileSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+const SHARDS = ["unit", "integration"] as const;
+type Shard = (typeof SHARDS)[number];
+
+interface Assignment {
+  location: string;
+  shard: Shard;
+}
+
+export interface ShardCoverage {
+  shardCounts: Record<Shard, number>;
+  testCount: number;
+}
+
+function ordinaryTestFiles(root: string): string[] {
+  const files = new Set<string>();
+  for (const pattern of ["test/**/*.test.ts", "test/**/*.test.tsx"]) {
+    for (const file of new Bun.Glob(pattern).scanSync({ cwd: root, onlyFiles: true })) {
+      files.add(file.replaceAll("\\", "/"));
+    }
+  }
+  return [...files].sort();
+}
+
+export function checkTestShards(root = resolve(import.meta.dir, "../..")): ShardCoverage {
+  const assignments = new Map<string, Assignment>();
+  const errors: string[] = [];
+  const shardCounts: Record<Shard, number> = { unit: 0, integration: 0 };
+
+  for (const shard of SHARDS) {
+    const manifestRelativePath = `scripts/test/${shard}-files.txt`;
+    const manifestPath = resolve(root, manifestRelativePath);
+    const text = readFileSync(manifestPath, "utf8");
+
+    for (const [index, raw] of text.split(/\r?\n/).entries()) {
+      const line = raw.trim();
+      if (!line || line.startsWith("#")) continue;
+
+      const normalized = line.replaceAll("\\", "/");
+      const absolute = resolve(root, normalized);
+      const relativePath = relative(root, absolute).replaceAll(sep, "/");
+      const location = `${manifestRelativePath}:${index + 1}`;
+
+      if (relativePath !== normalized || !relativePath.startsWith("test/")) {
+        errors.push(`${location}: path must stay inside test/: ${line}`);
+        continue;
+      }
+      if (!/\.test\.tsx?$/.test(relativePath)) {
+        errors.push(`${location}: invalid test path: ${line}`);
+        continue;
+      }
+      if (!existsSync(absolute)) {
+        errors.push(`${location}: listed test file does not exist: ${relativePath}`);
+      }
+
+      const previous = assignments.get(relativePath);
+      if (previous) {
+        errors.push(`${relativePath}: listed more than once (${previous.location}, ${location})`);
+        continue;
+      }
+
+      assignments.set(relativePath, { location, shard });
+      shardCounts[shard] += 1;
+    }
+
+    if (shardCounts[shard] === 0) errors.push(`${manifestRelativePath}: no test files`);
+  }
+
+  const discovered = ordinaryTestFiles(root);
+  const discoveredSet = new Set(discovered);
+  for (const file of discovered) {
+    if (!assignments.has(file)) errors.push(`${file}: not assigned to a test shard`);
+  }
+  for (const [file, assignment] of assignments) {
+    if (existsSync(resolve(root, file)) && !discoveredSet.has(file)) {
+      errors.push(`${assignment.location}: listed path is not an ordinary test file: ${file}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(`Test shard coverage failed:\n${errors.map((error) => `- ${error}`).join("\n")}`);
+  }
+
+  return { shardCounts, testCount: discovered.length };
+}
+
+if (import.meta.main) {
+  try {
+    const coverage = checkTestShards();
+    console.log(`All ${coverage.testCount} ordinary tests are assigned exactly once ` + `(${coverage.shardCounts.unit} unit, ${coverage.shardCounts.integration} integration).`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+  }
+}

--- a/scripts/test/run-suite.ts
+++ b/scripts/test/run-suite.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve, relative, sep } from "node:path";
+import { checkTestShards } from "./check-shards";
 
 const suite = process.argv[2];
 if (suite !== "unit" && suite !== "integration") {
@@ -9,6 +10,7 @@ if (suite !== "unit" && suite !== "integration") {
 }
 
 const root = resolve(import.meta.dir, "../..");
+checkTestShards(root);
 const manifestPath = resolve(root, "scripts/test", `${suite}-files.txt`);
 const config = suite === "unit" ? "bunfig.unit.toml" : "bunfig.integration.toml";
 const text = await Bun.file(manifestPath).text();
@@ -34,7 +36,7 @@ for (const [index, raw] of text.split(/\r?\n/).entries()) {
 if (files.length === 0) throw new Error(`${manifestPath}: no test files`);
 
 const workers = process.env.BUN_TEST_WORKERS ?? "4";
-if (suite === "unit" && !/^\d+$/.test(workers) || suite === "unit" && Number(workers) < 1) {
+if ((suite === "unit" && !/^\d+$/.test(workers)) || (suite === "unit" && Number(workers) < 1)) {
   throw new Error("BUN_TEST_WORKERS must be a positive integer");
 }
 const suiteRoot = mkdtempSync(resolve(tmpdir(), `raceiq-bun-${suite}-`));
@@ -43,13 +45,12 @@ try {
   const suiteRootToml = suiteRoot.replaceAll("\\", "/");
   const configPath = resolve(suiteRoot, "bunfig.toml");
   const preload = resolve(root, "test/support/setup-data-dir.ts").replaceAll("\\", "/");
-  writeFileSync(configPath, suite === "unit"
-    ? `[test]\nroot = "${suiteRootToml}"\ntimeout = 30000\n`
-    : `[test]\nroot = "${suiteRootToml}"\npreload = ["${preload}"]\ntimeout = 30000\nmaxConcurrency = 1\n`);
+  writeFileSync(
+    configPath,
+    suite === "unit" ? `[test]\nroot = "${suiteRootToml}"\ntimeout = 30000\n` : `[test]\nroot = "${suiteRootToml}"\npreload = ["${preload}"]\ntimeout = 30000\nmaxConcurrency = 1\n`,
+  );
   const manifestFiles = files.map((file) => resolve(root, file));
-  const args = suite === "unit"
-    ? ["test", "--config", configPath, "--parallel", workers, ...manifestFiles]
-    : ["test", "--config", configPath, "--max-concurrency=1", ...manifestFiles];
+  const args = suite === "unit" ? ["test", "--config", configPath, "--parallel", workers, ...manifestFiles] : ["test", "--config", configPath, "--max-concurrency=1", ...manifestFiles];
   const env = { ...process.env };
   if (suite === "unit") env.RACEIQ_UNIT_TESTS = "1";
   if (suite === "integration" && env.DATA_DIR === undefined) env.DATA_DIR = resolve(root, ".data-test");

--- a/scripts/test/unit-files.txt
+++ b/scripts/test/unit-files.txt
@@ -26,3 +26,4 @@ test/lap-analysis/stints/stint-stats.test.ts
 test/lap-analysis/stints/stint-trace-codec.test.ts
 test/lap-analysis/stints/stint-traces.test.ts
 test/lap-analysis/time-loss.test.ts
+test/tooling/test-shards.test.ts

--- a/test/README.md
+++ b/test/README.md
@@ -11,6 +11,7 @@ ending in `*.test.ts` and `*.test.tsx` below `test/`. Files ending in
 partitioned by manifests:
 
 ```sh
+bun run test:shards
 bun run test:unit
 bun run test:integration
 bun run test
@@ -18,6 +19,10 @@ bun test test/games/shared/parser.test.ts --timeout 30000
 bun run test:ai
 bun run bench
 ```
+
+`bun run test:shards` verifies every ordinary test belongs to exactly one
+manifest and rejects duplicate, missing, stale, or invalid entries. Suite
+runners, pre-commit checks, and CI run this guard before tests can be skipped.
 
 `bun run test:unit` runs only `scripts/test/unit-files.txt`. It is DB-free:
 there is no DB preload, and Bun may run workers in parallel. `bun run

--- a/test/tooling/test-shards.test.ts
+++ b/test/tooling/test-shards.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { checkTestShards } from "../../scripts/test/check-shards";
+
+interface ShardFixture {
+  integration: string[];
+  tests: string[];
+  unit: string[];
+}
+
+function withShardFixture(fixture: ShardFixture, run: (root: string) => void): void {
+  const root = mkdtempSync(resolve(tmpdir(), "raceiq-test-shards-"));
+  try {
+    mkdirSync(resolve(root, "scripts/test"), { recursive: true });
+    writeFileSync(resolve(root, "scripts/test/unit-files.txt"), fixture.unit.join("\n"));
+    writeFileSync(resolve(root, "scripts/test/integration-files.txt"), fixture.integration.join("\n"));
+    for (const file of fixture.tests) {
+      const path = resolve(root, file);
+      mkdirSync(resolve(path, ".."), { recursive: true });
+      writeFileSync(path, "");
+    }
+    run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe("test shard coverage", () => {
+  test("accepts every ordinary test assigned exactly once", () => {
+    withShardFixture(
+      {
+        unit: ["test/unit/example.test.ts"],
+        integration: ["test/integration/example.test.tsx"],
+        tests: ["test/unit/example.test.ts", "test/integration/example.test.tsx"],
+      },
+      (root) => {
+        expect(checkTestShards(root)).toEqual({
+          testCount: 2,
+          shardCounts: { unit: 1, integration: 1 },
+        });
+      },
+    );
+  });
+
+  test("rejects an ordinary test missing from both shards", () => {
+    withShardFixture(
+      {
+        unit: ["test/unit/example.test.ts"],
+        integration: ["test/integration/example.test.ts"],
+        tests: ["test/unit/example.test.ts", "test/integration/example.test.ts", "test/new.test.ts"],
+      },
+      (root) => {
+        expect(() => checkTestShards(root)).toThrow("test/new.test.ts: not assigned to a test shard");
+      },
+    );
+  });
+
+  test("rejects a test assigned to multiple shards", () => {
+    withShardFixture(
+      {
+        unit: ["test/shared.test.ts"],
+        integration: ["test/shared.test.ts"],
+        tests: ["test/shared.test.ts"],
+      },
+      (root) => {
+        expect(() => checkTestShards(root)).toThrow("test/shared.test.ts: listed more than once");
+      },
+    );
+  });
+
+  test("rejects a stale manifest entry", () => {
+    withShardFixture(
+      {
+        unit: ["test/unit/example.test.ts"],
+        integration: ["test/deleted.test.ts"],
+        tests: ["test/unit/example.test.ts"],
+      },
+      (root) => {
+        expect(() => checkTestShards(root)).toThrow("listed test file does not exist: test/deleted.test.ts");
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- validate every ordinary Bun test appears exactly once across unit and integration manifests
- run shard coverage guard from suite runners, pre-commit, and CI
- cover missing, duplicate, stale, and invalid manifest entries

## Testing
- `bun run test:shards`
- `bun run test:unit`
- `bun run typecheck`
- `bun run lint`
- `bun test test/tooling/changelog.test.ts --timeout 60000`