### PR TITLE
feat(tracks): deliver curated track imagery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - Hide unsupported telemetry channels and label iRacing pit snapshots instead of presenting normalized zeroes as live data
 - Resolve car and track names on the global home page in each lap's game context
 - Treat tracks without optional boundary geometry as available instead of failed requests
+- Load curated track imagery from checksum-verified cached artifacts when imagery packs are not bundled
 - Open Analyse from home and session recaps without a full-page white flash
 - Keep Analyse responsive while loading and playing large laps or recovering from server disconnects
 - Keep Analyse 3D playback at configured 60 or 120 FPS while telemetry panels update

--- a/scripts/test/integration-files.txt
+++ b/scripts/test/integration-files.txt
@@ -196,6 +196,7 @@ test/tooling/story-isolation.test.ts
 test/tooling/storybook-ready.test.ts
 test/tooling/theme-contract.test.ts
 test/tooling/version-label.test.ts
+test/track-imagery.test.ts
 test/tracks/compact-route.test.ts
 test/tracks/discovered-cars.test.ts
 test/tracks/guides/anchor-validity.test.ts

--- a/scripts/test/integration-files.txt
+++ b/scripts/test/integration-files.txt
@@ -196,6 +196,7 @@ test/tooling/story-isolation.test.ts
 test/tooling/storybook-ready.test.ts
 test/tooling/theme-contract.test.ts
 test/tooling/version-label.test.ts
+test/track-imagery-artifact.test.ts
 test/track-imagery.test.ts
 test/tracks/compact-route.test.ts
 test/tracks/discovered-cars.test.ts

--- a/server/routes/tracks/imagery-routes.ts
+++ b/server/routes/tracks/imagery-routes.ts
@@ -27,20 +27,20 @@ const BaseTrackImageQuerySchema = z.object({
 });
 
 export const trackImageryRoutes = new Hono()
-  .get("/api/track-imagery/:ordinal", zValidator("param", OrdinalParamSchema), zValidator("query", TrackImageryQuerySchema), (c) => {
+  .get("/api/track-imagery/:ordinal", zValidator("param", OrdinalParamSchema), zValidator("query", TrackImageryQuerySchema), async (c) => {
     const { ordinal } = c.req.valid("param");
     const { gameId } = c.req.valid("query");
     if (!Number.isSafeInteger(ordinal) || ordinal < 0) return c.json({ error: "Invalid track ordinal" }, 400);
-    const loaded = loadTrackImagery(gameId, ordinal);
+    const loaded = await loadTrackImagery(gameId, ordinal);
     return c.json(loaded?.imagery ?? null);
   })
-  .get("/api/track-imagery/:ordinal/base/hq/:x/:y", zValidator("param", TrackImageryTileParamSchema), zValidator("query", TrackImageryQuerySchema), (c) => {
+  .get("/api/track-imagery/:ordinal/base/hq/:x/:y", zValidator("param", TrackImageryTileParamSchema), zValidator("query", TrackImageryQuerySchema), async (c) => {
     const { ordinal, x, y } = c.req.valid("param");
     const { gameId } = c.req.valid("query");
     const tileX = Number(x);
     const tileY = Number(y);
     if (!Number.isSafeInteger(ordinal) || ordinal < 0 || !Number.isSafeInteger(tileX) || !Number.isSafeInteger(tileY)) return c.json({ error: "Invalid imagery tile coordinate" }, 400);
-    const loaded = loadTrackImagery(gameId, ordinal);
+    const loaded = await loadTrackImagery(gameId, ordinal);
     if (!loaded) return c.json({ error: "Track imagery not found" }, 404);
     const tile = readTrackImageryPackTile(loaded.packPath, tileX, tileY, loaded.packMetadata);
     if (!tile) return c.json({ error: "Track imagery tile not found" }, 404);
@@ -52,11 +52,11 @@ export const trackImageryRoutes = new Hono()
       },
     });
   })
-  .get("/api/track-imagery/:ordinal/texture/:textureId", zValidator("param", TrackImageryTextureParamSchema), zValidator("query", TrackImageryQuerySchema), (c) => {
+  .get("/api/track-imagery/:ordinal/texture/:textureId", zValidator("param", TrackImageryTextureParamSchema), zValidator("query", TrackImageryQuerySchema), async (c) => {
     const { ordinal, textureId } = c.req.valid("param");
     const { gameId } = c.req.valid("query");
     if (!Number.isSafeInteger(ordinal) || ordinal < 0) return c.json({ error: "Invalid track ordinal" }, 400);
-    const loaded = loadTrackImagery(gameId, ordinal);
+    const loaded = await loadTrackImagery(gameId, ordinal);
     const texture = loaded?.textures[textureId];
     if (!texture) return c.json({ error: "Track imagery texture not found" }, 404);
     return new Response(Bun.file(texture.path), {

--- a/server/routes/tracks/imagery-routes.ts
+++ b/server/routes/tracks/imagery-routes.ts
@@ -1,0 +1,96 @@
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { z } from "zod";
+import { GameIdSchema } from "../../../shared/games/ids";
+import { OrdinalParamSchema } from "../../../shared/platform/http/route-schemas";
+import { getBaseTrackImagePath, loadTrackImagery, saveBaseTrackImage } from "../../tracks/imagery";
+import { readTrackImageryPackTile } from "../../tracks/imagery-pack";
+
+const TrackImageryQuerySchema = z.object({ gameId: GameIdSchema });
+const TrackImageryTextureParamSchema = OrdinalParamSchema.extend({ textureId: z.string().regex(/^[a-z0-9][a-z0-9-]*$/) });
+const TrackImageryTileParamSchema = OrdinalParamSchema.extend({
+  x: z.string().regex(/^(?:0|[1-9]\d*)$/),
+  y: z.string().regex(/^(?:0|[1-9]\d*)$/),
+});
+
+const MAX_BASE_TRACK_IMAGE_BYTES = 20 * 1024 * 1024;
+const SUPPORTED_IMAGE_TYPES: Record<string, true> = {
+  "image/jpeg": true,
+  "image/png": true,
+  "image/webp": true,
+  "image/avif": true,
+};
+const BaseTrackImageQuerySchema = z.object({
+  gameId: GameIdSchema,
+  baseTrackName: z.string().trim().min(1).max(200),
+  v: z.string().optional(),
+});
+
+export const trackImageryRoutes = new Hono()
+  .get("/api/track-imagery/:ordinal", zValidator("param", OrdinalParamSchema), zValidator("query", TrackImageryQuerySchema), (c) => {
+    const { ordinal } = c.req.valid("param");
+    const { gameId } = c.req.valid("query");
+    if (!Number.isSafeInteger(ordinal) || ordinal < 0) return c.json({ error: "Invalid track ordinal" }, 400);
+    const loaded = loadTrackImagery(gameId, ordinal);
+    return c.json(loaded?.imagery ?? null);
+  })
+  .get("/api/track-imagery/:ordinal/base/hq/:x/:y", zValidator("param", TrackImageryTileParamSchema), zValidator("query", TrackImageryQuerySchema), (c) => {
+    const { ordinal, x, y } = c.req.valid("param");
+    const { gameId } = c.req.valid("query");
+    const tileX = Number(x);
+    const tileY = Number(y);
+    if (!Number.isSafeInteger(ordinal) || ordinal < 0 || !Number.isSafeInteger(tileX) || !Number.isSafeInteger(tileY)) return c.json({ error: "Invalid imagery tile coordinate" }, 400);
+    const loaded = loadTrackImagery(gameId, ordinal);
+    if (!loaded) return c.json({ error: "Track imagery not found" }, 404);
+    const tile = readTrackImageryPackTile(loaded.packPath, tileX, tileY, loaded.packMetadata);
+    if (!tile) return c.json({ error: "Track imagery tile not found" }, 404);
+    return new Response(Uint8Array.from(tile.data).buffer, {
+      headers: {
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Type": "image/webp",
+        ETag: `"${loaded.imagery.base.contentHash}-${tileX}-${tileY}"`,
+      },
+    });
+  })
+  .get("/api/track-imagery/:ordinal/texture/:textureId", zValidator("param", TrackImageryTextureParamSchema), zValidator("query", TrackImageryQuerySchema), (c) => {
+    const { ordinal, textureId } = c.req.valid("param");
+    const { gameId } = c.req.valid("query");
+    if (!Number.isSafeInteger(ordinal) || ordinal < 0) return c.json({ error: "Invalid track ordinal" }, 400);
+    const loaded = loadTrackImagery(gameId, ordinal);
+    const texture = loaded?.textures[textureId];
+    if (!texture) return c.json({ error: "Track imagery texture not found" }, 404);
+    return new Response(Bun.file(texture.path), {
+      headers: {
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Type": texture.path.toLowerCase().endsWith(".png") ? "image/png" : texture.path.toLowerCase().endsWith(".webp") ? "image/webp" : "image/jpeg",
+        ETag: `"${Math.round(texture.modifiedAtMs)}"`,
+      },
+    });
+  })
+  .get("/api/track-base-image", zValidator("query", BaseTrackImageQuerySchema), async (c) => {
+    const { gameId, baseTrackName } = c.req.valid("query");
+    const image = Bun.file(getBaseTrackImagePath(gameId, baseTrackName));
+    if (!(await image.exists())) return c.json({ error: "Base track image not found" }, 404);
+
+    return new Response(image, {
+      headers: {
+        "Cache-Control": "public, max-age=31536000, immutable",
+        "Content-Type": "image/webp",
+      },
+    });
+  })
+  .post("/api/track-base-image", zValidator("query", BaseTrackImageQuerySchema), async (c) => {
+    const { gameId, baseTrackName } = c.req.valid("query");
+    const form = await c.req.formData().catch(() => null);
+    const file = form?.get("file");
+    if (!(file instanceof File)) return c.json({ error: "Missing 'file' in multipart body" }, 400);
+    if (!SUPPORTED_IMAGE_TYPES[file.type]) return c.json({ error: "Expected a JPEG, PNG, WebP, or AVIF image" }, 400);
+    if (file.size === 0 || file.size > MAX_BASE_TRACK_IMAGE_BYTES) return c.json({ error: "Image must be between 1 byte and 20 MB" }, 400);
+
+    try {
+      const imageUrl = await saveBaseTrackImage(gameId, baseTrackName, await file.arrayBuffer());
+      return c.json({ imageUrl });
+    } catch {
+      return c.json({ error: "Image could not be decoded" }, 400);
+    }
+  });

--- a/server/routes/tracks/index.ts
+++ b/server/routes/tracks/index.ts
@@ -18,6 +18,7 @@ import {
   trackCalibrationRoutes,
   trackGeometryRoutes,
 } from "./geometry-routes";
+import { trackImageryRoutes } from "./imagery-routes";
 
 // Keep registration order identical to the former monolithic router.
 export const trackRoutes = new Hono()
@@ -31,4 +32,5 @@ export const trackRoutes = new Hono()
   .route("/", trackCalibrationRoutes)
   .route("/", trackLapSectorRoutes)
   .route("/", trackOutlineRoutes)
+  .route("/", trackImageryRoutes)
   .route("/", trackGeometryRoutes);

--- a/server/tracks/configuration.ts
+++ b/server/tracks/configuration.ts
@@ -1,0 +1,168 @@
+import { KNOWN_GAME_IDS, type GameId } from "../../shared/games/ids";
+import { TrackConfigurationSchema, trackConfigurationCanonicalId, type TrackConfiguration, type TrackIdentityNode } from "../../shared/racing/tracks/configuration";
+import { updateTrackRegistrySource } from "../../shared/racing/tracks/registry-source";
+import { getTrackRegistry } from "../../shared/racing/tracks/registry";
+
+interface ConfigurationRow {
+  gameId: GameId;
+  trackOrdinal: number;
+  venuePath: string;
+  layoutSlug: string;
+  layoutName: string;
+  confirmedAt: string | null;
+  confirmedBy: string | null;
+  commitId: string | null;
+}
+
+interface VenueRow extends TrackIdentityNode {
+  path: string;
+  depth: number;
+}
+
+const CONFIGURATION_SELECT = `
+  SELECT gt.game_id AS gameId,
+         gt.track_ordinal AS trackOrdinal,
+         l.venue_path AS venuePath,
+         l.slug AS layoutSlug,
+         l.name AS layoutName,
+         gt.confirmed_at AS confirmedAt,
+         gt.confirmed_by AS confirmedBy,
+         gt.commit_id AS commitId
+    FROM game_tracks gt
+    JOIN layouts l ON l.canonical_id = gt.layout_id`;
+
+function venueNodesByPath(): Map<string, VenueRow> {
+  const rows = getTrackRegistry()
+    .query("SELECT path, slug AS id, name, depth FROM venue_nodes ORDER BY depth, path")
+    .all() as VenueRow[];
+  return new Map(rows.map((row) => [row.path, row]));
+}
+
+function configurationFromRow(row: ConfigurationRow, venues: Map<string, VenueRow>): TrackConfiguration {
+  const paths = row.venuePath.split("/").map((_, index, parts) => parts.slice(0, index + 1).join("/"));
+  const nodes = paths.map((path) => venues.get(path));
+  if (nodes.some((entry) => !entry)) throw new Error(`Track registry venue hierarchy is incomplete for ${row.venuePath}`);
+  const [venue, ...subVenues] = nodes as VenueRow[];
+  return TrackConfigurationSchema.parse({
+    version: 1,
+    gameId: row.gameId,
+    trackOrdinal: row.trackOrdinal,
+    venue: { id: venue.id, name: venue.name },
+    subVenues: subVenues.map(({ id, name }) => ({ id, name })),
+    track: { id: row.layoutSlug, name: row.layoutName },
+    confirmation: row.confirmedAt && row.confirmedBy
+      ? { confirmedAt: row.confirmedAt, confirmedBy: row.confirmedBy, ...(row.commitId ? { commitId: row.commitId } : {}) }
+      : null,
+  });
+}
+
+export function loadTrackConfiguration(gameId: GameId, trackOrdinal: number): TrackConfiguration | null {
+  const row = getTrackRegistry()
+    .query(`${CONFIGURATION_SELECT} WHERE gt.game_id = ? AND gt.track_ordinal = ?`)
+    .get(gameId, trackOrdinal) as ConfigurationRow | null;
+  return row ? configurationFromRow(row, venueNodesByPath()) : null;
+}
+
+/** Resolve authored facts identity directly from generated registry SQLite. */
+export function loadTrackConfigurationFactsSlug(gameId: GameId, trackOrdinal: number): string | null {
+  const row = getTrackRegistry().query(`
+    SELECT l.facts_slug AS factsSlug
+      FROM game_tracks gt
+      JOIN layouts l ON l.canonical_id = gt.layout_id
+     WHERE gt.game_id = ? AND gt.track_ordinal = ?
+  `).get(gameId, trackOrdinal) as { factsSlug: string | null } | null;
+  return row?.factsSlug ?? null;
+}
+
+export function listTrackConfigurations(): TrackConfiguration[] {
+  const venues = venueNodesByPath();
+  const rows = getTrackRegistry().query(`${CONFIGURATION_SELECT} ORDER BY gt.game_id, gt.track_ordinal`).all() as ConfigurationRow[];
+  return rows
+    .map((row) => configurationFromRow(row, venues))
+    .sort((a, b) => KNOWN_GAME_IDS.indexOf(a.gameId) - KNOWN_GAME_IDS.indexOf(b.gameId) || a.trackOrdinal - b.trackOrdinal);
+}
+
+export function saveTrackConfiguration(configuration: TrackConfiguration): TrackConfiguration {
+  const parsed = TrackConfigurationSchema.parse(configuration);
+  updateTrackRegistrySource((draft) => {
+    const pathParts: string[] = [];
+    for (const node of [parsed.venue, ...parsed.subVenues]) {
+      pathParts.push(node.id);
+      const venue = { id: pathParts.join("/"), name: node.name };
+      const venueIndex = draft.configurations.venues.findIndex((entry) => entry.id === venue.id);
+      if (venueIndex >= 0) draft.configurations.venues[venueIndex] = venue;
+      else draft.configurations.venues.push(venue);
+    }
+
+    const canonicalId = trackConfigurationCanonicalId(parsed);
+    const layoutIndex = draft.configurations.layouts.findIndex((entry) => entry.id === canonicalId);
+    if (layoutIndex >= 0) {
+      draft.configurations.layouts[layoutIndex] = {
+        ...draft.configurations.layouts[layoutIndex],
+        id: canonicalId,
+        name: parsed.track.name,
+      };
+    } else {
+      draft.configurations.layouts.push({ id: canonicalId, name: parsed.track.name });
+    }
+
+    const assignment = {
+      gameId: parsed.gameId,
+      trackOrdinal: parsed.trackOrdinal,
+      layoutId: canonicalId,
+      confirmation: parsed.confirmation,
+    };
+    const assignmentIndex = draft.configurations.assignments.findIndex(
+      (entry) => entry.gameId === parsed.gameId && entry.trackOrdinal === parsed.trackOrdinal,
+    );
+    if (assignmentIndex >= 0) draft.configurations.assignments[assignmentIndex] = assignment;
+    else draft.configurations.assignments.push(assignment);
+  });
+  return parsed;
+}
+
+export function deleteTrackConfiguration(gameId: GameId, trackOrdinal: number): boolean {
+  let deleted = false;
+  updateTrackRegistrySource((draft) => {
+    const index = draft.configurations.assignments.findIndex(
+      (entry) => entry.gameId === gameId && entry.trackOrdinal === trackOrdinal,
+    );
+    if (index < 0) return;
+    draft.configurations.assignments.splice(index, 1);
+    deleted = true;
+  });
+  return deleted;
+}
+
+/** List tracks from one game in the same root venue family, preferring overall venue layouts before historical descendants. */
+export function listTrackVenueFamilyConfigurations(gameId: GameId, trackOrdinal: number, venueGameId: GameId): TrackConfiguration[] {
+  const source = loadTrackConfiguration(gameId, trackOrdinal);
+  if (!source) return [];
+  const venueRoot = source.venue.id;
+  const rows = getTrackRegistry().query(`
+    ${CONFIGURATION_SELECT}
+     WHERE gt.game_id = ?
+       AND (l.venue_path = ? OR l.venue_path LIKE ?)
+     ORDER BY CASE WHEN l.venue_path = ? THEN 0 ELSE 1 END,
+              l.venue_path,
+              gt.track_ordinal
+  `).all(venueGameId, venueRoot, `${venueRoot}/%`, venueRoot) as ConfigurationRow[];
+  const venues = venueNodesByPath();
+  return rows.map((row) => configurationFromRow(row, venues));
+}
+
+/** List tracks assigned to the same exact canonical layout, excluding source track. */
+export function listCanonicalTrackPeers(gameId: GameId, trackOrdinal: number): TrackConfiguration[] {
+  const rows = getTrackRegistry().query(`
+    ${CONFIGURATION_SELECT}
+     WHERE gt.layout_id = (SELECT layout_id FROM game_tracks WHERE game_id = ? AND track_ordinal = ?)
+       AND (gt.game_id <> ? OR gt.track_ordinal <> ?)
+     ORDER BY gt.game_id, gt.track_ordinal
+  `).all(gameId, trackOrdinal, gameId, trackOrdinal) as ConfigurationRow[];
+  const venues = venueNodesByPath();
+  return rows.map((row) => configurationFromRow(row, venues));
+}
+
+export function loadCanonicalTrackPeer(gameId: GameId, trackOrdinal: number, peerGameId: GameId): TrackConfiguration | null {
+  return listCanonicalTrackPeers(gameId, trackOrdinal).find((configuration) => configuration.gameId === peerGameId) ?? null;
+}

--- a/server/tracks/imagery-artifact.ts
+++ b/server/tracks/imagery-artifact.ts
@@ -1,0 +1,101 @@
+import { createHash, randomBytes } from "node:crypto";
+import { createReadStream, existsSync, mkdirSync, renameSync, rmSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import type { TrackImageryArtifact } from "../../shared/racing/tracks/imagery";
+import { USER_TRACKS_DIR } from "../../shared/platform/runtime/data-paths";
+
+const TRACK_IMAGERY_ARTIFACT_CACHE = resolve(USER_TRACKS_DIR, "track-imagery-artifacts");
+const DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
+
+type TrackImageryArtifactFetcher = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+interface VerifiedFile {
+  modifiedAtMs: number;
+  sizeBytes: number;
+}
+
+interface ResolveTrackImageryPackOptions {
+  cacheDirectory?: string;
+  fetcher?: TrackImageryArtifactFetcher;
+}
+
+const verifiedFiles = new Map<string, VerifiedFile>();
+const pendingArtifacts = new Map<string, Promise<string>>();
+
+async function sha256File(path: string): Promise<string> {
+  const hash = createHash("sha256");
+  for await (const chunk of createReadStream(path)) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function verifyArtifactFile(path: string, artifact: TrackImageryArtifact): Promise<boolean> {
+  if (!existsSync(path)) return false;
+  const stat = statSync(path);
+  if (!stat.isFile() || stat.size !== artifact.sizeBytes) return false;
+
+  const cacheKey = `${path}\0${artifact.sha256}`;
+  const verified = verifiedFiles.get(cacheKey);
+  if (verified?.modifiedAtMs === stat.mtimeMs && verified.sizeBytes === stat.size) return true;
+  if ((await sha256File(path)) !== artifact.sha256) return false;
+
+  verifiedFiles.set(cacheKey, { modifiedAtMs: stat.mtimeMs, sizeBytes: stat.size });
+  return true;
+}
+
+async function downloadArtifact(artifact: TrackImageryArtifact, cacheDirectory: string, fetcher: TrackImageryArtifactFetcher): Promise<string> {
+  mkdirSync(cacheDirectory, { recursive: true });
+  const cachePath = resolve(cacheDirectory, `${artifact.sha256}.rqi`);
+  if (await verifyArtifactFile(cachePath, artifact)) return cachePath;
+  rmSync(cachePath, { force: true });
+
+  const response = await fetcher(artifact.url, {
+    headers: { Accept: "application/octet-stream" },
+    signal: AbortSignal.timeout(DOWNLOAD_TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`Track imagery artifact ${artifact.version} returned HTTP ${response.status}`);
+
+  const temporaryPath = `${cachePath}.${process.pid}.${randomBytes(6).toString("hex")}.tmp`;
+  const temporaryVerificationKey = `${temporaryPath}\0${artifact.sha256}`;
+  try {
+    const sizeBytes = await Bun.write(temporaryPath, response);
+    if (sizeBytes !== artifact.sizeBytes) {
+      throw new Error(`Track imagery artifact ${artifact.version} size mismatch: expected ${artifact.sizeBytes}, received ${sizeBytes}`);
+    }
+    if (!(await verifyArtifactFile(temporaryPath, artifact))) {
+      throw new Error(`Track imagery artifact ${artifact.version} SHA-256 mismatch`);
+    }
+    try {
+      renameSync(temporaryPath, cachePath);
+    } catch (error) {
+      if (await verifyArtifactFile(cachePath, artifact)) return cachePath;
+      throw error;
+    }
+    const stat = statSync(cachePath);
+    verifiedFiles.set(`${cachePath}\0${artifact.sha256}`, { modifiedAtMs: stat.mtimeMs, sizeBytes: stat.size });
+    return cachePath;
+  } finally {
+    verifiedFiles.delete(temporaryVerificationKey);
+    rmSync(temporaryPath, { force: true });
+  }
+}
+
+export async function resolveTrackImageryPackPath(localPath: string, artifact?: TrackImageryArtifact, options: ResolveTrackImageryPackOptions = {}): Promise<string> {
+  if (!artifact) {
+    if (!existsSync(localPath)) throw new Error(`Missing track imagery package ${localPath}`);
+    return localPath;
+  }
+  if (await verifyArtifactFile(localPath, artifact)) return localPath;
+
+  const cacheDirectory = options.cacheDirectory ?? TRACK_IMAGERY_ARTIFACT_CACHE;
+  const pendingKey = `${cacheDirectory}\0${artifact.sha256}`;
+  const existing = pendingArtifacts.get(pendingKey);
+  if (existing) return existing;
+
+  const pending = downloadArtifact(artifact, cacheDirectory, options.fetcher ?? fetch);
+  pendingArtifacts.set(pendingKey, pending);
+  try {
+    return await pending;
+  } finally {
+    if (pendingArtifacts.get(pendingKey) === pending) pendingArtifacts.delete(pendingKey);
+  }
+}

--- a/server/tracks/imagery-pack.ts
+++ b/server/tracks/imagery-pack.ts
@@ -1,0 +1,331 @@
+import { Database } from "bun:sqlite";
+import { createHash, randomUUID } from "node:crypto";
+import { mkdirSync, renameSync, rmSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { TRACK_IMAGERY_PACKAGE_NAME, TrackImageryGeographicBoundsSchema, type TrackImageryGeographicBounds } from "../../shared/racing/tracks/imagery";
+
+export { TRACK_IMAGERY_PACKAGE_NAME };
+
+export const TRACK_IMAGERY_PACK_SCHEMA_VERSION = 1 as const;
+export const TRACK_IMAGERY_PACK_TIER = "hq" as const;
+export const TRACK_IMAGERY_PACK_FORMAT = "webp" as const;
+
+export interface TrackImageryPackMetadata {
+  schemaVersion: typeof TRACK_IMAGERY_PACK_SCHEMA_VERSION;
+  tier: typeof TRACK_IMAGERY_PACK_TIER;
+  width: number;
+  height: number;
+  tileSize: number;
+  columns: number;
+  rows: number;
+  resolutionM?: number;
+  bounds: TrackImageryGeographicBounds;
+  contentHash?: string;
+}
+
+export interface TrackImageryPackTile {
+  tier: typeof TRACK_IMAGERY_PACK_TIER;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  format: typeof TRACK_IMAGERY_PACK_FORMAT;
+  data: Uint8Array;
+}
+
+export type TrackImageryPackTileSource = Iterable<TrackImageryPackTile> | AsyncIterable<TrackImageryPackTile>;
+
+export interface TrackImageryPackWriteOptions {
+  signal?: AbortSignal;
+  deadlineAtMs?: number;
+}
+
+function assertPackWriteActive(options: TrackImageryPackWriteOptions): void {
+  options.signal?.throwIfAborted();
+  if (options.deadlineAtMs !== undefined && Date.now() >= options.deadlineAtMs) throw new Error("Imagery import exceeded its job deadline");
+}
+
+const PACK_METADATA_KEYS = new Set(["schemaVersion", "tier", "width", "height", "tileSize", "columns", "rows", "resolutionM", "bounds", "contentHash"]);
+
+function fail(path: string, message: string): never {
+  throw new Error(`Invalid imagery pack ${path}: ${message}`);
+}
+
+function integer(value: unknown, name: string, path: string, positive = false): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || (positive ? value <= 0 : value < 0)) {
+    fail(path, `${name} must be ${positive ? "a positive" : "a non-negative"} safe integer`);
+  }
+  return value;
+}
+
+function finitePositive(value: unknown, name: string, path: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) fail(path, `${name} must be positive and finite`);
+  return value;
+}
+
+function validateMetadata(input: TrackImageryPackMetadata, path: string): TrackImageryPackMetadata {
+  if (input.schemaVersion !== TRACK_IMAGERY_PACK_SCHEMA_VERSION) fail(path, "unsupported schemaVersion");
+  if (input.tier !== TRACK_IMAGERY_PACK_TIER) fail(path, "only hq tier is supported");
+  const width = integer(input.width, "width", path, true);
+  const height = integer(input.height, "height", path, true);
+  const tileSize = integer(input.tileSize, "tileSize", path, true);
+  const columns = integer(input.columns, "columns", path, true);
+  const rows = integer(input.rows, "rows", path, true);
+  if (columns !== Math.ceil(width / tileSize) || rows !== Math.ceil(height / tileSize)) fail(path, "columns/rows do not describe complete tile grid");
+  if (input.resolutionM !== undefined) finitePositive(input.resolutionM, "resolutionM", path);
+  const parsedBounds = TrackImageryGeographicBoundsSchema.safeParse(input.bounds);
+  if (!parsedBounds.success) fail(path, `bounds are invalid: ${parsedBounds.error.message}`);
+  if (input.contentHash !== undefined && !/^[a-f0-9]{64}$/.test(input.contentHash)) fail(path, "contentHash must be lowercase SHA-256");
+  return { ...input, width, height, tileSize, columns, rows };
+}
+
+function metadataRows(metadata: TrackImageryPackMetadata): Array<[string, string]> {
+  const rows: Array<[string, string]> = [
+    ["schemaVersion", String(metadata.schemaVersion)],
+    ["tier", metadata.tier],
+    ["width", String(metadata.width)],
+    ["height", String(metadata.height)],
+    ["tileSize", String(metadata.tileSize)],
+    ["columns", String(metadata.columns)],
+    ["rows", String(metadata.rows)],
+  ];
+  if (metadata.resolutionM !== undefined) rows.push(["resolutionM", String(metadata.resolutionM)]);
+  rows.push(["bounds", JSON.stringify(metadata.bounds)]);
+  if (metadata.contentHash !== undefined) rows.push(["contentHash", metadata.contentHash]);
+  return rows;
+}
+
+function parseInteger(path: string, key: string, value: string): number {
+  if (!/^(?:0|[1-9]\d*)$/.test(value)) fail(path, `metadata ${key} must be canonical integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) fail(path, `metadata ${key} exceeds safe integer range`);
+  return parsed;
+}
+
+function validateSchema(db: Database, path: string): void {
+  const tables = db.query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all() as Array<{ name: string }>;
+  const names = tables.map((row) => row.name).sort();
+  if (names.length !== 2 || names[0] !== "metadata" || names[1] !== "tiles") fail(path, "unexpected SQLite tables");
+  const metadataColumns = db.query("PRAGMA table_info(metadata)").all() as Array<{ name: string; notnull: number; pk: number }>;
+  const tileColumns = db.query("PRAGMA table_info(tiles)").all() as Array<{ name: string; notnull: number; pk: number }>;
+  const expectedMetadata = ["key", "value"];
+  const expectedTiles = ["tier", "x", "y", "width", "height", "format", "data"];
+  if (metadataColumns.map((column) => column.name).join(",") !== expectedMetadata.join(",")) fail(path, "metadata table schema mismatch");
+  if (tileColumns.map((column) => column.name).join(",") !== expectedTiles.join(",")) fail(path, "tiles table schema mismatch");
+  if (metadataColumns.some((column) => column.name === "value" && column.notnull !== 1) || tileColumns.some((column) => column.notnull !== 1)) fail(path, "pack columns must be NOT NULL");
+  if (
+    metadataColumns
+      .filter((column) => column.pk > 0)
+      .map((column) => column.name)
+      .join(",") !== "key"
+  )
+    fail(path, "metadata primary key mismatch");
+  const primaryKey = tileColumns
+    .filter((column) => column.pk > 0)
+    .sort((a, b) => a.pk - b.pk)
+    .map((column) => column.name);
+  if (primaryKey.join(",") !== "tier,x,y") fail(path, "tiles primary key mismatch");
+}
+
+function parseMetadataRows(path: string, rows: Array<{ key: string; value: string }>): TrackImageryPackMetadata {
+  const values = new Map<string, string>();
+  for (const row of rows) {
+    if (values.has(row.key) || !PACK_METADATA_KEYS.has(row.key)) fail(path, `unexpected or duplicate metadata key ${row.key}`);
+    values.set(row.key, row.value);
+  }
+  const required = ["schemaVersion", "tier", "width", "height", "tileSize", "columns", "rows", "bounds", "contentHash"];
+  for (const key of required) if (!values.has(key)) fail(path, `missing metadata ${key}`);
+  let rawBounds: unknown;
+  try {
+    rawBounds = JSON.parse(values.get("bounds")!);
+  } catch {
+    fail(path, "bounds metadata is not valid JSON");
+  }
+  const parsedBounds = TrackImageryGeographicBoundsSchema.safeParse(rawBounds);
+  if (!parsedBounds.success) fail(path, `bounds metadata is invalid: ${parsedBounds.error.message}`);
+  const hash = values.get("contentHash")!;
+  if (!/^[a-f0-9]{64}$/.test(hash)) fail(path, "contentHash must be lowercase SHA-256");
+  const metadata: TrackImageryPackMetadata = {
+    schemaVersion: parseInteger(path, "schemaVersion", values.get("schemaVersion")!) as 1,
+    tier: values.get("tier") as "hq",
+    width: parseInteger(path, "width", values.get("width")!),
+    height: parseInteger(path, "height", values.get("height")!),
+    tileSize: parseInteger(path, "tileSize", values.get("tileSize")!),
+    columns: parseInteger(path, "columns", values.get("columns")!),
+    rows: parseInteger(path, "rows", values.get("rows")!),
+    bounds: parsedBounds.data,
+    contentHash: hash,
+  };
+  if (values.has("resolutionM")) metadata.resolutionM = finitePositive(Number(values.get("resolutionM")), "resolutionM", path);
+  return validateMetadata(metadata, path);
+}
+
+function assertTile(tile: TrackImageryPackTile, metadata: TrackImageryPackMetadata, path: string): void {
+  if (tile.tier !== "hq" || !Number.isSafeInteger(tile.x) || !Number.isSafeInteger(tile.y)) fail(path, "tile tier or coordinates invalid");
+  if (tile.x < 0 || tile.x >= metadata.columns || tile.y < 0 || tile.y >= metadata.rows) fail(path, `tile coordinate out of range (${tile.x},${tile.y})`);
+  const expectedWidth = Math.min(metadata.tileSize, metadata.width - tile.x * metadata.tileSize);
+  const expectedHeight = Math.min(metadata.tileSize, metadata.height - tile.y * metadata.tileSize);
+  if (tile.width !== expectedWidth || tile.height !== expectedHeight) fail(path, `tile dimensions invalid at (${tile.x},${tile.y})`);
+  if (tile.format !== "webp") fail(path, "tile format must be webp");
+  if (!(tile.data instanceof Uint8Array) || tile.data.byteLength === 0) fail(path, `tile data missing at (${tile.x},${tile.y})`);
+}
+
+function validateTileGrid(db: Database, metadata: TrackImageryPackMetadata, path: string, options: TrackImageryPackWriteOptions): void {
+  const rows = db.query("SELECT tier,x,y,width,height,format,length(data) AS dataLength FROM tiles").all() as Array<Omit<TrackImageryPackTile, "data"> & { dataLength: number }>;
+  if (rows.length !== metadata.columns * metadata.rows) fail(path, `expected ${metadata.columns * metadata.rows} tiles, received ${rows.length}`);
+  const seen = new Set<string>();
+  for (const row of rows) {
+    assertPackWriteActive(options);
+    if (!Number.isSafeInteger(row.dataLength) || row.dataLength <= 0) fail(path, `tile data missing at (${row.x},${row.y})`);
+    const tile = { ...row, data: new Uint8Array([1]) };
+    assertTile(tile, metadata, path);
+    const key = `${row.x}:${row.y}`;
+    if (seen.has(key)) fail(path, `duplicate tile at (${row.x},${row.y})`);
+    seen.add(key);
+  }
+}
+
+function canonicalMetadata(metadata: TrackImageryPackMetadata): string {
+  return JSON.stringify({
+    schemaVersion: metadata.schemaVersion,
+    tier: metadata.tier,
+    width: metadata.width,
+    height: metadata.height,
+    tileSize: metadata.tileSize,
+    columns: metadata.columns,
+    rows: metadata.rows,
+    resolutionM: metadata.resolutionM ?? null,
+    bounds: metadata.bounds,
+  });
+}
+
+function tileDigest(tile: TrackImageryPackTile): string {
+  return createHash("sha256").update(`${tile.x},${tile.y},${tile.width},${tile.height},${tile.format}\0`).update(tile.data).digest("hex");
+}
+
+function replacePack(tempPath: string, targetPath: string): void {
+  try {
+    renameSync(tempPath, targetPath);
+    return;
+  } catch {
+    const backupPath = `${targetPath}.${randomUUID()}.bak`;
+    let movedExisting = false;
+    try {
+      try {
+        renameSync(targetPath, backupPath);
+        movedExisting = true;
+      } catch {}
+      renameSync(tempPath, targetPath);
+      if (movedExisting) rmSync(backupPath, { force: true });
+    } catch (error) {
+      if (movedExisting) {
+        rmSync(targetPath, { force: true });
+        renameSync(backupPath, targetPath);
+      }
+      throw error;
+    }
+  }
+}
+
+export async function writeTrackImageryPack(
+  targetPath: string,
+  input: TrackImageryPackMetadata,
+  tiles: TrackImageryPackTileSource,
+  options: TrackImageryPackWriteOptions = {},
+): Promise<TrackImageryPackMetadata> {
+  assertPackWriteActive(options);
+  const target = resolve(targetPath);
+  const metadata = validateMetadata(input, target);
+  const tempPath = `${target}.tmp`;
+  mkdirSync(dirname(target), { recursive: true });
+  rmSync(tempPath, { force: true });
+  let db: Database | undefined;
+  try {
+    db = new Database(tempPath, { create: true, strict: true });
+    db.exec(
+      "CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL); CREATE TABLE tiles (tier TEXT NOT NULL, x INTEGER NOT NULL, y INTEGER NOT NULL, width INTEGER NOT NULL, height INTEGER NOT NULL, format TEXT NOT NULL, data BLOB NOT NULL, PRIMARY KEY(tier,x,y)) WITHOUT ROWID;",
+    );
+    const insertMetadata = db.query("INSERT INTO metadata (key,value) VALUES (?,?)");
+    for (const [key, value] of metadataRows(metadata)) insertMetadata.run(key, value);
+    db.exec("BEGIN IMMEDIATE");
+    const insertTile = db.query("INSERT INTO tiles (tier,x,y,width,height,format,data) VALUES (?,?,?,?,?,?,?)");
+    const digests = new Map<string, string>();
+    let count = 0;
+    for await (const tile of tiles) {
+      assertPackWriteActive(options);
+      assertTile(tile, metadata, target);
+      const key = `${tile.x}:${tile.y}`;
+      if (digests.has(key)) fail(target, `duplicate tile at (${tile.x},${tile.y})`);
+      digests.set(key, tileDigest(tile));
+      insertTile.run(tile.tier, tile.x, tile.y, tile.width, tile.height, tile.format, tile.data);
+      count++;
+    }
+    assertPackWriteActive(options);
+    if (count !== metadata.columns * metadata.rows) fail(target, `expected ${metadata.columns * metadata.rows} tiles, received ${count}`);
+    db.exec("COMMIT");
+    const contentHash = createHash("sha256").update(canonicalMetadata(metadata));
+    for (const [key, digest] of [...digests.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      assertPackWriteActive(options);
+      contentHash.update(`${key}:${digest};`);
+    }
+    const completed = { ...metadata, contentHash: contentHash.digest("hex") };
+    db.query("INSERT OR REPLACE INTO metadata (key,value) VALUES (?,?)").run("contentHash", completed.contentHash);
+    assertPackWriteActive(options);
+    validateSchema(db, target);
+    const completedRows = db.query("SELECT key,value FROM metadata ORDER BY key").all() as Array<{ key: string; value: string }>;
+    validateTileGrid(db, parseMetadataRows(target, completedRows), target, options);
+    assertPackWriteActive(options);
+    const integrity = db.query("PRAGMA integrity_check").get() as { integrity_check?: string } | null;
+    if (integrity?.integrity_check !== "ok") fail(target, "SQLite integrity check failed");
+    assertPackWriteActive(options);
+    db.close();
+    db = undefined;
+    replacePack(tempPath, target);
+    return completed;
+  } catch (error) {
+    try {
+      if (db) {
+        try {
+          db.exec("ROLLBACK");
+        } catch {}
+        db.close();
+      }
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
+    throw error;
+  }
+}
+
+export function readTrackImageryPackMetadata(packPath: string): TrackImageryPackMetadata {
+  const path = resolve(packPath);
+  let db: Database | undefined;
+  try {
+    db = new Database(path, { readonly: true, create: false, strict: true });
+    validateSchema(db, path);
+    const rows = db.query("SELECT key,value FROM metadata ORDER BY key").all() as Array<{ key: string; value: string }>;
+    return parseMetadataRows(path, rows);
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Invalid imagery pack")) throw error;
+    return fail(path, error instanceof Error ? error.message : "unable to open package");
+  } finally {
+    db?.close();
+  }
+}
+
+export function readTrackImageryPackTile(packPath: string, x: number, y: number, metadata?: TrackImageryPackMetadata): TrackImageryPackTile | null {
+  const path = resolve(packPath);
+  const checkedMetadata = metadata ?? readTrackImageryPackMetadata(path);
+  validateMetadata(checkedMetadata, path);
+  if (!Number.isSafeInteger(x) || !Number.isSafeInteger(y) || x < 0 || y < 0 || x >= checkedMetadata.columns || y >= checkedMetadata.rows) return null;
+  const db = new Database(path, { readonly: true, create: false, strict: true });
+  try {
+    const row = db.query("SELECT tier,x,y,width,height,format,data FROM tiles WHERE tier = 'hq' AND x = ? AND y = ?").get(x, y) as (Omit<TrackImageryPackTile, "data"> & { data: Uint8Array }) | null;
+    if (!row) return null;
+    const tile = { ...row, data: row.data instanceof Uint8Array ? row.data : new Uint8Array(row.data as unknown as ArrayBuffer) };
+    assertTile(tile, checkedMetadata, path);
+    return tile;
+  } finally {
+    db.close();
+  }
+}

--- a/server/tracks/imagery.ts
+++ b/server/tracks/imagery.ts
@@ -11,17 +11,13 @@ import {
   type TrackImageryLayoutManifest,
   type TrackImageryVenueManifest,
 } from "../../shared/racing/tracks/imagery";
-import {
-  revisionDirectoryPathComponents,
-  canonicalTrackAssetPathComponents,
-  trackConfigurationVenueId,
-  type TrackConfiguration,
-} from "../../shared/racing/tracks/configuration";
+import { revisionDirectoryPathComponents, canonicalTrackAssetPathComponents, trackConfigurationVenueId, type TrackConfiguration } from "../../shared/racing/tracks/configuration";
 import type { GameId } from "../../shared/games/ids";
 import { USER_TRACKS_DIR } from "../../shared/platform/runtime/data-paths";
 import { SHARED_DIR } from "../runtime/config/paths";
 import { listTrackConfigurations, loadTrackConfiguration } from "./configuration";
 import { readTrackImageryPackMetadata, type TrackImageryPackMetadata } from "./imagery-pack";
+import { resolveTrackImageryPackPath } from "./imagery-artifact";
 
 const TRACK_ASSET_ROOT = resolve(SHARED_DIR, "tracks");
 
@@ -43,12 +39,7 @@ export function trackImageryVenueDirectory(venueId: string): string {
 
 function trackImageryLayoutPathForConfiguration(configuration: TrackConfiguration): string {
   const venueId = trackConfigurationVenueId(configuration);
-  return resolve(
-    TRACK_ASSET_ROOT,
-    ...canonicalTrackAssetPathComponents(venueId, configuration.track.id),
-    "imagery",
-    `${configuration.gameId}.json`,
-  );
+  return resolve(TRACK_ASSET_ROOT, ...canonicalTrackAssetPathComponents(venueId, configuration.track.id), "imagery", `${configuration.gameId}.json`);
 }
 
 export function trackImageryLayoutPath(gameId: GameId, trackOrdinal: number): string {
@@ -106,7 +97,7 @@ function textureFile(directory: string, fileName: string): LoadedTrackImageryTex
   return { path, modifiedAtMs: statSync(path).mtimeMs };
 }
 
-export function loadTrackImagery(gameId: GameId, trackOrdinal: number): LoadedTrackImagery | null {
+export async function loadTrackImagery(gameId: GameId, trackOrdinal: number): Promise<LoadedTrackImagery | null> {
   const configuration = loadTrackConfiguration(gameId, trackOrdinal);
   if (!configuration) return null;
   const layout = loadTrackImageryLayoutForConfiguration(configuration);
@@ -116,8 +107,8 @@ export function loadTrackImagery(gameId: GameId, trackOrdinal: number): LoadedTr
   if (!venue) throw new Error(`Missing track imagery venue ${venueId}`);
   const directory = trackImageryVenueDirectory(venueId);
   if (venue.base.pack !== TRACK_IMAGERY_PACKAGE_NAME) throw new Error(`Unsupported imagery package ${venue.base.pack}`);
-  const packPath = resolve(directory, TRACK_IMAGERY_PACKAGE_NAME);
-  if (!existsSync(packPath)) throw new Error(`Missing track imagery package ${packPath}`);
+  const localPackPath = resolve(directory, TRACK_IMAGERY_PACKAGE_NAME);
+  const packPath = await resolveTrackImageryPackPath(localPackPath, venue.base.artifact);
   const packMetadata = readTrackImageryPackMetadata(packPath);
   const boundsMatch = JSON.stringify(packMetadata.bounds) === JSON.stringify(venue.base.bounds);
   const resolutionMatch = venue.base.source.storedResolutionM === undefined || venue.base.source.storedResolutionM === packMetadata.resolutionM;

--- a/server/tracks/imagery.ts
+++ b/server/tracks/imagery.ts
@@ -1,0 +1,217 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, statSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import sharp from "sharp";
+import {
+  TRACK_IMAGERY_PACKAGE_NAME,
+  TrackImageryLayoutManifestSchema,
+  TrackImageryVenueManifestSchema,
+  type TrackImagery,
+  type TrackImageryConfigurationIndex,
+  type TrackImageryLayoutManifest,
+  type TrackImageryVenueManifest,
+} from "../../shared/racing/tracks/imagery";
+import {
+  revisionDirectoryPathComponents,
+  canonicalTrackAssetPathComponents,
+  trackConfigurationVenueId,
+  type TrackConfiguration,
+} from "../../shared/racing/tracks/configuration";
+import type { GameId } from "../../shared/games/ids";
+import { USER_TRACKS_DIR } from "../../shared/platform/runtime/data-paths";
+import { SHARED_DIR } from "../runtime/config/paths";
+import { listTrackConfigurations, loadTrackConfiguration } from "./configuration";
+import { readTrackImageryPackMetadata, type TrackImageryPackMetadata } from "./imagery-pack";
+
+const TRACK_ASSET_ROOT = resolve(SHARED_DIR, "tracks");
+
+export interface LoadedTrackImageryTexture {
+  path: string;
+  modifiedAtMs: number;
+}
+
+export interface LoadedTrackImagery {
+  imagery: TrackImagery;
+  textures: Record<string, LoadedTrackImageryTexture>;
+  packPath: string;
+  packMetadata: TrackImageryPackMetadata;
+}
+
+export function trackImageryVenueDirectory(venueId: string): string {
+  return resolve(TRACK_ASSET_ROOT, ...revisionDirectoryPathComponents(venueId), "imagery");
+}
+
+function trackImageryLayoutPathForConfiguration(configuration: TrackConfiguration): string {
+  const venueId = trackConfigurationVenueId(configuration);
+  return resolve(
+    TRACK_ASSET_ROOT,
+    ...canonicalTrackAssetPathComponents(venueId, configuration.track.id),
+    "imagery",
+    `${configuration.gameId}.json`,
+  );
+}
+
+export function trackImageryLayoutPath(gameId: GameId, trackOrdinal: number): string {
+  const configuration = loadTrackConfiguration(gameId, trackOrdinal);
+  if (!configuration) throw new Error(`Missing track configuration ${gameId}/${trackOrdinal}`);
+  return trackImageryLayoutPathForConfiguration(configuration);
+}
+
+function loadTrackImageryLayoutForConfiguration(configuration: TrackConfiguration): TrackImageryLayoutManifest | null {
+  const path = trackImageryLayoutPathForConfiguration(configuration);
+  if (!existsSync(path)) return null;
+  const parsed = TrackImageryLayoutManifestSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+  if (!parsed.success) throw new Error(`Invalid track imagery layout ${path}: ${parsed.error.message}`);
+  if (parsed.data.gameId !== configuration.gameId || parsed.data.trackOrdinal !== configuration.trackOrdinal) {
+    throw new Error(`Track imagery layout identity mismatch in ${path}`);
+  }
+  return parsed.data;
+}
+
+export function loadTrackImageryLayout(gameId: GameId, trackOrdinal: number): TrackImageryLayoutManifest | null {
+  const configuration = loadTrackConfiguration(gameId, trackOrdinal);
+  return configuration ? loadTrackImageryLayoutForConfiguration(configuration) : null;
+}
+
+export function loadTrackImageryVenue(venueId: string): TrackImageryVenueManifest | null {
+  const path = resolve(trackImageryVenueDirectory(venueId), "manifest.json");
+  if (!existsSync(path)) return null;
+  const parsed = TrackImageryVenueManifestSchema.safeParse(JSON.parse(readFileSync(path, "utf8")));
+  if (!parsed.success) throw new Error(`Invalid track imagery venue ${path}: ${parsed.error.message}`);
+  if (parsed.data.venueId !== venueId) throw new Error(`Track imagery venue identity mismatch in ${path}`);
+  return parsed.data;
+}
+export function listTrackImageryConfigurations(): TrackImageryConfigurationIndex {
+  const venues: TrackImageryVenueManifest[] = [];
+  const layouts: TrackImageryLayoutManifest[] = [];
+  const seenVenues = new Set<string>();
+  for (const configuration of listTrackConfigurations()) {
+    const venueId = trackConfigurationVenueId(configuration);
+    if (!seenVenues.has(venueId)) {
+      seenVenues.add(venueId);
+      const venue = loadTrackImageryVenue(venueId);
+      if (venue) venues.push(venue);
+    }
+    const layout = loadTrackImageryLayoutForConfiguration(configuration);
+    if (layout) layouts.push(layout);
+  }
+  venues.sort((a, b) => a.venueId.localeCompare(b.venueId));
+  return { venues, layouts };
+}
+
+function textureFile(directory: string, fileName: string): LoadedTrackImageryTexture {
+  if (fileName !== basename(fileName)) throw new Error(`Invalid track imagery file name ${fileName}`);
+  const path = resolve(directory, fileName);
+  if (!existsSync(path)) throw new Error(`Missing track imagery texture ${path}`);
+  return { path, modifiedAtMs: statSync(path).mtimeMs };
+}
+
+export function loadTrackImagery(gameId: GameId, trackOrdinal: number): LoadedTrackImagery | null {
+  const configuration = loadTrackConfiguration(gameId, trackOrdinal);
+  if (!configuration) return null;
+  const layout = loadTrackImageryLayoutForConfiguration(configuration);
+  if (!layout) return null;
+  const venueId = trackConfigurationVenueId(configuration);
+  const venue = loadTrackImageryVenue(venueId);
+  if (!venue) throw new Error(`Missing track imagery venue ${venueId}`);
+  const directory = trackImageryVenueDirectory(venueId);
+  if (venue.base.pack !== TRACK_IMAGERY_PACKAGE_NAME) throw new Error(`Unsupported imagery package ${venue.base.pack}`);
+  const packPath = resolve(directory, TRACK_IMAGERY_PACKAGE_NAME);
+  if (!existsSync(packPath)) throw new Error(`Missing track imagery package ${packPath}`);
+  const packMetadata = readTrackImageryPackMetadata(packPath);
+  const boundsMatch = JSON.stringify(packMetadata.bounds) === JSON.stringify(venue.base.bounds);
+  const resolutionMatch = venue.base.source.storedResolutionM === undefined || venue.base.source.storedResolutionM === packMetadata.resolutionM;
+  if (packMetadata.tier !== "hq" || packMetadata.tileSize !== venue.base.tileSize || !boundsMatch || !resolutionMatch || !packMetadata.contentHash) {
+    throw new Error(`Imagery package metadata mismatch in ${packPath}`);
+  }
+  const packageVersion = packMetadata.contentHash;
+  const textures: Record<string, LoadedTrackImageryTexture> = {};
+  const selectedLayers = [];
+  const seen = new Set<string>();
+  for (const layerId of layout.layers) {
+    if (seen.has(layerId)) continue;
+    seen.add(layerId);
+    const layer = venue.layers.find((candidate) => candidate.id === layerId);
+    if (!layer) throw new Error(`Missing imagery layer ${layerId} in venue ${venueId}`);
+    textures[layer.id] = textureFile(resolve(directory, "layers"), layer.image);
+    selectedLayers.push(layer);
+  }
+  const publicTextures = selectedLayers.map((layer) => ({
+    id: layer.id,
+    kind: layer.kind,
+    opacity: layer.opacity,
+    source: layer.source,
+    url: `/api/track-imagery/${trackOrdinal}/texture/${encodeURIComponent(layer.id)}?gameId=${encodeURIComponent(gameId)}&v=${Math.round(textures[layer.id]!.modifiedAtMs)}`,
+  }));
+  return {
+    imagery: {
+      version: 2,
+      venueId: venue.venueId,
+      calibration: venue.calibration,
+      base: {
+        tier: packMetadata.tier,
+        width: packMetadata.width,
+        height: packMetadata.height,
+        tileSize: packMetadata.tileSize,
+        columns: packMetadata.columns,
+        rows: packMetadata.rows,
+        bounds: venue.base.bounds,
+        contentHash: packageVersion,
+        ...(packMetadata.resolutionM === undefined ? {} : { resolutionM: packMetadata.resolutionM }),
+        source: venue.base.source,
+        tileUrlTemplate: `/api/track-imagery/${trackOrdinal}/base/hq/{x}/{y}?gameId=${encodeURIComponent(gameId)}&v=${encodeURIComponent(packageVersion)}`,
+      },
+      textures: publicTextures,
+    },
+    textures,
+    packPath,
+    packMetadata,
+  };
+}
+
+export function trackImageryContentType(fileName: string): string {
+  const lower = fileName.toLowerCase();
+  if (lower.endsWith(".png")) return "image/png";
+  if (lower.endsWith(".webp")) return "image/webp";
+  return "image/jpeg";
+}
+
+const TRACK_BASE_IMAGERY_DIR = join(USER_TRACKS_DIR, "imagery");
+const MAX_BASE_IMAGE_DIMENSION = 2560;
+const baseImageUrlByPath = new Map<string, string | null>();
+
+export function getBaseTrackImagePath(gameId: GameId, baseTrackName: string): string {
+  const identity = `${gameId}\0${baseTrackName.trim().normalize("NFKC").toLocaleLowerCase()}`;
+  const digest = createHash("sha256").update(identity).digest("hex").slice(0, 24);
+  return join(TRACK_BASE_IMAGERY_DIR, `${gameId}-${digest}.webp`);
+}
+
+export function getBaseTrackImageUrl(gameId: GameId, baseTrackName: string): string | null {
+  const path = getBaseTrackImagePath(gameId, baseTrackName);
+  const cached = baseImageUrlByPath.get(path);
+  if (cached !== undefined) return cached;
+
+  try {
+    const modifiedAt = Math.trunc(statSync(path).mtimeMs);
+    const url = `/api/track-base-image?gameId=${encodeURIComponent(gameId)}&baseTrackName=${encodeURIComponent(baseTrackName)}&v=${modifiedAt}`;
+    baseImageUrlByPath.set(path, url);
+    return url;
+  } catch {
+    baseImageUrlByPath.set(path, null);
+    return null;
+  }
+}
+
+export async function saveBaseTrackImage(gameId: GameId, baseTrackName: string, input: ArrayBuffer): Promise<string> {
+  const image = await sharp(input, { failOn: "error", limitInputPixels: 40_000_000 })
+    .rotate()
+    .resize({ width: MAX_BASE_IMAGE_DIMENSION, height: MAX_BASE_IMAGE_DIMENSION, fit: "inside", withoutEnlargement: true })
+    .webp({ quality: 88 })
+    .toBuffer();
+
+  mkdirSync(TRACK_BASE_IMAGERY_DIR, { recursive: true });
+  const path = getBaseTrackImagePath(gameId, baseTrackName);
+  await Bun.write(path, image);
+  baseImageUrlByPath.delete(path);
+  return getBaseTrackImageUrl(gameId, baseTrackName)!;
+}

--- a/shared/platform/http/route-schemas.ts
+++ b/shared/platform/http/route-schemas.ts
@@ -20,6 +20,11 @@ export const GameIdQuerySchema = z.object({
   gameId: GameIdSchema.optional(),
 });
 
+/** Required `?gameId=` query param for game-scoped geometry routes. */
+export const RequiredGameIdQuerySchema = z.object({
+  gameId: GameIdSchema,
+});
+
 const parseIntParam = (name: "id" | "versionId") =>
   z
     .string()

--- a/shared/racing/tracks/configuration.ts
+++ b/shared/racing/tracks/configuration.ts
@@ -1,0 +1,92 @@
+import { z } from "zod";
+import { GameIdSchema } from "../../games/ids";
+
+export const TRACK_CONFIGURATION_VERSION = 1 as const;
+
+function validCalendarDate(value: string): boolean {
+  const timestamp = Date.parse(`${value}T00:00:00Z`);
+  return Number.isFinite(timestamp) && new Date(timestamp).toISOString().slice(0, 10) === value;
+}
+
+export const TrackVenueIdSchema = z.string().regex(/^[a-z0-9][a-z0-9-]*(?:\/[a-z0-9][a-z0-9-]*)*$/, "Use slash-separated lowercase venue segments");
+const trackIdentityId = z.string().regex(/^[a-z0-9][a-z0-9-]*$/, "Use lowercase letters, digits, and hyphens");
+export const TrackIdentityNodeSchema = z.object({
+  id: trackIdentityId,
+  name: z.string().trim().min(1),
+});
+export const CURRENT_TRACK_REVISION = "current";
+
+export interface VenueRevisionPath {
+  rootVenuePath: string;
+  revisionPath: string;
+}
+
+/**
+ * Splits SQLite venue path into its stable root venue and source revision.
+ * A root-only path addresses current source revision.
+ */
+export function parseVenueRevisionPath(venuePath: string): VenueRevisionPath {
+  const segments = TrackVenueIdSchema.parse(venuePath).split("/");
+  const rootVenuePath = segments[0]!;
+  return {
+    rootVenuePath,
+    revisionPath: segments.slice(1).join("/") || CURRENT_TRACK_REVISION,
+  };
+}
+
+/** Browser-safe path components for one source revision directory. */
+export function revisionDirectoryPathComponents(venuePath: string): string[] {
+  const { rootVenuePath, revisionPath } = parseVenueRevisionPath(venuePath);
+  return ["venues", rootVenuePath, "revisions", ...revisionPath.split("/")];
+}
+
+/** Browser-safe path components for one canonical layout's source assets. */
+export function canonicalTrackAssetPathComponents(venuePath: string, layoutSlug: string): string[] {
+  return [...revisionDirectoryPathComponents(venuePath), "tracks", trackIdentityId.parse(layoutSlug)];
+}
+
+/** Splits one canonical layout ID into SQLite venue path and layout slug. */
+export function parseCanonicalTrackId(canonicalTrackId: string): { venuePath: string; layoutSlug: string } {
+  const segments = TrackVenueIdSchema.parse(canonicalTrackId).split("/");
+  if (segments.length < 2) throw new Error(`Invalid canonical track ID ${JSON.stringify(canonicalTrackId)}`);
+  const layoutSlug = trackIdentityId.parse(segments.pop()!);
+  return {
+    venuePath: TrackVenueIdSchema.parse(segments.join("/")),
+    layoutSlug,
+  };
+}
+
+export const TrackConfigurationConfirmationSchema = z.object({
+  confirmedAt: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "Confirmation date must use YYYY-MM-DD")
+    .refine(validCalendarDate, "Confirmation date must be valid"),
+  confirmedBy: z.string().trim().min(1),
+  commitId: z
+    .string()
+    .trim()
+    .regex(/^[0-9a-f]{7,64}$/i, "Commit ID must be a 7-64 digit hexadecimal hash")
+    .optional(),
+});
+
+export const TrackConfigurationSchema = z.object({
+  version: z.literal(TRACK_CONFIGURATION_VERSION),
+  gameId: GameIdSchema,
+  trackOrdinal: z.number().int().nonnegative(),
+  venue: TrackIdentityNodeSchema,
+  subVenues: z.array(TrackIdentityNodeSchema).max(8),
+  track: TrackIdentityNodeSchema,
+  confirmation: TrackConfigurationConfirmationSchema.nullable(),
+});
+
+export type TrackConfiguration = z.infer<typeof TrackConfigurationSchema>;
+export type TrackConfigurationConfirmation = z.infer<typeof TrackConfigurationConfirmationSchema>;
+export type TrackIdentityNode = z.infer<typeof TrackIdentityNodeSchema>;
+
+export function trackConfigurationVenueId(configuration: Pick<TrackConfiguration, "venue" | "subVenues">): string {
+  return [configuration.venue.id, ...configuration.subVenues.map((node) => node.id)].join("/");
+}
+
+export function trackConfigurationCanonicalId(configuration: Pick<TrackConfiguration, "venue" | "subVenues" | "track">): string {
+  return `${trackConfigurationVenueId(configuration)}/${configuration.track.id}`;
+}

--- a/shared/racing/tracks/facts.ts
+++ b/shared/racing/tracks/facts.ts
@@ -1,74 +1,62 @@
 /**
  * Track facts: what the circuit IS. Game-agnostic, no fractions.
  *
- * Two files describe a track layout.
+ * Bundled registry splits each layout between:
  *
- *   shared/data/tracks/meta/<slug>.json         facts  — what the circuit IS
- *   shared/data/tracks/<gameId>/<slug>-segments.json   geometry — where it is, per game
+ *   track facts rows      — what circuit IS
+ *   per-game geometry rows — where segments are in each simulator
  *
- * The facts file carries turn numbers, turn names, named straights, groups and
- * layout identity. It is game-agnostic and holds no fractions. Every game that
+ * Facts carry turn numbers, turn names, named straights, groups, and layout
+ * identity. They are game-agnostic and hold no fractions. Every game that
  * ships this layout is modelling the same real-world circuit, so the set of
  * turns is identical across games — only where each turn sits along the lap
  * differs, because each game digitises its own centerline.
  *
  * That is the whole invariant: classification is a property of the track,
  * geometry is a property of the (track, game) pair. A name never appears in a
- * geometry file, and a fraction never appears in a facts file.
+ * geometry row, and a fraction never appears in facts.
  *
  * Geometry lives in `shared/racing/tracks/geometry.ts`; the keys that join the two in
  * `shared/racing/tracks/keys.ts`; the join itself in `shared/racing/tracks/curation/join.ts`.
  */
 
+import { z } from "zod";
+
+const trackFactId = z.string().regex(/^[a-z0-9][a-z0-9-]*$/, "Use lowercase letters, digits, and hyphens");
+
+export const CornerFactSchema = z.object({
+  number: z.number().int().positive(),
+  covers: z.array(z.number().int().positive()).optional(),
+  name: z.string(),
+  direction: z.enum(["left", "right"]).optional(),
+  group: z.string().optional(),
+});
+
+export const StraightFactSchema = z.object({
+  after: z.number().int().positive(),
+  name: z.string(),
+  group: z.string().optional(),
+});
+
+export const TrackFactsSchema = z.object({
+  slug: trackFactId,
+  track: trackFactId,
+  layout: trackFactId,
+  layoutName: z.string().min(1),
+  name: z.string().min(1),
+  source: z.string().optional(),
+  corners: z.array(CornerFactSchema),
+  straights: z.array(StraightFactSchema).optional(),
+});
+
 /** One officially numbered corner. `number` plus `covers` is its identity. */
-export interface CornerFact {
-  /** Official turn number. Lowest number when the corner spans several. */
-  number: number;
-  /** Further official numbers this one corner subsumes (Pouhon: 10, covers [11]). */
-  covers?: number[];
-  /** Canonical name, untranslated. Empty when the circuit doesn't name this turn. */
-  name: string;
-  direction?: "left" | "right";
-  /**
-   * Complex this corner belongs to (Rivazza, Senna S, Bus Stop). Members share
-   * the key so consumers can label the piece once instead of once per apex.
-   */
-  group?: string;
-  // No detector allowances here — how many arcs a centerline resolves this
-  // corner into, or whether a game draws it at all, is not a property of the
-  // circuit. Those live in shared/data/tracks/detect-hints.json.
-}
+export type CornerFact = z.infer<typeof CornerFactSchema>;
 
 /** A named gap between corners. Unnamed gaps get no entry — they're derived. */
-export interface StraightFact {
-  /** Turn number this straight follows. The pre-T1 straight follows the last corner. */
-  after: number;
-  name: string;
-  group?: string;
-}
+export type StraightFact = z.infer<typeof StraightFactSchema>;
 
 /** The facts file. No fractions, no per-game anything. */
-export interface TrackFacts {
-  slug: string;
-  /** Physical venue, groups layouts: brands-hatch-indy and brands-hatch-gp share "brands-hatch". */
-  track: string;
-  /** Layout id within the venue: "gp", "indy", "national". */
-  layout: string;
-  /** Display layout name, rendered as "<name> — <layoutName>". */
-  layoutName: string;
-  /** Venue name, identical across layouts of the same venue. */
-  name: string;
-  /**
-   * Where these corner names came from — official circuit map, FIA track guide,
-   * or an explicit admission that the numbering was detected rather than sourced
-   * ("Sequential detected corners"). Names in this file are real-world claims;
-   * this is the citation that makes them auditable. Never invent one.
-   */
-  source?: string;
-  corners: CornerFact[];
-  /** Only gaps that carry a real name. */
-  straights?: StraightFact[];
-}
+export type TrackFacts = z.infer<typeof TrackFactsSchema>;
 
 /** Turn numbers a corner fact occupies, sorted. */
 export function cornerNumbers(c: CornerFact): number[] {

--- a/shared/racing/tracks/geometry.ts
+++ b/shared/racing/tracks/geometry.ts
@@ -5,17 +5,40 @@
  * into `shared/racing/tracks/facts.ts` by the keys in `shared/racing/tracks/keys.ts`. Each game
  * digitises its own centerline, so one file exists per (track, game) pair.
  */
-import type { TrackSectors } from "./sectors";
+import { z } from "zod";
+import { cornerKey, parseCornerKey, parseStraightKey, straightKey } from "./keys";
+
+const SegmentKeySchema = z.string().refine((key) => {
+  if (key.startsWith("t")) {
+    const numbers = parseCornerKey(key);
+    return numbers.length > 0
+      && numbers.every((number) => Number.isInteger(number) && number > 0)
+      && new Set(numbers).size === numbers.length
+      && cornerKey(numbers) === key;
+  }
+  const after = parseStraightKey(key);
+  return after !== null && Number.isInteger(after) && after > 0 && straightKey(after) === key;
+}, "Invalid track geometry segment key");
+
+export const GeometrySegmentSchema = z.object({
+  key: SegmentKeySchema,
+  startFrac: z.number().min(0).max(1),
+  endFrac: z.number().min(0).max(1),
+});
+
+export const TrackGeometrySchema = z.object({
+  sectors: z
+    .object({
+      s1End: z.number().gt(0).lt(1),
+      s2End: z.number().gt(0).lt(1),
+      source: z.string().optional(),
+    })
+    .refine(({ s1End, s2End }) => s1End < s2End, "Sector 1 must end before sector 2")
+    .optional(),
+  segments: z.array(GeometrySegmentSchema),
+});
 
 /** Where one segment sits along this game's lap. Classification-free. */
-export interface GeometrySegment {
-  /** `t3` / `t10-11` for corners, `s3` for the gap after turn 3. */
-  key: string;
-  startFrac: number;
-  endFrac: number;
-}
+export type GeometrySegment = z.infer<typeof GeometrySegmentSchema>;
 
-export interface TrackGeometry {
-  sectors?: TrackSectors & { source?: string };
-  segments: GeometrySegment[];
-}
+export type TrackGeometry = z.infer<typeof TrackGeometrySchema>;

--- a/shared/racing/tracks/imagery.ts
+++ b/shared/racing/tracks/imagery.ts
@@ -1,0 +1,431 @@
+import { z } from "zod";
+import { GameIdSchema } from "../../games/ids";
+import { TrackVenueIdSchema } from "./configuration";
+
+export const TRACK_IMAGERY_MANIFEST_VERSION = 2 as const;
+export const TRACK_IMAGERY_PACKAGE_NAME = "imagery.rqi" as const;
+export const TrackImageryQualitySchema = z.enum(["hq", "context"]);
+export const TrackImageryCoverageSchema = z.enum(["full", "partial", "unknown"]);
+export const TrackImageryGeographicReliabilitySchema = z.enum(["authoritative", "community", "satellite"]);
+export const TrackImageryProviderStabilitySchema = z.enum(["authoritative", "stable", "opportunistic"]);
+export const TrackImageryRedistributionSchema = z.literal("allowed");
+
+const finiteNumber = z.number().finite();
+const safeId = z.string().regex(/^[a-z0-9][a-z0-9-]*$/, "Use lowercase letters, digits, and hyphens");
+const imageFileName = z.string().regex(/^[a-zA-Z0-9][a-zA-Z0-9._-]*\.(?:png|jpe?g|webp)$/i, "Image must be PNG, JPEG, or WebP");
+const imageSourceSchema = z.object({
+  name: z.string().trim().min(1),
+  provider: z.string().trim().min(1).optional(),
+  url: z.string().trim().optional(),
+  capturedAt: z.string().trim().optional(),
+  license: z.string().trim().min(1),
+  attribution: z.string().trim(),
+  quality: TrackImageryQualitySchema.optional(),
+  coverage: TrackImageryCoverageSchema.optional(),
+  geographicReliability: TrackImageryGeographicReliabilitySchema.optional(),
+  cloudCoverPercent: finiteNumber.min(0).max(100).optional(),
+  providerStability: TrackImageryProviderStabilitySchema.optional(),
+  redistribution: TrackImageryRedistributionSchema.optional(),
+  resolutionM: finiteNumber.positive().optional(),
+  sourceResolutionM: finiteNumber.positive().optional(),
+  storedResolutionM: finiteNumber.positive().optional(),
+});
+const textureSchema = z.object({
+  image: imageFileName,
+  opacity: finiteNumber.min(0).max(1),
+  source: imageSourceSchema,
+});
+
+export const TrackImageryGeographicPointSchema = z.object({
+  latitudeDeg: finiteNumber.min(-90).max(90),
+  longitudeDeg: finiteNumber.min(-180).max(180),
+});
+
+export const TrackImageryGeographicBoundsSchema = z
+  .object({
+    west: finiteNumber.min(-180).max(180),
+    south: finiteNumber.min(-90).max(90),
+    east: finiteNumber.min(-180).max(180),
+    north: finiteNumber.min(-90).max(90),
+  })
+  .refine((bounds) => bounds.east > bounds.west && bounds.north > bounds.south, "Imagery bounds must have positive width and height");
+
+export const TrackImageryCalibrationSchema = z.object({
+  originLatitudeDeg: finiteNumber.min(-90).max(90),
+  originLongitudeDeg: finiteNumber.min(-180).max(180),
+  /** Canvas-style affine transform from normalized image U/V to local east/north metres. */
+  imageToEnu: z.tuple([finiteNumber, finiteNumber, finiteNumber, finiteNumber, finiteNumber, finiteNumber]),
+});
+
+export const TrackImageryCandidateSchema = z.object({
+  id: z.string().trim().min(1),
+  provider: z.string().trim().min(1),
+  quality: TrackImageryQualitySchema,
+  coverage: TrackImageryCoverageSchema,
+  title: z.string().trim().min(1),
+  capturedAt: z.string().trim().optional(),
+  sourceResolutionM: finiteNumber.positive(),
+  geographicReliability: TrackImageryGeographicReliabilitySchema,
+  cloudCoverPercent: finiteNumber.min(0).max(100).optional(),
+  providerStability: TrackImageryProviderStabilitySchema,
+  redistribution: TrackImageryRedistributionSchema,
+  license: z.string().trim().min(1),
+  attribution: z.string().trim().min(1),
+  sourceUrl: z.string().url(),
+});
+const imageryOutputCount = z.number().int().nonnegative();
+export const TrackImageryOutputEstimateSchema = z.object({
+  width: imageryOutputCount.positive(),
+  height: imageryOutputCount.positive(),
+  totalPixels: imageryOutputCount.positive(),
+  tileSize: imageryOutputCount.positive(),
+  columns: imageryOutputCount.positive(),
+  rows: imageryOutputCount.positive(),
+  totalTiles: imageryOutputCount.positive(),
+  sourceChunks: imageryOutputCount.positive(),
+  resolutionM: finiteNumber.positive(),
+  estimatedUncompressedBytes: imageryOutputCount.positive(),
+  estimatedPackBytes: z.object({ minimum: imageryOutputCount.positive(), maximum: imageryOutputCount.positive() }),
+  estimatedJobDurationMs: imageryOutputCount.positive(),
+});
+export const TrackImageryOutputBudgetSchema = TrackImageryOutputEstimateSchema.extend({
+  availableDiskBytes: imageryOutputCount.nullable(),
+  requiredDiskBytes: imageryOutputCount.positive(),
+  maximumJobDurationMs: imageryOutputCount.positive(),
+  maximumConcurrency: imageryOutputCount.positive(),
+  safe: z.boolean(),
+  overrideActive: z.boolean(),
+  problems: z.array(z.string().min(1)),
+});
+export const TrackImageryOutputBudgetResultSchema = z.object({
+  candidate: TrackImageryCandidateSchema,
+  budget: TrackImageryOutputBudgetSchema,
+});
+export const TrackImageryGeographicReferenceSchema = z.object({
+  sourceGameId: z.literal("iracing"),
+  sourceTrackOrdinal: z.number().int().nonnegative(),
+  sourceName: z.string().trim().min(1),
+  match: z.enum(["game-id", "assigned-identity", "venue-identity", "shared-name"]),
+  outlineSource: z.enum(["shared", "official-svg", "generated", "bundled", "recorded", "estimated"]),
+  alignmentRmseM: finiteNumber.nonnegative().nullable(),
+  center: TrackImageryGeographicPointSchema,
+  geographicPositions: z.array(TrackImageryGeographicPointSchema).min(4),
+});
+
+const baseSourceSchema = imageSourceSchema.extend({ provider: z.string().trim().min(1) }).superRefine((source, context) => {
+  if (source.provider === "manual" && source.sourceResolutionM === undefined && source.storedResolutionM === undefined) return;
+  if (source.sourceResolutionM === undefined || source.storedResolutionM === undefined) {
+    context.addIssue({ code: "custom", message: "Packed source requires source and stored resolution" });
+    return;
+  }
+  if (source.storedResolutionM < Math.max(source.sourceResolutionM, 0.1)) {
+    context.addIssue({ code: "custom", message: "Stored imagery resolution must not upscale its source or exceed the 0.10 m/pixel detail target" });
+  }
+});
+
+export const TrackImageryVenueManifestSchema = z.object({
+  version: z.literal(TRACK_IMAGERY_MANIFEST_VERSION),
+  venueId: TrackVenueIdSchema,
+  calibration: TrackImageryCalibrationSchema,
+  base: z.object({
+    pack: z.literal(TRACK_IMAGERY_PACKAGE_NAME),
+    tileSize: z.number().int().positive(),
+    bounds: TrackImageryGeographicBoundsSchema,
+    source: baseSourceSchema,
+  }),
+  layers: z.array(
+    textureSchema.extend({
+      id: safeId,
+      kind: z.enum(["game", "layout", "correction"]),
+    }),
+  ),
+});
+
+export const TrackImageryLayoutManifestSchema = z.object({
+  version: z.literal(TRACK_IMAGERY_MANIFEST_VERSION),
+  gameId: GameIdSchema,
+  trackOrdinal: z.number().int().nonnegative(),
+  layers: z.array(safeId),
+});
+
+export type TrackImageryVenueManifest = z.infer<typeof TrackImageryVenueManifestSchema>;
+export type TrackImageryLayoutManifest = z.infer<typeof TrackImageryLayoutManifestSchema>;
+export type TrackImageryGeographicBounds = z.infer<typeof TrackImageryGeographicBoundsSchema>;
+export type TrackImageryCandidate = z.infer<typeof TrackImageryCandidateSchema>;
+export type TrackImageryGeographicReference = z.infer<typeof TrackImageryGeographicReferenceSchema>;
+export interface TrackImagerySourceSearchGroup {
+  id: string;
+  name: string;
+  candidates: TrackImageryCandidate[];
+}
+export interface TrackImagerySourceSearchResult {
+  sources: TrackImagerySourceSearchGroup[];
+  notices: string[];
+}
+export type TrackImageryOutputEstimate = z.infer<typeof TrackImageryOutputEstimateSchema>;
+export type TrackImageryOutputBudget = z.infer<typeof TrackImageryOutputBudgetSchema>;
+export type TrackImageryOutputBudgetResult = z.infer<typeof TrackImageryOutputBudgetResultSchema>;
+export interface TrackImageryConfigurationIndex {
+  venues: TrackImageryVenueManifest[];
+  layouts: TrackImageryLayoutManifest[];
+}
+export type TrackImageryCalibration = TrackImageryVenueManifest["calibration"];
+export type TrackImageryMatrix = TrackImageryCalibration["imageToEnu"];
+export type TrackImagerySource = z.infer<typeof imageSourceSchema>;
+export type TrackImageryLayerKind = TrackImageryVenueManifest["layers"][number]["kind"];
+
+export interface TrackImageryTexture {
+  id: string;
+  kind: TrackImageryLayerKind;
+  url: string;
+  opacity: number;
+  source: TrackImagerySource;
+}
+
+export interface TrackImageryBase {
+  tier: "hq";
+  width: number;
+  height: number;
+  tileSize: number;
+  columns: number;
+  rows: number;
+  bounds: TrackImageryGeographicBounds;
+  contentHash: string;
+  resolutionM?: number;
+  source: TrackImagerySource;
+  tileUrlTemplate: string;
+}
+
+export interface TrackImagery {
+  version: typeof TRACK_IMAGERY_MANIFEST_VERSION;
+  venueId: string;
+  calibration: TrackImageryCalibration;
+  base: TrackImageryBase;
+  textures: TrackImageryTexture[];
+}
+
+export interface TrackImageryPoint {
+  x: number;
+  z: number;
+}
+
+export type TrackImageryGeographicPoint = z.infer<typeof TrackImageryGeographicPointSchema>;
+
+const EARTH_RADIUS_M = 6_378_137;
+
+function finitePoint(point: TrackImageryPoint | undefined): point is TrackImageryPoint {
+  return !!point && Number.isFinite(point.x) && Number.isFinite(point.z);
+}
+
+function finiteGeographicPoint(point: TrackImageryGeographicPoint | null | undefined): point is TrackImageryGeographicPoint {
+  return !!point && Number.isFinite(point.latitudeDeg) && Number.isFinite(point.longitudeDeg) && Math.abs(point.latitudeDeg) <= 90 && Math.abs(point.longitudeDeg) <= 180;
+}
+
+function toEnu(point: TrackImageryGeographicPoint, originLatitudeDeg: number, originLongitudeDeg: number): TrackImageryPoint {
+  const latitudeRad = (originLatitudeDeg * Math.PI) / 180;
+  return {
+    x: (((point.longitudeDeg - originLongitudeDeg) * Math.PI) / 180) * EARTH_RADIUS_M * Math.cos(latitudeRad),
+    z: (((point.latitudeDeg - originLatitudeDeg) * Math.PI) / 180) * EARTH_RADIUS_M,
+  };
+}
+export function geographicTrackImageryPoint(point: TrackImageryGeographicPoint, calibration: TrackImageryCalibration): TrackImageryPoint {
+  return toEnu(point, calibration.originLatitudeDeg, calibration.originLongitudeDeg);
+}
+export function geographicTrackImageryPointFromEnu(point: TrackImageryPoint, originLatitudeDeg: number, originLongitudeDeg: number): TrackImageryGeographicPoint {
+  const latitudeRad = (originLatitudeDeg * Math.PI) / 180;
+  return {
+    latitudeDeg: originLatitudeDeg + ((point.z / EARTH_RADIUS_M) * 180) / Math.PI,
+    longitudeDeg: originLongitudeDeg + ((point.x / (EARTH_RADIUS_M * Math.cos(latitudeRad))) * 180) / Math.PI,
+  };
+}
+const DEFAULT_TRACK_IMAGERY_PADDING_FRACTION = 0.5;
+
+/** Include broad surrounding context because catalog outlines have no geographic heading and must be rotated into place. */
+export function trackImageryGeographicBounds(
+  geographic: readonly (TrackImageryGeographicPoint | null)[],
+  paddingFraction = DEFAULT_TRACK_IMAGERY_PADDING_FRACTION,
+): TrackImageryGeographicBounds | null {
+  const valid = geographic.filter(finiteGeographicPoint);
+  if (valid.length < 2) return null;
+  let west = Infinity;
+  let south = Infinity;
+  let east = -Infinity;
+  let north = -Infinity;
+  for (const point of valid) {
+    west = Math.min(west, point.longitudeDeg);
+    south = Math.min(south, point.latitudeDeg);
+    east = Math.max(east, point.longitudeDeg);
+    north = Math.max(north, point.latitudeDeg);
+  }
+  const safePadding = Number.isFinite(paddingFraction) ? Math.max(0, paddingFraction) : DEFAULT_TRACK_IMAGERY_PADDING_FRACTION;
+  const longitudePadding = Math.max((east - west) * safePadding, 0.000_01);
+  const latitudePadding = Math.max((north - south) * safePadding, 0.000_01);
+  return TrackImageryGeographicBoundsSchema.parse({
+    west: Math.max(-180, west - longitudePadding),
+    south: Math.max(-90, south - latitudePadding),
+    east: Math.min(180, east + longitudePadding),
+    north: Math.min(90, north + latitudePadding),
+  });
+}
+
+/** Create an exact north-up calibration for an API image exported to geographic bounds. */
+export function trackImageryCalibrationFromBounds(geographic: readonly (TrackImageryGeographicPoint | null)[], bounds: TrackImageryGeographicBounds): TrackImageryCalibration | null {
+  const valid = geographic.filter(finiteGeographicPoint);
+  if (valid.length < 2 || !TrackImageryGeographicBoundsSchema.safeParse(bounds).success) return null;
+  const originLatitudeDeg = valid.reduce((sum, point) => sum + point.latitudeDeg, 0) / valid.length;
+  const originLongitudeDeg = valid.reduce((sum, point) => sum + point.longitudeDeg, 0) / valid.length;
+  const northWest = toEnu({ latitudeDeg: bounds.north, longitudeDeg: bounds.west }, originLatitudeDeg, originLongitudeDeg);
+  const northEast = toEnu({ latitudeDeg: bounds.north, longitudeDeg: bounds.east }, originLatitudeDeg, originLongitudeDeg);
+  const southWest = toEnu({ latitudeDeg: bounds.south, longitudeDeg: bounds.west }, originLatitudeDeg, originLongitudeDeg);
+  return {
+    originLatitudeDeg,
+    originLongitudeDeg,
+    imageToEnu: [northEast.x - northWest.x, northEast.z - northWest.z, southWest.x - northWest.x, southWest.z - northWest.z, northWest.x, northWest.z],
+  };
+}
+
+/** Create a north-up venue footprint covering one GPS path. */
+export function defaultVenueImageryCalibration(geographic: readonly (TrackImageryGeographicPoint | null)[], imageAspectRatio: number): TrackImageryCalibration | null {
+  const valid = geographic.filter(finiteGeographicPoint);
+  if (valid.length < 2) return null;
+  const originLatitudeDeg = valid.reduce((sum, point) => sum + point.latitudeDeg, 0) / valid.length;
+  const originLongitudeDeg = valid.reduce((sum, point) => sum + point.longitudeDeg, 0) / valid.length;
+  const enu = valid.map((point) => toEnu(point, originLatitudeDeg, originLongitudeDeg));
+  let minEast = Infinity;
+  let maxEast = -Infinity;
+  let minNorth = Infinity;
+  let maxNorth = -Infinity;
+  for (const point of enu) {
+    minEast = Math.min(minEast, point.x);
+    maxEast = Math.max(maxEast, point.x);
+    minNorth = Math.min(minNorth, point.z);
+    maxNorth = Math.max(maxNorth, point.z);
+  }
+  const aspectRatio = Number.isFinite(imageAspectRatio) && imageAspectRatio > 0 ? imageAspectRatio : 1;
+  let width = Math.max(1, (maxEast - minEast) * 1.2);
+  let height = Math.max(1, (maxNorth - minNorth) * 1.2);
+  if (width / height < aspectRatio) width = height * aspectRatio;
+  else height = width / aspectRatio;
+  const centerEast = (minEast + maxEast) / 2;
+  const centerNorth = (minNorth + maxNorth) / 2;
+  return {
+    originLatitudeDeg,
+    originLongitudeDeg,
+    imageToEnu: [width, 0, 0, -height, centerEast - width / 2, centerNorth + height / 2],
+  };
+}
+
+function fitEnuToTrack(local: readonly TrackImageryPoint[], geographic: readonly (TrackImageryGeographicPoint | null)[], calibration: TrackImageryCalibration): TrackImageryMatrix | null {
+  const count = Math.min(local.length, geographic.length);
+  const pairs: Array<{ source: TrackImageryPoint; target: TrackImageryPoint }> = [];
+  const stride = Math.max(1, Math.floor(count / 500));
+  for (let index = 0; index < count; index += stride) {
+    const target = local[index];
+    const geo = geographic[index];
+    if (!finitePoint(target) || !finiteGeographicPoint(geo)) continue;
+    pairs.push({ source: toEnu(geo, calibration.originLatitudeDeg, calibration.originLongitudeDeg), target });
+  }
+  if (pairs.length < 3) return null;
+
+  let best: { matrix: TrackImageryMatrix; error: number } | null = null;
+  for (const flipEast of [1, -1]) {
+    for (const flipNorth of [1, -1]) {
+      let sourceX = 0;
+      let sourceZ = 0;
+      let targetX = 0;
+      let targetZ = 0;
+      for (const pair of pairs) {
+        sourceX += flipEast * pair.source.x;
+        sourceZ += flipNorth * pair.source.z;
+        targetX += pair.target.x;
+        targetZ += pair.target.z;
+      }
+      sourceX /= pairs.length;
+      sourceZ /= pairs.length;
+      targetX /= pairs.length;
+      targetZ /= pairs.length;
+      let cross = 0;
+      let dot = 0;
+      let sourceNorm = 0;
+      let targetNorm = 0;
+      for (const pair of pairs) {
+        const sx = flipEast * pair.source.x - sourceX;
+        const sz = flipNorth * pair.source.z - sourceZ;
+        const tx = pair.target.x - targetX;
+        const tz = pair.target.z - targetZ;
+        cross += sx * tz - sz * tx;
+        dot += sx * tx + sz * tz;
+        sourceNorm += sx * sx + sz * sz;
+        targetNorm += tx * tx + tz * tz;
+      }
+      if (sourceNorm <= 0 || targetNorm <= 0) continue;
+      const rotation = Math.atan2(cross, dot);
+      const cos = Math.cos(rotation);
+      const sin = Math.sin(rotation);
+      const scale = Math.sqrt(targetNorm / sourceNorm);
+      const a = scale * cos * flipEast;
+      const b = scale * sin * flipEast;
+      const c = -scale * sin * flipNorth;
+      const d = scale * cos * flipNorth;
+      const e = targetX - (a * sourceX) / flipEast - (c * sourceZ) / flipNorth;
+      const f = targetZ - (b * sourceX) / flipEast - (d * sourceZ) / flipNorth;
+      const matrix: TrackImageryMatrix = [a, b, c, d, e, f];
+      let error = 0;
+      for (const pair of pairs) {
+        const mapped = transformTrackImageryPoint(matrix, pair.source.x, pair.source.z);
+        error += (mapped.x - pair.target.x) ** 2 + (mapped.z - pair.target.z) ** 2;
+      }
+      if (!best || error < best.error) best = { matrix, error };
+    }
+  }
+  return best?.matrix ?? null;
+}
+
+export function composeTrackImageryMatrices(outer: TrackImageryMatrix, inner: TrackImageryMatrix): TrackImageryMatrix {
+  return [
+    outer[0] * inner[0] + outer[2] * inner[1],
+    outer[1] * inner[0] + outer[3] * inner[1],
+    outer[0] * inner[2] + outer[2] * inner[3],
+    outer[1] * inner[2] + outer[3] * inner[3],
+    outer[0] * inner[4] + outer[2] * inner[5] + outer[4],
+    outer[1] * inner[4] + outer[3] * inner[5] + outer[5],
+  ];
+}
+
+/** Resolve shared venue imagery into current game's local X/Z coordinates. */
+export function resolveTrackImageryMatrix(
+  local: readonly TrackImageryPoint[],
+  geographic: readonly (TrackImageryGeographicPoint | null)[],
+  calibration: TrackImageryCalibration,
+): TrackImageryMatrix | null {
+  const enuToTrack = fitEnuToTrack(local, geographic, calibration);
+  return enuToTrack ? composeTrackImageryMatrices(enuToTrack, calibration.imageToEnu) : null;
+}
+
+export function transformTrackImageryPoint(matrix: TrackImageryMatrix, u: number, v: number): TrackImageryPoint {
+  return { x: matrix[0] * u + matrix[2] * v + matrix[4], z: matrix[1] * u + matrix[3] * v + matrix[5] };
+}
+
+export function translateTrackImageryMatrix(matrix: TrackImageryMatrix, x: number, z: number): TrackImageryMatrix {
+  return [matrix[0], matrix[1], matrix[2], matrix[3], matrix[4] + x, matrix[5] + z];
+}
+
+export function scaleTrackImageryMatrix(matrix: TrackImageryMatrix, factor: number): TrackImageryMatrix {
+  const center = transformTrackImageryPoint(matrix, 0.5, 0.5);
+  const a = matrix[0] * factor;
+  const b = matrix[1] * factor;
+  const c = matrix[2] * factor;
+  const d = matrix[3] * factor;
+  return [a, b, c, d, center.x - (a + c) / 2, center.z - (b + d) / 2];
+}
+
+export function rotateTrackImageryMatrix(matrix: TrackImageryMatrix, radians: number): TrackImageryMatrix {
+  const center = transformTrackImageryPoint(matrix, 0.5, 0.5);
+  const cos = Math.cos(radians);
+  const sin = Math.sin(radians);
+  const a = cos * matrix[0] - sin * matrix[1];
+  const b = sin * matrix[0] + cos * matrix[1];
+  const c = cos * matrix[2] - sin * matrix[3];
+  const d = sin * matrix[2] + cos * matrix[3];
+  return [a, b, c, d, center.x - (a + c) / 2, center.z - (b + d) / 2];
+}

--- a/shared/racing/tracks/imagery.ts
+++ b/shared/racing/tracks/imagery.ts
@@ -123,12 +123,27 @@ const baseSourceSchema = imageSourceSchema.extend({ provider: z.string().trim().
   }
 });
 
+export const TrackImageryArtifactSchema = z.object({
+  url: z
+    .string()
+    .url()
+    .refine((value) => new URL(value).protocol === "https:", "Artifact URL must use HTTPS"),
+  version: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9][a-z0-9.-]*$/),
+  sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  sizeBytes: z.number().int().positive(),
+  attribution: z.string().trim().min(1),
+});
+
 export const TrackImageryVenueManifestSchema = z.object({
   version: z.literal(TRACK_IMAGERY_MANIFEST_VERSION),
   venueId: TrackVenueIdSchema,
   calibration: TrackImageryCalibrationSchema,
   base: z.object({
     pack: z.literal(TRACK_IMAGERY_PACKAGE_NAME),
+    artifact: TrackImageryArtifactSchema.optional(),
     tileSize: z.number().int().positive(),
     bounds: TrackImageryGeographicBoundsSchema,
     source: baseSourceSchema,
@@ -149,6 +164,7 @@ export const TrackImageryLayoutManifestSchema = z.object({
 });
 
 export type TrackImageryVenueManifest = z.infer<typeof TrackImageryVenueManifestSchema>;
+export type TrackImageryArtifact = z.infer<typeof TrackImageryArtifactSchema>;
 export type TrackImageryLayoutManifest = z.infer<typeof TrackImageryLayoutManifestSchema>;
 export type TrackImageryGeographicBounds = z.infer<typeof TrackImageryGeographicBoundsSchema>;
 export type TrackImageryCandidate = z.infer<typeof TrackImageryCandidateSchema>;

--- a/shared/racing/tracks/registry-source.ts
+++ b/shared/racing/tracks/registry-source.ts
@@ -1,0 +1,2007 @@
+import { Database } from "bun:sqlite";
+import { createHash, randomBytes } from "node:crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
+  writeFileSync,
+  type Dirent,
+} from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+
+import { z } from "zod";
+
+import { SHARED_DIR } from "@shared/platform/runtime/data-paths";
+import { KNOWN_GAME_IDS, type GameId, GameIdSchema } from "../../games/ids";
+import {
+  canonicalTrackAssetPathComponents,
+  CURRENT_TRACK_REVISION,
+  parseCanonicalTrackId,
+  parseVenueRevisionPath,
+  revisionDirectoryPathComponents,
+  type TrackConfigurationConfirmation,
+  TrackConfigurationConfirmationSchema,
+  TrackVenueIdSchema,
+} from "./configuration";
+import {
+  TrackFactsSchema,
+  type CornerFact,
+  type StraightFact,
+  type TrackFacts,
+} from "./facts";
+import {
+  TrackGeometrySchema,
+  type TrackGeometry,
+} from "./geometry";
+import { parseCornerKey, parseStraightKey } from "./keys";
+import { TRACK_REGISTRY_VERSION, writeGeneratedTrackRegistry } from "./registry";
+export const TRACK_REGISTRY_SOURCE_VERSION = 1 as const;
+
+export interface TrackRegistryLocations {
+  sourceDirectory: string;
+  databasePath: string;
+  reportPath: string;
+  transactionPath: string;
+}
+
+export interface TrackRegistryLocationsInput {
+  sourceDirectory?: string;
+  databasePath?: string;
+  reportPath?: string;
+  transactionPath?: string;
+}
+
+const TRACK_FACT_ID = /^[a-z0-9][a-z0-9-]*$/;
+
+const TrackFactIdSchema = z.string().regex(TRACK_FACT_ID, "Use lowercase letters, digits, and hyphens");
+
+const TrackIdentityNodeSchema = z.object({
+  id: TrackVenueIdSchema,
+  name: z.string().trim().min(1),
+}).strict();
+
+const TrackLayoutSchema = z.object({
+  id: TrackVenueIdSchema,
+  name: z.string().trim().min(1),
+  factsSlug: TrackFactIdSchema.optional(),
+}).strict();
+
+const TrackAssignmentSchema = z.object({
+  gameId: GameIdSchema,
+  trackOrdinal: z.number().int().nonnegative(),
+  layoutId: TrackVenueIdSchema,
+  confirmation: TrackConfigurationConfirmationSchema.strict().nullable(),
+}).strict();
+
+const TrackConfigurationsSchema = z.object({
+  version: z.literal(TRACK_REGISTRY_SOURCE_VERSION),
+  venues: z.array(TrackIdentityNodeSchema),
+  layouts: z.array(TrackLayoutSchema),
+  assignments: z.array(TrackAssignmentSchema),
+}).strict();
+
+const TrackFileAssignmentSchema = z.object({
+  gameId: GameIdSchema,
+  trackOrdinal: z.number().int().nonnegative(),
+  confirmation: TrackConfigurationConfirmationSchema.strict().nullable(),
+}).strict();
+
+const VerifiedEntrySchema = z.object({
+  hash: z.string().min(1),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  by: z.string().trim().min(1).optional(),
+  note: z.string().trim().min(1).optional(),
+}).strict();
+
+const VenueMetadataFileSchema = z.object({
+  version: z.literal(TRACK_REGISTRY_SOURCE_VERSION),
+  id: TrackVenueIdSchema,
+  name: z.string().trim().min(1),
+}).strict();
+
+const TrackMetadataFileSchema = z.object({
+  version: z.literal(TRACK_REGISTRY_SOURCE_VERSION),
+  id: TrackVenueIdSchema,
+  name: z.string().trim().min(1),
+  assignments: z.array(TrackFileAssignmentSchema),
+  facts: TrackFactsSchema.strict().optional(),
+  geometryByGame: z.partialRecord(GameIdSchema, TrackGeometrySchema.strict()).optional(),
+  verification: z.object({
+    meta: VerifiedEntrySchema.optional(),
+    segments: z.partialRecord(GameIdSchema, VerifiedEntrySchema).optional(),
+  }).strict().optional(),
+}).strict();
+
+const RevisionMetadataFileSchema = z.object({
+  version: z.literal(TRACK_REGISTRY_SOURCE_VERSION),
+  id: TrackVenueIdSchema,
+  name: z.string().trim().min(1),
+}).strict();
+
+export type TrackConfigurationSource = z.infer<typeof TrackConfigurationsSchema>;
+export interface TrackFactsSource {
+  version: typeof TRACK_REGISTRY_SOURCE_VERSION;
+  facts: TrackFacts[];
+}
+export interface TrackGeometrySource {
+  version: typeof TRACK_REGISTRY_SOURCE_VERSION;
+  geometry: Array<{ factsSlug: string; gameId: GameId } & TrackGeometry>;
+}
+export interface TrackVerificationSource {
+  version: typeof TRACK_REGISTRY_SOURCE_VERSION;
+  entries: Record<string, VerifiedEntry>;
+}
+
+export interface VerifiedEntry {
+  hash: string;
+  date: string;
+  by?: string;
+  note?: string;
+}
+
+export type VerifiedLedger = Record<string, VerifiedEntry>;
+
+export interface TrackRegistrySource {
+  configurations: TrackConfigurationSource;
+  facts: TrackFactsSource;
+  geometry: TrackGeometrySource;
+  verification: TrackVerificationSource;
+}
+
+export interface TrackRegistryProjectionSnapshot {
+  userVersion: number;
+  schema: Array<{
+    type: "index" | "table";
+    name: string;
+    tbl_name: string;
+    sql: string;
+  }>;
+  sourceVersion: number;
+  sourceHash: string;
+  venueNodes: Array<{
+    path: string;
+    parent_path: string | null;
+    slug: string;
+    name: string;
+    depth: number;
+  }>;
+  layouts: Array<{
+    canonical_id: string;
+    venue_path: string;
+    slug: string;
+    name: string;
+    facts_slug: string | null;
+  }>;
+  assignments: Array<{
+    game_id: GameId;
+    track_ordinal: number;
+    layout_id: string;
+    confirmed_at: string | null;
+    confirmed_by: string | null;
+    commit_id: string | null;
+  }>;
+  facts: Array<{
+    slug: string;
+    track_slug: string;
+    layout_slug: string;
+    layout_name: string;
+    name: string;
+    source: string | null;
+  }>;
+  corners: Array<{
+    facts_slug: string;
+    sequence: number;
+    turn_number: number;
+    name: string;
+    direction: "left" | "right" | null;
+    group_name: string | null;
+  }>;
+  covers: Array<{
+    facts_slug: string;
+    corner_sequence: number;
+    turn_number: number;
+  }>;
+  straights: Array<{
+    facts_slug: string;
+    after_turn: number;
+    name: string;
+    group_name: string | null;
+  }>;
+  geometry: Array<{
+    facts_slug: string;
+    game_id: GameId;
+    sector_1_end: number | null;
+    sector_2_end: number | null;
+    sector_source: string | null;
+  }>;
+  segments: Array<{
+    facts_slug: string;
+    game_id: GameId;
+    sequence: number;
+    segment_key: string;
+    start_fraction: number;
+    end_fraction: number;
+  }>;
+  verification: Array<{
+    kind: "meta" | "segments";
+    facts_slug: string;
+    game_id: string;
+    data_hash: string;
+    verified_date: string;
+    verified_by: string | null;
+    note: string | null;
+  }>;
+}
+
+export interface TrackRegistryReport {
+  sourceVersion: number;
+  sourceHash: string;
+  recordCounts: {
+    venues: number;
+    layouts: number;
+    assignments: number;
+    facts: number;
+    corners: number;
+    covers: number;
+    straights: number;
+    geometry: number;
+    geometrySegments: number;
+    verification: number;
+  };
+  trackIdentities: Array<{
+    gameId: GameId;
+    trackOrdinal: number;
+    layoutId: string;
+    factsSlug: string | null;
+  }>;
+  geometrySectors: Array<{
+    gameId: GameId;
+    factsSlug: string;
+    s1End: number | null;
+    s2End: number | null;
+    source: string | null;
+  }>;
+  facts: Array<{
+    slug: string;
+    track: string;
+    layout: string;
+    layoutName: string;
+    name: string;
+    source?: string;
+    corners: Array<{
+      sequence: number;
+      number: number;
+      covers?: number[];
+      name: string;
+      direction?: "left" | "right";
+      group?: string;
+    }>;
+    straights?: Array<{
+      after: number;
+      name: string;
+      group?: string;
+    }>;
+  }>;
+  aliases: Array<{
+    layoutId: string;
+    factsSlug: string | null;
+    assignments: Array<{
+      gameId: GameId;
+      trackOrdinal: number;
+    }>;
+  }>;
+  orphanedReferences: {
+    assignments: Array<{ gameId: string; trackOrdinal: number; layoutId: string }>;
+    geometry: Array<{ gameId: string; factsSlug: string }>;
+    verification: Array<{ kind: string; gameId: string; factsSlug: string }>;
+  };
+  unlinked: {
+    layoutsWithoutFacts: string[];
+    factsWithoutLayouts: string[];
+  };
+}
+
+interface TrackRegistryUpdateJournal {
+  version: number;
+  oldSourceHash: string;
+  newSourceHash: string;
+  sourceBackups: Record<string, string>;
+  sourceStaged: Record<string, string>;
+  databaseBackup: string;
+  databaseStaged: string;
+  reportBackup: string;
+  reportStaged: string;
+}
+
+const VENUES_DIRECTORY = "venues";
+const VENUE_FILE = "venue.json";
+const REVISIONS_DIRECTORY = "revisions";
+const REVISION_FILE = "revision.json";
+const TRACKS_DIRECTORY = "tracks";
+const TRACK_METADATA_FILE = "metadata.json";
+const SEGMENTS_SUFFIX = "-segments.json";
+const VENUE_METADATA_PATH = /^venues\/([a-z0-9][a-z0-9-]*)\/venue\.json$/;
+const REVISION_METADATA_PATH = /^venues\/([a-z0-9][a-z0-9-]*)\/revisions\/((?:[a-z0-9][a-z0-9-]*\/)*[a-z0-9][a-z0-9-]*)\/revision\.json$/;
+const TRACK_METADATA_PATH = /^venues\/([a-z0-9][a-z0-9-]*)\/revisions\/((?:[a-z0-9][a-z0-9-]*\/)*[a-z0-9][a-z0-9-]*)\/tracks\/([a-z0-9][a-z0-9-]*)\/metadata\.json$/;
+const GAME_ORDER = Object.fromEntries(KNOWN_GAME_IDS.map((gameId, index) => [gameId, index])) as Record<string, number>;
+
+function jsonBytes(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function parseIsoDate(value: string, path: string): void {
+  const timestamp = Date.parse(`${value}T00:00:00Z`);
+  if (!Number.isFinite(timestamp) || new Date(timestamp).toISOString().slice(0, 10) !== value) {
+    throw new Error(`${path}: invalid date ${value}`);
+  }
+}
+
+function sha256OverSourceFiles(files: ReadonlyMap<string, string>): string {
+  const hash = createHash("sha256");
+  for (const [filename, body] of [...files.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    hash.update(filename).update("\0").update(body);
+  }
+  return hash.digest("hex");
+}
+
+
+function deriveVenueParent(path: string): string | null {
+  const { rootVenuePath, revisionPath } = parseVenueRevisionPath(path);
+  if (revisionPath === CURRENT_TRACK_REVISION) return null;
+  const components = revisionDirectoryPathComponents(path).slice(3, -1);
+  return components.length === 0 ? rootVenuePath : `${rootVenuePath}/${components.join("/")}`;
+}
+
+function deriveVenueSlug(path: string): string {
+  const { rootVenuePath, revisionPath } = parseVenueRevisionPath(path);
+  if (revisionPath === CURRENT_TRACK_REVISION) return rootVenuePath;
+  return revisionDirectoryPathComponents(path).at(-1)!;
+}
+
+function deriveLayoutVenuePath(id: string): string {
+  return parseCanonicalTrackId(id).venuePath;
+}
+
+function deriveLayoutSlug(id: string): string {
+  return parseCanonicalTrackId(id).layoutSlug;
+}
+
+function readFile(path: string): string {
+  if (!existsSync(path)) throw new Error(`Missing track registry file ${path}`);
+  return readFileSync(path, "utf8");
+}
+
+function writeFile(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
+}
+
+function removeIfExists(path: string): void {
+  if (!existsSync(path)) return;
+  try {
+    unlinkSync(path);
+  } catch {
+    // best effort
+  }
+}
+function pruneEmptySourceDirectories(path: string, root: string): void {
+  let directory = dirname(path);
+  while (directory !== root && !relative(root, directory).startsWith("..")) {
+    if (!existsSync(directory) || readdirSync(directory).length > 0) return;
+    rmdirSync(directory);
+    directory = dirname(directory);
+  }
+}
+
+
+function shardRoot(locations: TrackRegistryLocations): string {
+  return dirname(locations.sourceDirectory);
+}
+
+function sourceFilePath(locations: TrackRegistryLocations, filename: string): string {
+  const root = shardRoot(locations);
+  const path = resolve(root, filename);
+  if (relative(root, path).startsWith("..")) {
+    throw new Error(`Invalid track registry shard path ${filename}`);
+  }
+  return path;
+}
+
+function isUpdateSidecar(name: string): boolean {
+  return /\.(?:backup|stage)\.[a-z0-9]+$/i.test(name);
+}
+
+function readDirectory(path: string): Dirent[] {
+  if (!existsSync(path)) throw new Error(`Missing track registry directory ${path}`);
+  return readdirSync(path, { withFileTypes: true });
+}
+
+function sourcePaths(locations: TrackRegistryLocations): string[] {
+  const root = shardRoot(locations);
+  const venuesRoot = resolve(root, VENUES_DIRECTORY);
+  const paths: string[] = [];
+
+  function collectTrackPaths(directory: string, venuePath: string): void {
+    const tracksDirectory = resolve(directory, TRACKS_DIRECTORY);
+    if (!existsSync(tracksDirectory)) return;
+    for (const entry of readDirectory(tracksDirectory)) {
+      if (isUpdateSidecar(entry.name)) continue;
+      if (!entry.isDirectory()) {
+        throw new Error(`Unexpected track metadata shard ${resolve(tracksDirectory, entry.name)}`);
+      }
+      const metadataPath = resolve(tracksDirectory, entry.name, TRACK_METADATA_FILE);
+      if (!existsSync(metadataPath)) {
+        const remaining = readDirectory(resolve(tracksDirectory, entry.name)).filter((candidate) => !isUpdateSidecar(candidate.name));
+        if (remaining.length === 0) continue;
+        throw new Error(`Missing track metadata shard ${metadataPath}`);
+      }
+      paths.push(`${canonicalTrackAssetPathComponents(venuePath, entry.name).join("/")}/${TRACK_METADATA_FILE}`);
+    }
+  }
+
+  function collectRevisionPaths(directory: string, rootVenuePath: string, revisionPath: string): void {
+    const venuePath = `${rootVenuePath}/${revisionPath}`;
+    const revisionDocument = resolve(directory, REVISION_FILE);
+    if (existsSync(revisionDocument)) {
+      paths.push(`${revisionDirectoryPathComponents(venuePath).join("/")}/${REVISION_FILE}`);
+    } else if (existsSync(resolve(directory, TRACKS_DIRECTORY))) {
+      throw new Error(`Missing revision metadata shard ${revisionDocument}`);
+    }
+    collectTrackPaths(directory, venuePath);
+
+    for (const entry of readDirectory(directory)) {
+      if (!entry.isDirectory() || entry.name === TRACKS_DIRECTORY) continue;
+      const child = resolve(directory, entry.name);
+      if (existsSync(resolve(child, VENUE_FILE))) {
+        throw new Error(`Unexpected nested venue metadata shard ${resolve(child, VENUE_FILE)}`);
+      }
+      if (entry.name === "imagery") continue;
+      collectRevisionPaths(child, rootVenuePath, `${revisionPath}/${entry.name}`);
+    }
+  }
+
+  for (const entry of readDirectory(venuesRoot)) {
+    if (!entry.isDirectory()) continue;
+    const directory = resolve(venuesRoot, entry.name);
+    const venueDocument = resolve(directory, VENUE_FILE);
+    if (!existsSync(venueDocument)) {
+      throw new Error(`Missing venue metadata shard ${venueDocument}`);
+    }
+    paths.push(`${VENUES_DIRECTORY}/${entry.name}/${VENUE_FILE}`);
+    const directTracks = resolve(directory, TRACKS_DIRECTORY);
+    if (existsSync(directTracks)) {
+      throw new Error(`Unexpected direct track metadata directory ${directTracks}`);
+    }
+    for (const child of readDirectory(directory)) {
+      if (child.isDirectory() && child.name !== REVISIONS_DIRECTORY && existsSync(resolve(directory, child.name, VENUE_FILE))) {
+        throw new Error(`Unexpected nested venue metadata shard ${resolve(directory, child.name, VENUE_FILE)}`);
+      }
+    }
+    const revisionsDirectory = resolve(directory, REVISIONS_DIRECTORY);
+    if (!existsSync(revisionsDirectory)) continue;
+    for (const revision of readDirectory(revisionsDirectory)) {
+      if (revision.isDirectory()) collectRevisionPaths(resolve(revisionsDirectory, revision.name), entry.name, revision.name);
+    }
+  }
+  if (existsSync(resolve(root, "meta"))) {
+    throw new Error(`Unexpected legacy track metadata directory ${resolve(root, "meta")}`);
+  }
+  if (existsSync(locations.sourceDirectory)) {
+    for (const entry of readDirectory(locations.sourceDirectory)) {
+      if (isUpdateSidecar(entry.name)) continue;
+      if (entry.isFile() && entry.name.endsWith(".json")) {
+        throw new Error(`Unexpected aggregate track registry source ${resolve(locations.sourceDirectory, entry.name)}`);
+      }
+    }
+  }
+  for (const gameId of KNOWN_GAME_IDS) {
+    const gameDirectory = resolve(root, gameId);
+    if (!existsSync(gameDirectory)) continue;
+    for (const entry of readDirectory(gameDirectory)) {
+      if (entry.isFile() && entry.name.endsWith(SEGMENTS_SUFFIX)) {
+        throw new Error(`Unexpected legacy track segments shard ${resolve(gameDirectory, entry.name)}`);
+      }
+    }
+  }
+  return paths.sort((a, b) => a.localeCompare(b));
+}
+
+export function readTrackRegistrySourceFiles(
+  locations: TrackRegistryLocationsInput = {},
+): ReadonlyMap<string, string> {
+  const resolved = resolveTrackRegistryLocations(locations);
+  return new Map(sourcePaths(resolved).map((filename) => [filename, readFile(sourceFilePath(resolved, filename))]));
+}
+
+export function resolveTrackRegistryLocations(locations: TrackRegistryLocationsInput = {}): TrackRegistryLocations {
+  const overrideRoot =
+    process.env.RACEIQ_TRACK_REGISTRY_DIR &&
+    (process.env.RACEIQ_TEST_MODE === "1" || process.env.NODE_ENV === "test" || process.env.RACEIQ_E2E === "1")
+      ? resolve(process.env.RACEIQ_TRACK_REGISTRY_DIR)
+      : null;
+  const tracksRoot = overrideRoot ?? resolve(SHARED_DIR, "tracks");
+  const defaultLocations: TrackRegistryLocations = {
+    sourceDirectory: resolve(tracksRoot, "registry-source"),
+    databasePath: resolve(tracksRoot, "registry.sqlite"),
+    reportPath: resolve(tracksRoot, "registry-report.json"),
+    transactionPath: resolve(tracksRoot, ".registry-source-update.json"),
+  };
+
+  return {
+    ...defaultLocations,
+    ...locations,
+  };
+}
+function findColocatedAsset(
+  directory: string,
+  root: string,
+  registryPaths: ReadonlySet<string>,
+): string | null {
+  if (!existsSync(directory)) return null;
+  for (const entry of readDirectory(directory)) {
+    if (isUpdateSidecar(entry.name)) continue;
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      const nested = findColocatedAsset(path, root, registryPaths);
+      if (nested) return nested;
+      continue;
+    }
+    const relativePath = relative(root, path).replaceAll("\\", "/");
+    if (!registryPaths.has(relativePath)) return path;
+  }
+  return null;
+}
+
+function assertRemovedMetadataHasNoAssets(
+  current: ReadonlyMap<string, string>,
+  next: ReadonlyMap<string, string>,
+  locations: TrackRegistryLocations,
+): void {
+  const root = shardRoot(locations);
+  const currentPaths = new Set(current.keys());
+  for (const filename of currentPaths) {
+    if (next.has(filename)) continue;
+    const asset = findColocatedAsset(dirname(sourceFilePath(locations, filename)), root, currentPaths);
+    if (asset) {
+      throw new Error(`Cannot remove track metadata ${filename} while colocated asset remains: ${asset}`);
+    }
+  }
+}
+
+
+function parseJsonDocument(contents: string, filename: string): unknown {
+  try {
+    return JSON.parse(contents);
+  } catch {
+    throw new Error(`Invalid JSON in ${filename}`);
+  }
+}
+
+function parseSourceDocuments(locations: TrackRegistryLocations): TrackRegistrySource {
+  const files = readTrackRegistrySourceFiles(locations);
+  const venues: TrackConfigurationSource["venues"] = [];
+  const layouts: TrackConfigurationSource["layouts"] = [];
+  const assignments: TrackConfigurationSource["assignments"] = [];
+  const facts: TrackFacts[] = [];
+  const geometry: TrackGeometrySource["geometry"] = [];
+  const entries: VerifiedLedger = {};
+  const revisions = new Map<string, { rootVenuePath: string; revisionPath: string; name: string }>();
+
+  for (const [filename, contents] of files) {
+    const venueMatch = VENUE_METADATA_PATH.exec(filename);
+    if (venueMatch) {
+      const venue = VenueMetadataFileSchema.parse(parseJsonDocument(contents, filename));
+      if (venue.id !== venueMatch[1]) {
+        throw new Error(`Venue metadata shard ${filename} must match venue id ${venue.id}`);
+      }
+      venues.push({ id: venue.id, name: venue.name });
+      continue;
+    }
+
+    const revisionMatch = REVISION_METADATA_PATH.exec(filename);
+    if (revisionMatch) {
+      const revision = RevisionMetadataFileSchema.parse(parseJsonDocument(contents, filename));
+      const venuePath = `${revisionMatch[1]}/${revisionMatch[2]}`;
+      const { rootVenuePath, revisionPath } = parseVenueRevisionPath(venuePath);
+      if (revision.id !== revisionPath) {
+        throw new Error(`Revision metadata shard ${filename} must match revision id ${revision.id}`);
+      }
+      if (revisionPath !== CURRENT_TRACK_REVISION) {
+        revisions.set(venuePath, { rootVenuePath, revisionPath, name: revision.name });
+      }
+      continue;
+    }
+
+    const trackMatch = TRACK_METADATA_PATH.exec(filename);
+    if (!trackMatch) throw new Error(`Unexpected track metadata shard ${filename}`);
+    const venuePath = `${trackMatch[1]}/${trackMatch[2]}`;
+    const { rootVenuePath, revisionPath } = parseVenueRevisionPath(venuePath);
+    const layoutId = `${rootVenuePath}/${revisionPath === CURRENT_TRACK_REVISION ? "" : `${revisionPath}/`}${trackMatch[3]}`;
+    const track = TrackMetadataFileSchema.parse(parseJsonDocument(contents, filename));
+    if (track.id !== layoutId) {
+      throw new Error(`Track metadata shard ${filename} must match layout id ${track.id}`);
+    }
+    if ((track.geometryByGame || track.verification) && !track.facts) {
+      throw new Error(`Track metadata shard ${filename} needs facts for geometry or verification`);
+    }
+    layouts.push({
+      id: track.id,
+      name: track.name,
+      ...(track.facts ? { factsSlug: track.facts.slug } : {}),
+    });
+    for (const assignment of track.assignments) {
+      assignments.push({
+        ...assignment,
+        layoutId: track.id,
+      });
+    }
+    if (!track.facts) continue;
+
+    facts.push(track.facts);
+    for (const [gameId, value] of Object.entries(track.geometryByGame ?? {}) as Array<[GameId, TrackGeometry]>) {
+      geometry.push({
+        factsSlug: track.facts.slug,
+        gameId,
+        ...(value.sectors ? { sectors: value.sectors } : {}),
+        segments: value.segments,
+      });
+    }
+    if (track.verification?.meta) {
+      entries[`meta:${track.facts.slug}`] = track.verification.meta;
+    }
+    for (const [gameId, entry] of Object.entries(track.verification?.segments ?? {}) as Array<[GameId, VerifiedEntry]>) {
+      entries[`segments:${gameId}/${track.facts.slug}`] = entry;
+    }
+  }
+
+  for (const { rootVenuePath, revisionPath, name } of revisions.values()) {
+    const components = revisionDirectoryPathComponents(`${rootVenuePath}/${revisionPath}`).slice(3);
+    for (let index = 0; index < components.length; index += 1) {
+      const path = `${rootVenuePath}/${components.slice(0, index + 1).join("/")}`;
+      const explicitName = revisions.get(path)?.name;
+      if (!venues.some((venue) => venue.id === path)) {
+        venues.push({ id: path, name: explicitName ?? (index === components.length - 1 ? name : components[index]!) });
+      }
+    }
+  }
+
+  return {
+
+    configurations: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      venues,
+      layouts,
+      assignments,
+    },
+    facts: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      facts,
+    },
+    geometry: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      geometry,
+    },
+    verification: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      entries,
+    },
+  };
+}
+
+function canonicalizeCorner(corner: CornerFact): CornerFact {
+  const covers = (corner.covers ?? []).slice().sort((a, b) => a - b);
+  return {
+    number: corner.number,
+    ...(covers.length ? { covers } : {}),
+    name: corner.name,
+    ...(corner.direction ? { direction: corner.direction } : {}),
+    ...(corner.group ? { group: corner.group } : {}),
+  };
+}
+
+function canonicalizeStraight(straight: StraightFact): StraightFact {
+  return {
+    after: straight.after,
+    name: straight.name,
+    ...(straight.group ? { group: straight.group } : {}),
+  };
+}
+
+function canonicalizeConfirmation(confirmation: TrackConfigurationConfirmation | null): TrackConfigurationConfirmation | null {
+  if (confirmation === null) return null;
+  parseIsoDate(confirmation.confirmedAt, "confirmation.confirmedAt");
+  return {
+    confirmedAt: confirmation.confirmedAt,
+    confirmedBy: confirmation.confirmedBy,
+    ...(confirmation.commitId ? { commitId: confirmation.commitId.toLowerCase() } : {}),
+  };
+}
+
+function canonicalizeTrackRegistrySource(source: TrackRegistrySource): TrackRegistrySource {
+  const configurations = source.configurations;
+  const facts = source.facts;
+  const geometry = source.geometry;
+  const verification = source.verification;
+
+  const venues = configurations.venues
+    .map((venue) => ({
+      id: venue.id,
+      name: venue.name,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  const layouts = configurations.layouts
+    .map((layout) => ({
+      id: layout.id,
+      name: layout.name,
+      ...(layout.factsSlug ? { factsSlug: layout.factsSlug } : {}),
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  const assignments = configurations.assignments
+    .map((assignment) => ({
+      gameId: assignment.gameId,
+      trackOrdinal: assignment.trackOrdinal,
+      layoutId: assignment.layoutId,
+      confirmation: canonicalizeConfirmation(assignment.confirmation),
+    }))
+    .sort((a, b) => {
+      const byGame = (GAME_ORDER[a.gameId] ?? Number.MAX_SAFE_INTEGER) - (GAME_ORDER[b.gameId] ?? Number.MAX_SAFE_INTEGER);
+      return byGame !== 0 ? byGame : a.trackOrdinal === b.trackOrdinal ? a.layoutId.localeCompare(b.layoutId) : a.trackOrdinal - b.trackOrdinal;
+    });
+
+  const factsSorted = facts.facts
+    .map((fact) => {
+      const corners = fact.corners.map((corner) => canonicalizeCorner(corner));
+      const straights = (fact.straights ?? []).map((straight) => canonicalizeStraight(straight));
+      return {
+        slug: fact.slug,
+        track: fact.track,
+        layout: fact.layout,
+        layoutName: fact.layoutName,
+        name: fact.name,
+        ...(fact.source ? { source: fact.source } : {}),
+        corners,
+        ...(straights.length
+          ? { straights: straights.sort((a, b) => a.after - b.after) }
+          : {}),
+      };
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+
+  const geometrySorted = geometry.geometry
+    .map((geometryRow) => {
+      const segments = geometryRow.segments.map((segment) => ({ ...segment }));
+      const sectors = geometryRow.sectors ?? undefined;
+      return {
+        factsSlug: geometryRow.factsSlug,
+        gameId: geometryRow.gameId,
+        ...(sectors ? { sectors } : {}),
+        segments,
+      };
+    })
+    .sort((a, b) => {
+      const byGame = (GAME_ORDER[a.gameId] ?? Number.MAX_SAFE_INTEGER) - (GAME_ORDER[b.gameId] ?? Number.MAX_SAFE_INTEGER);
+      return byGame !== 0 ? byGame : a.factsSlug.localeCompare(b.factsSlug);
+    });
+
+  const entries: Array<[string, VerifiedEntry]> = Object.entries(verification.entries)
+    .map(([key, entry]): [string, VerifiedEntry] => [
+      key,
+      {
+        hash: entry.hash,
+        date: entry.date,
+        ...(entry.by ? { by: entry.by } : {}),
+        ...(entry.note ? { note: entry.note } : {}),
+      },
+    ])
+    .sort(([a], [b]) => a.localeCompare(b));
+
+  return {
+    configurations: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      venues,
+      layouts,
+      assignments,
+    },
+    facts: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      facts: factsSorted,
+    },
+    geometry: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      geometry: geometrySorted,
+    },
+    verification: {
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      entries: Object.fromEntries(entries),
+    },
+  };
+}
+
+function validateTrackConfigurationSource(source: TrackRegistrySource): TrackRegistrySource {
+  const canonical = canonicalizeTrackRegistrySource(source);
+
+  const errors: string[] = [];
+  const venueIds = new Set<string>();
+  for (const venue of canonical.configurations.venues) {
+    if (venueIds.has(venue.id)) errors.push(`Duplicate venue ${venue.id}`);
+    venueIds.add(venue.id);
+    const { rootVenuePath, revisionPath } = parseVenueRevisionPath(venue.id);
+    if (revisionPath === CURRENT_TRACK_REVISION && venue.id !== rootVenuePath) {
+      errors.push(`Current revision must not add venue node ${venue.id}`);
+    }
+    const parent = deriveVenueParent(venue.id);
+    if (parent && !venueIds.has(parent) && !canonical.configurations.venues.some((candidate) => candidate.id === parent)) {
+      errors.push(`Missing parent venue for ${venue.id}: ${parent}`);
+    }
+  }
+
+  const layoutIds = new Set<string>();
+  const assignmentKeys = new Set<string>();
+  const layoutVenueMissing: string[] = [];
+  const layoutRefsFacts = new Set<string>();
+  const factsLayoutIds = new Map<string, string>();
+  for (const fact of canonical.facts.facts) {
+    if (layoutRefsFacts.has(fact.slug)) errors.push(`Duplicate facts ${fact.slug}`);
+    layoutRefsFacts.add(fact.slug);
+  }
+
+  for (const layout of canonical.configurations.layouts) {
+    if (layoutIds.has(layout.id)) errors.push(`Duplicate layout ${layout.id}`);
+    layoutIds.add(layout.id);
+    const parent = deriveLayoutVenuePath(layout.id);
+    const { venuePath } = parseCanonicalTrackId(layout.id);
+    const { rootVenuePath, revisionPath } = parseVenueRevisionPath(venuePath);
+    if (revisionPath === CURRENT_TRACK_REVISION && venuePath !== rootVenuePath) {
+      errors.push(`Current revision must not appear in canonical layout id ${layout.id}`);
+    }
+    if (!canonical.configurations.venues.some((venue) => venue.id === parent)) {
+      layoutVenueMissing.push(layout.id);
+    }
+    if (layout.factsSlug && !layoutRefsFacts.has(layout.factsSlug)) {
+      errors.push(`Layout ${layout.id} references unknown factsSlug ${layout.factsSlug}`);
+    }
+    if (layout.factsSlug) {
+      const previousLayout = factsLayoutIds.get(layout.factsSlug);
+      if (previousLayout) {
+        errors.push(`Facts ${layout.factsSlug} belongs to multiple layouts: ${previousLayout}, ${layout.id}`);
+      }
+      factsLayoutIds.set(layout.factsSlug, layout.id);
+    }
+  }
+
+  if (layoutVenueMissing.length > 0) {
+    errors.push(...layoutVenueMissing.map((layout) => `Missing layout venue for ${layout}`));
+  }
+  for (const fact of canonical.facts.facts) {
+    if (!factsLayoutIds.has(fact.slug)) errors.push(`Facts ${fact.slug} has no layout metadata shard`);
+  }
+
+  const layoutMap = new Set(canonical.configurations.layouts.map((layout) => layout.id));
+  for (const assignment of canonical.configurations.assignments) {
+    const key = `${assignment.gameId}\0${assignment.trackOrdinal}`;
+    if (assignmentKeys.has(key)) {
+      errors.push(`Duplicate assignment ${assignment.gameId} #${assignment.trackOrdinal}`);
+    }
+    assignmentKeys.add(key);
+    if (!layoutMap.has(assignment.layoutId)) {
+      errors.push(`Assignment references missing layout ${assignment.layoutId}`);
+    }
+  }
+
+  for (const fact of canonical.facts.facts) {
+    const used = new Set<number>();
+    const byAfter = new Set<number>();
+    let previousMaximum = 0;
+    for (const corner of fact.corners) {
+      if (used.has(corner.number)) {
+        errors.push(`Duplicate corner number ${corner.number} in facts ${fact.slug}`);
+      }
+      used.add(corner.number);
+      for (const covered of corner.covers ?? []) {
+        if (used.has(covered)) {
+          errors.push(`Duplicate corner number ${covered} in facts ${fact.slug}`);
+        }
+        used.add(covered);
+      }
+      const numbers = [corner.number, ...(corner.covers ?? [])];
+      const minimum = Math.min(...numbers);
+      if (minimum <= previousMaximum) {
+        errors.push(`Corner ${corner.number} is out of racing order in facts ${fact.slug}`);
+      }
+      previousMaximum = Math.max(...numbers);
+    }
+    for (const straight of fact.straights ?? []) {
+      if (byAfter.has(straight.after)) {
+        errors.push(`Duplicate straight after_turn ${straight.after} in facts ${fact.slug}`);
+      }
+      byAfter.add(straight.after);
+    }
+  }
+
+  const geometryKeySet = new Set<string>();
+  for (const row of canonical.geometry.geometry) {
+    const key = `${row.factsSlug}\0${row.gameId}`;
+    if (geometryKeySet.has(key)) {
+      errors.push(`Duplicate geometry ${row.gameId}/${row.factsSlug}`);
+    }
+    geometryKeySet.add(key);
+
+    if (!layoutRefsFacts.has(row.factsSlug)) {
+      errors.push(`Geometry references missing facts slug ${row.factsSlug}`);
+    }
+
+    if (row.sectors) {
+      if (!Number.isFinite(row.sectors.s1End) || !Number.isFinite(row.sectors.s2End) || row.sectors.s1End <= 0 || row.sectors.s1End >= row.sectors.s2End || row.sectors.s2End >= 1) {
+        errors.push(`Invalid sectors for ${row.gameId}/${row.factsSlug}`);
+      }
+    }
+
+    for (const segment of row.segments) {
+      const key = segment.key;
+      if (!Number.isFinite(segment.startFrac) || !Number.isFinite(segment.endFrac) || segment.startFrac < 0 || segment.startFrac > 1 || segment.endFrac < 0 || segment.endFrac > 1) {
+        errors.push(`Segment fraction out of range for ${row.gameId}/${row.factsSlug} ${key}`);
+      }
+      if (!(segment.startFrac < segment.endFrac)) {
+        errors.push(`Segment fraction ordering invalid for ${row.gameId}/${row.factsSlug} ${key}`);
+      }
+      if (key.startsWith("t")) {
+        const corners = parseCornerKey(key);
+        if (!corners.length || corners.some((n) => n <= 0)) {
+          errors.push(`Invalid corner segment key ${key} for geometry ${row.gameId}/${row.factsSlug}`);
+        }
+      } else if (key.startsWith("s")) {
+        const after = parseStraightKey(key);
+        if (after == null || after <= 0 || !Number.isInteger(after)) {
+          errors.push(`Invalid straight segment key ${key} for geometry ${row.gameId}/${row.factsSlug}`);
+        }
+      } else {
+        errors.push(`Malformed segment key ${key} for geometry ${row.gameId}/${row.factsSlug}`);
+      }
+    }
+  }
+
+  for (const [key, entry] of Object.entries(canonical.verification.entries)) {
+    parseIsoDate(entry.date, `verification ${key} date`);
+    const meta = /^meta:(.+)$/.exec(key);
+    const segments = /^segments:([^/]+)\/(.+)$/.exec(key);
+    if (!meta && !segments) {
+      errors.push(`Invalid verification key ${key}`);
+      continue;
+    }
+    if (meta) {
+      if (!layoutRefsFacts.has(meta[1])) {
+        errors.push(`Verification references missing facts slug ${meta[1]}`);
+      }
+      continue;
+    }
+    const gameId = segments![1];
+    const slug = segments![2];
+    if (!KNOWN_GAME_IDS.includes(gameId as (typeof KNOWN_GAME_IDS)[number])) {
+      errors.push(`Verification references unknown game ${gameId}`);
+    }
+    const geometryExists = canonical.geometry.geometry.some((row) => row.gameId === gameId && row.factsSlug === slug);
+    if (!geometryExists) {
+      errors.push(`Verification references missing geometry for ${gameId}/${slug}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    throw new Error(errors.join("; "));
+  }
+
+  return canonical;
+}
+
+export function loadTrackRegistrySource(locations: TrackRegistryLocationsInput = {}): TrackRegistrySource {
+  const resolved = resolveTrackRegistryLocations(locations);
+  const parsed = parseSourceDocuments(resolved);
+  return validateTrackConfigurationSource(parsed);
+}
+
+export function renderTrackRegistrySource(source: TrackRegistrySource): ReadonlyMap<string, string> {
+  const canonical = validateTrackConfigurationSource(source);
+  const map = new Map<string, string>();
+  const factsBySlug = new Map(canonical.facts.facts.map((fact) => [fact.slug, fact]));
+  const geometryByFactsSlug = new Map<string, TrackGeometrySource["geometry"]>();
+  for (const geometry of canonical.geometry.geometry) {
+    const rows = geometryByFactsSlug.get(geometry.factsSlug) ?? [];
+    rows.push(geometry);
+    geometryByFactsSlug.set(geometry.factsSlug, rows);
+  }
+
+  for (const venue of canonical.configurations.venues) {
+    const { rootVenuePath, revisionPath } = parseVenueRevisionPath(venue.id);
+    if (revisionPath === CURRENT_TRACK_REVISION) {
+      map.set(`${VENUES_DIRECTORY}/${rootVenuePath}/${VENUE_FILE}`, jsonBytes({
+        version: TRACK_REGISTRY_SOURCE_VERSION,
+        id: venue.id,
+        name: venue.name,
+      }));
+      map.set(`${revisionDirectoryPathComponents(venue.id).join("/")}/${REVISION_FILE}`, jsonBytes({
+        version: TRACK_REGISTRY_SOURCE_VERSION,
+        id: CURRENT_TRACK_REVISION,
+        name: "Current",
+      }));
+      continue;
+    }
+    map.set(`${revisionDirectoryPathComponents(venue.id).join("/")}/${REVISION_FILE}`, jsonBytes({
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      id: revisionPath,
+      name: venue.name,
+    }));
+  }
+  for (const layout of canonical.configurations.layouts) {
+    const fact = layout.factsSlug ? factsBySlug.get(layout.factsSlug) : undefined;
+    if (layout.factsSlug && !fact) throw new Error(`Layout ${layout.id} references unknown factsSlug ${layout.factsSlug}`);
+    const geometryByGame: Partial<Record<GameId, TrackGeometry>> = {};
+    for (const geometry of fact ? geometryByFactsSlug.get(fact.slug) ?? [] : []) {
+      geometryByGame[geometry.gameId] = {
+        ...(geometry.sectors ? { sectors: geometry.sectors } : {}),
+        segments: geometry.segments,
+      };
+    }
+    const segmentVerification = fact ? Object.fromEntries(
+      Object.keys(geometryByGame)
+        .filter((gameId) => canonical.verification.entries[`segments:${gameId}/${fact.slug}`])
+        .map((gameId) => [gameId, canonical.verification.entries[`segments:${gameId}/${fact.slug}`]!]),
+    ) : {};
+    const verification = fact ? {
+      ...(canonical.verification.entries[`meta:${fact.slug}`] ? { meta: canonical.verification.entries[`meta:${fact.slug}`] } : {}),
+      ...(Object.keys(segmentVerification).length ? { segments: segmentVerification } : {}),
+    } : undefined;
+    const { venuePath, layoutSlug } = parseCanonicalTrackId(layout.id);
+    map.set(`${canonicalTrackAssetPathComponents(venuePath, layoutSlug).join("/")}/${TRACK_METADATA_FILE}`, jsonBytes({
+      version: TRACK_REGISTRY_SOURCE_VERSION,
+      id: layout.id,
+      name: layout.name,
+      assignments: canonical.configurations.assignments
+        .filter((assignment) => assignment.layoutId === layout.id)
+        .map(({ gameId, trackOrdinal, confirmation }) => ({ gameId, trackOrdinal, confirmation })),
+      ...(fact ? { facts: fact } : {}),
+      ...(Object.keys(geometryByGame).length ? { geometryByGame } : {}),
+      ...(verification && Object.keys(verification).length ? { verification } : {}),
+    }));
+  }
+  return map;
+}
+
+function clearTrackRegistryProjection(database: Database): void {
+  database.query("DELETE FROM registry_metadata").run();
+  database.query("DELETE FROM curation_verification").run();
+  database.query("DELETE FROM game_geometry_segments").run();
+  database.query("DELETE FROM game_geometry").run();
+  database.query("DELETE FROM track_corner_covers").run();
+  database.query("DELETE FROM track_straights").run();
+  database.query("DELETE FROM track_corners").run();
+  database.query("DELETE FROM game_tracks").run();
+  database.query("DELETE FROM layouts").run();
+  const venues = database.query("SELECT path FROM venue_nodes ORDER BY depth DESC, path DESC").all() as Array<{ path: string }>;
+  const deleteVenue = database.prepare("DELETE FROM venue_nodes WHERE path = ?");
+  for (const venue of venues) deleteVenue.run(venue.path);
+  database.query("DELETE FROM track_facts").run();
+}
+
+function insertTrackRegistryProjection(
+  database: Database,
+  source: TrackRegistrySource,
+  sourceHash: string,
+): void {
+  const insertVenue = database.prepare("INSERT INTO venue_nodes (path, parent_path, slug, name, depth) VALUES (?, ?, ?, ?, ?)");
+  const insertLayout = database.prepare("INSERT INTO layouts (canonical_id, venue_path, slug, name, facts_slug) VALUES (?, ?, ?, ?, ?)");
+  const insertAssignment = database.prepare("INSERT INTO game_tracks (game_id, track_ordinal, layout_id, confirmed_at, confirmed_by, commit_id) VALUES (?, ?, ?, ?, ?, ?)");
+  const insertFact = database.prepare("INSERT INTO track_facts (slug, track_slug, layout_slug, layout_name, name, source) VALUES (?, ?, ?, ?, ?, ?)");
+  const insertCorner = database.prepare("INSERT INTO track_corners (facts_slug, sequence, turn_number, name, direction, group_name) VALUES (?, ?, ?, ?, ?, ?)");
+  const insertCover = database.prepare("INSERT INTO track_corner_covers (facts_slug, corner_sequence, turn_number) VALUES (?, ?, ?)");
+  const insertStraight = database.prepare("INSERT INTO track_straights (facts_slug, after_turn, name, group_name) VALUES (?, ?, ?, ?)");
+  const insertGeometry = database.prepare("INSERT INTO game_geometry (facts_slug, game_id, sector_1_end, sector_2_end, sector_source) VALUES (?, ?, ?, ?, ?)");
+  const insertSegment = database.prepare("INSERT INTO game_geometry_segments (facts_slug, game_id, sequence, segment_key, start_fraction, end_fraction) VALUES (?, ?, ?, ?, ?, ?)");
+  const insertVerification = database.prepare("INSERT INTO curation_verification (kind, facts_slug, game_id, data_hash, verified_date, verified_by, note) VALUES (?, ?, ?, ?, ?, ?, ?)");
+  const insertMetadata = database.prepare("INSERT INTO registry_metadata (key, value) VALUES (?, ?)");
+
+  for (const fact of source.facts.facts) {
+    insertFact.run(fact.slug, fact.track, fact.layout, fact.layoutName, fact.name, fact.source ?? null);
+  }
+
+  const venues = source.configurations.venues
+    .map((venue) => {
+      const parentPath = deriveVenueParent(venue.id);
+      return {
+        path: venue.id,
+        parentPath,
+        slug: deriveVenueSlug(venue.id),
+        name: venue.name,
+        depth: parentPath ? parentPath.split("/").length : 0,
+      };
+    })
+    .sort((a, b) => a.depth - b.depth || a.path.localeCompare(b.path));
+  for (const venue of venues) {
+    insertVenue.run(venue.path, venue.parentPath, venue.slug, venue.name, venue.depth);
+  }
+
+  for (const layout of source.configurations.layouts) {
+    insertLayout.run(layout.id, deriveLayoutVenuePath(layout.id), deriveLayoutSlug(layout.id), layout.name, layout.factsSlug ?? null);
+  }
+  for (const assignment of source.configurations.assignments) {
+    insertAssignment.run(
+      assignment.gameId,
+      assignment.trackOrdinal,
+      assignment.layoutId,
+      assignment.confirmation?.confirmedAt ?? null,
+      assignment.confirmation?.confirmedBy ?? null,
+      assignment.confirmation?.commitId ?? null,
+    );
+  }
+
+  for (const fact of source.facts.facts) {
+    fact.corners.forEach((corner, sequence) => {
+      insertCorner.run(fact.slug, sequence, corner.number, corner.name, corner.direction ?? null, corner.group ?? null);
+    });
+  }
+  for (const fact of source.facts.facts) {
+    fact.corners.forEach((corner, sequence) => {
+      for (const covered of corner.covers ?? []) insertCover.run(fact.slug, sequence, covered);
+    });
+    for (const straight of fact.straights ?? []) {
+      insertStraight.run(fact.slug, straight.after, straight.name, straight.group ?? null);
+    }
+  }
+
+  for (const row of source.geometry.geometry) {
+    insertGeometry.run(
+      row.factsSlug,
+      row.gameId,
+      row.sectors?.s1End ?? null,
+      row.sectors?.s2End ?? null,
+      row.sectors?.source ?? null,
+    );
+  }
+  for (const row of source.geometry.geometry) {
+    row.segments.forEach((segment, sequence) => {
+      insertSegment.run(row.factsSlug, row.gameId, sequence, segment.key, segment.startFrac, segment.endFrac);
+    });
+  }
+
+  for (const [key, entry] of Object.entries(source.verification.entries)) {
+    const meta = /^meta:(.+)$/.exec(key);
+    const segments = /^segments:([^/]+)\/(.+)$/.exec(key);
+    if (!meta && !segments) throw new Error(`Invalid verification key ${key}`);
+    insertVerification.run(
+      meta ? "meta" : "segments",
+      meta?.[1] ?? segments![2],
+      segments?.[1] ?? "",
+      entry.hash,
+      entry.date,
+      entry.by ?? null,
+      entry.note ?? null,
+    );
+  }
+  insertMetadata.run("sourceVersion", String(TRACK_REGISTRY_SOURCE_VERSION));
+  insertMetadata.run("sourceHash", sourceHash);
+}
+function compileTrackRegistryProjection(source: TrackRegistrySource, targetDatabasePath: string): TrackRegistryProjectionSnapshot {
+  const canonical = validateTrackConfigurationSource(source);
+
+
+  const sourceHash = sha256OverSourceFiles(renderTrackRegistrySource(canonical));
+
+  mkdirSync(dirname(targetDatabasePath), { recursive: true });
+  const database = new Database(targetDatabasePath);
+
+  try {
+    database.exec("PRAGMA foreign_keys = ON");
+    database.exec(`
+      CREATE TABLE venue_nodes (
+        path TEXT PRIMARY KEY,
+        parent_path TEXT REFERENCES venue_nodes(path) ON UPDATE CASCADE ON DELETE RESTRICT,
+        slug TEXT NOT NULL,
+        name TEXT NOT NULL,
+        depth INTEGER NOT NULL CHECK (depth >= 0),
+        UNIQUE (parent_path, slug)
+      ) WITHOUT ROWID;
+
+      CREATE TABLE layouts (
+        canonical_id TEXT PRIMARY KEY,
+        venue_path TEXT NOT NULL REFERENCES venue_nodes(path) ON UPDATE CASCADE ON DELETE RESTRICT,
+        slug TEXT NOT NULL,
+        name TEXT NOT NULL,
+        facts_slug TEXT REFERENCES track_facts(slug) ON UPDATE CASCADE ON DELETE SET NULL,
+        UNIQUE (venue_path, slug)
+      ) WITHOUT ROWID;
+
+      CREATE TABLE game_tracks (
+        game_id TEXT NOT NULL,
+        track_ordinal INTEGER NOT NULL CHECK (track_ordinal >= 0),
+        layout_id TEXT NOT NULL REFERENCES layouts(canonical_id) ON UPDATE CASCADE ON DELETE RESTRICT,
+        confirmed_at TEXT,
+        confirmed_by TEXT,
+        commit_id TEXT,
+        PRIMARY KEY (game_id, track_ordinal),
+        CHECK ((confirmed_at IS NULL AND confirmed_by IS NULL AND commit_id IS NULL) OR (confirmed_at IS NOT NULL AND confirmed_by IS NOT NULL))
+      ) WITHOUT ROWID;
+
+      CREATE TABLE track_facts (
+        slug TEXT PRIMARY KEY,
+        track_slug TEXT NOT NULL,
+        layout_slug TEXT NOT NULL,
+        layout_name TEXT NOT NULL,
+        name TEXT NOT NULL,
+        source TEXT
+      ) WITHOUT ROWID;
+
+      CREATE TABLE track_corners (
+        facts_slug TEXT NOT NULL REFERENCES track_facts(slug) ON UPDATE CASCADE ON DELETE CASCADE,
+        sequence INTEGER NOT NULL CHECK (sequence >= 0),
+        turn_number INTEGER NOT NULL CHECK (turn_number > 0),
+        name TEXT NOT NULL,
+        direction TEXT CHECK (direction IN ('left', 'right')),
+        group_name TEXT,
+        PRIMARY KEY (facts_slug, sequence),
+        UNIQUE (facts_slug, turn_number)
+      ) WITHOUT ROWID;
+
+      CREATE TABLE track_corner_covers (
+        facts_slug TEXT NOT NULL,
+        corner_sequence INTEGER NOT NULL,
+        turn_number INTEGER NOT NULL CHECK (turn_number > 0),
+        PRIMARY KEY (facts_slug, corner_sequence, turn_number),
+        UNIQUE (facts_slug, turn_number),
+        FOREIGN KEY (facts_slug, corner_sequence) REFERENCES track_corners(facts_slug, sequence) ON UPDATE CASCADE ON DELETE CASCADE
+      ) WITHOUT ROWID;
+
+      CREATE TABLE track_straights (
+        facts_slug TEXT NOT NULL REFERENCES track_facts(slug) ON UPDATE CASCADE ON DELETE CASCADE,
+        after_turn INTEGER NOT NULL CHECK (after_turn > 0),
+        name TEXT NOT NULL,
+        group_name TEXT,
+        PRIMARY KEY (facts_slug, after_turn)
+      ) WITHOUT ROWID;
+
+      CREATE TABLE game_geometry (
+        facts_slug TEXT NOT NULL REFERENCES track_facts(slug) ON UPDATE CASCADE ON DELETE CASCADE,
+        game_id TEXT NOT NULL,
+        sector_1_end REAL,
+        sector_2_end REAL,
+        sector_source TEXT,
+        PRIMARY KEY (facts_slug, game_id),
+        CHECK ((sector_1_end IS NULL AND sector_2_end IS NULL) OR (sector_1_end > 0 AND sector_1_end < sector_2_end AND sector_2_end < 1))
+      ) WITHOUT ROWID;
+
+      CREATE TABLE game_geometry_segments (
+        facts_slug TEXT NOT NULL,
+        game_id TEXT NOT NULL,
+        sequence INTEGER NOT NULL CHECK (sequence >= 0),
+        segment_key TEXT NOT NULL,
+        start_fraction REAL NOT NULL CHECK (start_fraction >= 0 AND start_fraction <= 1),
+        end_fraction REAL NOT NULL CHECK (end_fraction >= 0 AND end_fraction <= 1),
+        PRIMARY KEY (facts_slug, game_id, sequence),
+        FOREIGN KEY (facts_slug, game_id) REFERENCES game_geometry(facts_slug, game_id) ON UPDATE CASCADE ON DELETE CASCADE
+      ) WITHOUT ROWID;
+
+      CREATE TABLE curation_verification (
+        kind TEXT NOT NULL CHECK (kind IN ('meta', 'segments')),
+        facts_slug TEXT NOT NULL REFERENCES track_facts(slug) ON UPDATE CASCADE ON DELETE CASCADE,
+        game_id TEXT NOT NULL DEFAULT '',
+        data_hash TEXT NOT NULL,
+        verified_date TEXT NOT NULL,
+        verified_by TEXT,
+        note TEXT,
+        PRIMARY KEY (kind, facts_slug, game_id),
+        CHECK ((kind = 'meta' AND game_id = '') OR (kind = 'segments' AND game_id <> ''))
+      ) WITHOUT ROWID;
+
+      CREATE INDEX game_tracks_layout_idx ON game_tracks(layout_id);
+      CREATE INDEX layouts_facts_idx ON layouts(facts_slug);
+
+      CREATE TABLE registry_metadata (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        CHECK (key IN ('sourceVersion', 'sourceHash'))
+      ) WITHOUT ROWID;
+    `);
+
+    database.exec(`PRAGMA user_version = ${TRACK_REGISTRY_VERSION}`);
+
+    database.transaction(() => insertTrackRegistryProjection(database, canonical, sourceHash))();
+
+    const keyCheck = database.query("PRAGMA foreign_key_check").all() as Array<{ table: string; rowid: number; parent: string; fkid: string }>;
+    if (keyCheck.length > 0) {
+      throw new Error(`Track registry foreign key check failed: ${JSON.stringify(keyCheck)}`);
+    }
+
+    const [integrity] = database.query("PRAGMA integrity_check").all() as Array<{ integrity_check: string }>;
+    if (!integrity || integrity.integrity_check !== "ok") {
+      throw new Error(`Track registry integrity check failed: ${integrity?.integrity_check ?? "unknown"}`);
+    }
+
+  } finally {
+    database.close();
+  }
+  return readTrackRegistryProjection(targetDatabasePath);
+}
+
+export function buildTrackRegistryArtifacts(
+  source: TrackRegistrySource,
+  locations: TrackRegistryLocationsInput = {},
+): { sourceHash: string; projection: TrackRegistryProjectionSnapshot; report: string } {
+  const resolved = resolveTrackRegistryLocations(locations);
+  const canonical = validateTrackConfigurationSource(source);
+  const rendered = renderTrackRegistrySource(canonical);
+  const sourceHash = sha256OverSourceFiles(rendered);
+  const nonce = randomBytes(8).toString("hex");
+  const stagedDatabase = `${resolved.databasePath}.build.${nonce}.tmp`;
+  const stagedReport = `${resolved.reportPath}.build.${nonce}.tmp`;
+  const databaseBackup = `${resolved.databasePath}.build.${nonce}.backup`;
+  const reportBackup = `${resolved.reportPath}.build.${nonce}.backup`;
+
+  try {
+    const projection = compileTrackRegistryProjection(canonical, stagedDatabase);
+    Bun.gc(true);
+    const report = renderTrackRegistryReport(projection);
+    writeFile(stagedReport, report);
+    if (resolve(resolved.databasePath) === resolve(resolveTrackRegistryLocations().databasePath)) {
+      writeGeneratedTrackRegistry((database) => {
+        clearTrackRegistryProjection(database);
+        insertTrackRegistryProjection(database, canonical, sourceHash);
+      });
+      const committedProjection = readTrackRegistryProjection(resolved.databasePath);
+      writeAtomicFile(resolved.reportPath, renderTrackRegistryReport(committedProjection));
+      return {
+        sourceHash,
+        projection: committedProjection,
+        report: renderTrackRegistryReport(committedProjection),
+      };
+    }
+    if (existsSync(resolved.databasePath)) copyFileSync(resolved.databasePath, databaseBackup);
+    if (existsSync(resolved.reportPath)) copyFileSync(resolved.reportPath, reportBackup);
+    try {
+      removeIfExists(resolved.databasePath);
+      removeIfExists(resolved.reportPath);
+      renameSync(stagedDatabase, resolved.databasePath);
+      renameSync(stagedReport, resolved.reportPath);
+    } catch (error) {
+      if (existsSync(databaseBackup)) copyFileSync(databaseBackup, resolved.databasePath);
+      else removeIfExists(resolved.databasePath);
+      if (existsSync(reportBackup)) copyFileSync(reportBackup, resolved.reportPath);
+      else removeIfExists(resolved.reportPath);
+      throw error;
+    }
+    return { sourceHash, projection, report };
+  } finally {
+    removeIfExists(stagedDatabase);
+    removeIfExists(stagedReport);
+    removeIfExists(databaseBackup);
+    removeIfExists(reportBackup);
+  }
+}
+
+export function readTrackRegistryProjection(databasePath: string): TrackRegistryProjectionSnapshot {
+  if (!existsSync(databasePath)) {
+    throw new Error(`Missing track registry database ${databasePath}`);
+  }
+
+  const database = new Database(databasePath, { readonly: true, create: false, strict: true });
+  try {
+    const versionRow = database.query("PRAGMA user_version").get() as { user_version: number };
+    if (versionRow.user_version !== TRACK_REGISTRY_VERSION) {
+      throw new Error(`Unsupported track registry version ${versionRow.user_version}; expected ${TRACK_REGISTRY_VERSION}`);
+    }
+
+    const metadataRows = database.query("SELECT key, value FROM registry_metadata ORDER BY key").all() as Array<{ key: string; value: string }>;
+    if (
+      metadataRows.length !== 2 ||
+      metadataRows[0]?.key !== "sourceHash" ||
+      metadataRows[1]?.key !== "sourceVersion"
+    ) {
+      throw new Error("Invalid registry metadata");
+    }
+    const metadata = Object.fromEntries(metadataRows.map((row) => [row.key, row.value]));
+    const sourceVersion = Number(metadata.sourceVersion);
+    const sourceHash = metadata.sourceHash;
+    if (
+      sourceVersion !== TRACK_REGISTRY_SOURCE_VERSION ||
+      typeof sourceHash !== "string" ||
+      !/^[0-9a-f]{64}$/.test(sourceHash)
+    ) {
+      throw new Error("Invalid registry metadata");
+    }
+
+    const schema = database.query(`
+      SELECT type, name, tbl_name, sql
+        FROM sqlite_master
+       WHERE type IN ('table', 'index') AND name NOT LIKE 'sqlite_%'
+       ORDER BY type, name
+    `).all() as TrackRegistryProjectionSnapshot["schema"];
+
+    const venueNodes = database.query("SELECT path, parent_path, slug, name, depth FROM venue_nodes ORDER BY path").all() as Array<{
+      path: string;
+      parent_path: string | null;
+      slug: string;
+      name: string;
+      depth: number;
+    }>;
+
+    const layouts = database.query("SELECT canonical_id, venue_path, slug, name, facts_slug FROM layouts ORDER BY canonical_id").all() as Array<{
+      canonical_id: string;
+      venue_path: string;
+      slug: string;
+      name: string;
+      facts_slug: string | null;
+    }>;
+
+    const assignments = database.query("SELECT game_id AS gameId, track_ordinal, layout_id, confirmed_at, confirmed_by, commit_id FROM game_tracks").all() as Array<{
+      gameId: GameId;
+      track_ordinal: number;
+      layout_id: string;
+      confirmed_at: string | null;
+      confirmed_by: string | null;
+      commit_id: string | null;
+    }>;
+
+    const facts = database.query("SELECT slug, track_slug, layout_slug, layout_name, name, source FROM track_facts ORDER BY slug").all() as Array<{
+      slug: string;
+      track_slug: string;
+      layout_slug: string;
+      layout_name: string;
+      name: string;
+      source: string | null;
+    }>;
+
+    const corners = database.query("SELECT facts_slug, sequence, turn_number, name, direction, group_name FROM track_corners ORDER BY facts_slug, sequence").all() as Array<{
+      facts_slug: string;
+      sequence: number;
+      turn_number: number;
+      name: string;
+      direction: "left" | "right" | null;
+      group_name: string | null;
+    }>;
+
+    const covers = database.query("SELECT facts_slug, corner_sequence, turn_number FROM track_corner_covers ORDER BY facts_slug, corner_sequence, turn_number").all() as Array<{
+      facts_slug: string;
+      corner_sequence: number;
+      turn_number: number;
+    }>;
+
+    const straights = database.query("SELECT facts_slug, after_turn, name, group_name FROM track_straights ORDER BY facts_slug, after_turn").all() as Array<{
+      facts_slug: string;
+      after_turn: number;
+      name: string;
+      group_name: string | null;
+    }>;
+
+    const geometry = database.query("SELECT facts_slug, game_id, sector_1_end, sector_2_end, sector_source FROM game_geometry ORDER BY game_id, facts_slug").all() as Array<{
+      facts_slug: string;
+      game_id: GameId;
+      sector_1_end: number | null;
+      sector_2_end: number | null;
+      sector_source: string | null;
+    }>;
+
+    const segments = database.query("SELECT facts_slug, game_id, sequence, segment_key, start_fraction, end_fraction FROM game_geometry_segments ORDER BY facts_slug, game_id, sequence").all() as Array<{
+      facts_slug: string;
+      game_id: GameId;
+      sequence: number;
+      segment_key: string;
+      start_fraction: number;
+      end_fraction: number;
+    }>;
+
+    const verification = database.query("SELECT kind, facts_slug, game_id, data_hash, verified_date, verified_by, note FROM curation_verification ORDER BY kind, facts_slug, game_id").all() as Array<{
+      kind: "meta" | "segments";
+      facts_slug: string;
+      game_id: string;
+      data_hash: string;
+      verified_date: string;
+      verified_by: string | null;
+      note: string | null;
+    }>;
+
+    return {
+      userVersion: versionRow.user_version,
+      schema,
+      sourceVersion,
+      sourceHash,
+      venueNodes,
+      layouts,
+      assignments: assignments
+        .map((assignment) => ({
+          game_id: assignment.gameId,
+          track_ordinal: assignment.track_ordinal,
+          layout_id: assignment.layout_id,
+          confirmed_at: assignment.confirmed_at,
+          confirmed_by: assignment.confirmed_by,
+          commit_id: assignment.commit_id,
+        }))
+        .sort((a, b) => {
+          const byGame = GAME_ORDER[a.game_id] - GAME_ORDER[b.game_id];
+          return byGame || a.track_ordinal - b.track_ordinal;
+        }),
+      facts,
+      corners,
+      covers,
+      straights,
+      geometry: geometry.sort((a, b) => {
+        const byGame = GAME_ORDER[a.game_id] - GAME_ORDER[b.game_id];
+        return byGame || a.facts_slug.localeCompare(b.facts_slug);
+      }),
+      segments: segments.sort((a, b) => {
+        const byGame = GAME_ORDER[a.game_id] - GAME_ORDER[b.game_id];
+        return byGame || a.facts_slug.localeCompare(b.facts_slug) || a.sequence - b.sequence;
+      }),
+      verification,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+export function renderTrackRegistryReport(snapshot: TrackRegistryProjectionSnapshot): string {
+  const layoutById = new Map(snapshot.layouts.map((layout) => [layout.canonical_id, layout]));
+  const factsBySlug = new Map(snapshot.facts.map((fact) => [fact.slug, fact]));
+
+  const cornersByFacts = new Map<string, typeof snapshot.corners>();
+  for (const corner of snapshot.corners) {
+    const existing = cornersByFacts.get(corner.facts_slug) ?? [];
+    existing.push(corner);
+    cornersByFacts.set(corner.facts_slug, existing);
+  }
+
+  const coversByKey = new Map<string, number[]>();
+  for (const cover of snapshot.covers) {
+    const key = `${cover.facts_slug}\0${cover.corner_sequence}`;
+    const numbers = coversByKey.get(key) ?? [];
+    numbers.push(cover.turn_number);
+    coversByKey.set(key, numbers);
+  }
+
+  const straightsByFacts = new Map<string, typeof snapshot.straights>();
+  for (const straight of snapshot.straights) {
+    const existing = straightsByFacts.get(straight.facts_slug) ?? [];
+    existing.push(straight);
+    straightsByFacts.set(straight.facts_slug, existing);
+  }
+
+  const factWithCoverage = Array.from(factsBySlug.values())
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+    .map((fact) => {
+      const corners = (cornersByFacts.get(fact.slug) ?? []).map((corner) => ({
+        sequence: corner.sequence,
+        number: corner.turn_number,
+        ...(coversByKey.get(`${fact.slug}\0${corner.sequence}`) && (coversByKey.get(`${fact.slug}\0${corner.sequence}`)?.length ?? 0) > 0
+          ? { covers: coversByKey.get(`${fact.slug}\0${corner.sequence}`)?.sort((a, b) => a - b) }
+          : {}),
+        name: corner.name,
+        ...(corner.direction ? { direction: corner.direction } : {}),
+        ...(corner.group_name ? { group: corner.group_name } : {}),
+      }));
+
+      const straights = (straightsByFacts.get(fact.slug) ?? []).map((straight) => ({
+        after: straight.after_turn,
+        name: straight.name,
+        ...(straight.group_name ? { group: straight.group_name } : {}),
+      }));
+
+      return {
+        slug: fact.slug,
+        track: fact.track_slug,
+        layout: fact.layout_slug,
+        layoutName: fact.layout_name,
+        name: fact.name,
+        ...(fact.source ? { source: fact.source } : {}),
+        corners: corners,
+        ...(straights.length ? { straights } : {}),
+      };
+    });
+
+  const assignmentsByGameOrder = [...snapshot.assignments].sort((a, b) => {
+    const byGame = (GAME_ORDER[a.game_id] ?? Number.MAX_SAFE_INTEGER) - (GAME_ORDER[b.game_id] ?? Number.MAX_SAFE_INTEGER);
+    return byGame !== 0 ? byGame : a.track_ordinal - b.track_ordinal;
+  });
+
+  const trackIdentities = assignmentsByGameOrder.map((assignment) => {
+    const layout = layoutById.get(assignment.layout_id);
+    return {
+      gameId: assignment.game_id,
+      trackOrdinal: assignment.track_ordinal,
+      layoutId: assignment.layout_id,
+      factsSlug: layout?.facts_slug ?? null,
+    };
+  });
+
+  const geometrySectors = [...snapshot.geometry]
+    .sort((a, b) => {
+      const byGame = (GAME_ORDER[a.game_id] ?? Number.MAX_SAFE_INTEGER) - (GAME_ORDER[b.game_id] ?? Number.MAX_SAFE_INTEGER);
+      return byGame !== 0 ? byGame : a.facts_slug.localeCompare(b.facts_slug);
+    })
+    .map((row) => ({
+      gameId: row.game_id,
+      factsSlug: row.facts_slug,
+      s1End: row.sector_1_end,
+      s2End: row.sector_2_end,
+      source: row.sector_source,
+    }));
+
+  const assignmentsByLayout = new Map<string, Array<{ gameId: GameId; trackOrdinal: number }>>();
+  for (const identity of trackIdentities) {
+    const existing = assignmentsByLayout.get(identity.layoutId) ?? [];
+    existing.push({ gameId: identity.gameId, trackOrdinal: identity.trackOrdinal });
+    assignmentsByLayout.set(identity.layoutId, existing);
+  }
+
+  const aliases = Array.from(assignmentsByLayout.entries())
+    .filter(([, assignments]) => assignments.length > 1)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([layoutId, assignments]) => {
+      const layout = layoutById.get(layoutId);
+      const ordered = assignments
+        .map((assignment) => ({
+          gameId: assignment.gameId,
+          trackOrdinal: assignment.trackOrdinal,
+        }))
+        .sort((a, b) => (GAME_ORDER[a.gameId] ?? Number.MAX_SAFE_INTEGER) - (GAME_ORDER[b.gameId] ?? Number.MAX_SAFE_INTEGER));
+      return {
+        layoutId,
+        factsSlug: layout?.facts_slug ?? null,
+        assignments: ordered,
+      };
+    });
+
+  const layoutFactsRefs = new Set(layoutsHasFacts(snapshot.layouts));
+  const layoutWithoutFacts = [...layoutFactsRefs]
+    .filter((value) => value[1] === null)
+    .map(([id]) => id)
+    .sort();
+
+  const factsWithoutLayouts = [...factsBySlug.keys()]
+    .filter((slug) => !snapshot.layouts.some((layout) => layout.facts_slug === slug))
+    .sort();
+
+  const assignmentOrphans: Array<{ gameId: string; trackOrdinal: number; layoutId: string }> = [];
+  for (const assignment of assignmentsByGameOrder) {
+    if (!layoutById.has(assignment.layout_id)) {
+      assignmentOrphans.push({
+        gameId: assignment.game_id,
+        trackOrdinal: assignment.track_ordinal,
+        layoutId: assignment.layout_id,
+      });
+    }
+  }
+
+  const geometrySet = new Set(snapshot.geometry.map((row) => `${row.facts_slug}\0${row.game_id}`));
+  const geometryOrphans: Array<{ gameId: string; factsSlug: string }> = [];
+  for (const row of snapshot.geometry) {
+    if (!factsBySlug.has(row.facts_slug)) {
+      geometryOrphans.push({ gameId: row.game_id, factsSlug: row.facts_slug });
+    }
+  }
+
+  const verificationOrphans: Array<{ kind: string; gameId: string; factsSlug: string }> = [];
+  for (const row of snapshot.verification) {
+    if (row.kind === "meta") {
+      if (!factsBySlug.has(row.facts_slug)) {
+        verificationOrphans.push({ kind: "meta", gameId: row.game_id, factsSlug: row.facts_slug });
+      }
+      continue;
+    }
+    const hasTarget = geometrySet.has(`${row.facts_slug}\0${row.game_id}`);
+    if (!hasTarget) {
+      verificationOrphans.push({ kind: "segments", gameId: row.game_id, factsSlug: row.facts_slug });
+    }
+  }
+
+  const report = {
+    sourceVersion: snapshot.sourceVersion,
+    sourceHash: snapshot.sourceHash,
+    recordCounts: {
+      venues: snapshot.venueNodes.length,
+      layouts: snapshot.layouts.length,
+      assignments: snapshot.assignments.length,
+      facts: snapshot.facts.length,
+      corners: snapshot.corners.length,
+      covers: snapshot.covers.length,
+      straights: snapshot.straights.length,
+      geometry: snapshot.geometry.length,
+      geometrySegments: snapshot.segments.length,
+      verification: snapshot.verification.length,
+    },
+    trackIdentities,
+    geometrySectors,
+    facts: factWithCoverage,
+    aliases,
+    orphanedReferences: {
+      assignments: assignmentOrphans,
+      geometry: geometryOrphans,
+      verification: verificationOrphans,
+    },
+    unlinked: {
+      layoutsWithoutFacts: layoutWithoutFacts,
+      factsWithoutLayouts,
+    },
+  };
+
+  return `${JSON.stringify(report, null, 2)}\n`;
+}
+
+function layoutsHasFacts(layouts: TrackRegistryProjectionSnapshot["layouts"]): Map<string, string | null> {
+  return new Map(layouts.map((layout) => [layout.canonical_id, layout.facts_slug]));
+}
+
+function stageTrackRegistrySourceUpdate(
+  currentSource: TrackRegistrySource,
+  nextSource: TrackRegistrySource,
+  resolved: TrackRegistryLocations,
+  oldSourceHash: string,
+  newSourceHash: string,
+): TrackRegistryUpdateJournal {
+  const sessionId = randomBytes(8).toString("hex");
+  const renderedCurrent = renderTrackRegistrySource(currentSource);
+  const renderedNext = renderTrackRegistrySource(nextSource);
+  const sourceBackups: Record<string, string> = {};
+  const sourceStaged: Record<string, string> = {};
+  const databaseBackup = `${resolved.databasePath}.backup.${sessionId}`;
+  const databaseStaged = `${resolved.databasePath}.stage.${sessionId}`;
+  const reportBackup = `${resolved.reportPath}.backup.${sessionId}`;
+  const reportStaged = `${resolved.reportPath}.stage.${sessionId}`;
+
+  try {
+    const filenames = new Set([...renderedCurrent.keys(), ...renderedNext.keys()]);
+    for (const filename of filenames) {
+      const sourcePath = sourceFilePath(resolved, filename);
+      if (renderedCurrent.has(filename)) {
+        const backupPath = `${sourcePath}.backup.${sessionId}`;
+        writeFile(backupPath, renderedCurrent.get(filename)!);
+        sourceBackups[filename] = backupPath;
+      }
+      if (renderedNext.has(filename)) {
+        const stagedPath = `${sourcePath}.stage.${sessionId}`;
+        writeFile(stagedPath, renderedNext.get(filename)!);
+        sourceStaged[filename] = stagedPath;
+      }
+    }
+    if (existsSync(resolved.databasePath)) copyFileSync(resolved.databasePath, databaseBackup);
+    if (existsSync(resolved.reportPath)) copyFileSync(resolved.reportPath, reportBackup);
+    const projection = compileTrackRegistryProjection(nextSource, databaseStaged);
+    Bun.gc(true);
+    writeFile(reportStaged, renderTrackRegistryReport(projection));
+    return {
+      version: 1,
+      oldSourceHash,
+      newSourceHash,
+      sourceBackups,
+      sourceStaged,
+      databaseBackup,
+      databaseStaged,
+      reportBackup,
+      reportStaged,
+    };
+  } catch (error) {
+    for (const path of [...Object.values(sourceBackups), ...Object.values(sourceStaged)]) removeIfExists(path);
+    removeIfExists(databaseBackup);
+    removeIfExists(databaseStaged);
+    removeIfExists(reportBackup);
+    removeIfExists(reportStaged);
+    throw error;
+  }
+}
+
+function writeAtomicFile(path: string, content: string): void {
+  const nonce = randomBytes(8).toString("hex");
+  const temporary = `${path}.${nonce}.tmp`;
+  const backup = `${path}.${nonce}.backup`;
+  let backedUp = false;
+  writeFile(temporary, content);
+  try {
+    if (existsSync(path)) {
+      renameSync(path, backup);
+      backedUp = true;
+    }
+    renameSync(temporary, path);
+    removeIfExists(backup);
+  } catch (error) {
+    if (backedUp && existsSync(backup)) {
+      removeIfExists(path);
+      renameSync(backup, path);
+    }
+    throw error;
+  } finally {
+    removeIfExists(temporary);
+  }
+}
+
+function cleanTrackRegistryUpdateFiles(
+  journal: TrackRegistryUpdateJournal,
+  resolved: TrackRegistryLocations,
+): void {
+  for (const path of [...Object.values(journal.sourceStaged), ...Object.values(journal.sourceBackups)]) {
+    removeIfExists(path);
+  }
+  removeIfExists(journal.databaseStaged);
+  removeIfExists(journal.databaseBackup);
+  removeIfExists(journal.reportStaged);
+  removeIfExists(journal.reportBackup);
+  removeIfExists(resolved.transactionPath);
+  const root = shardRoot(resolved);
+  for (const filename of new Set([
+    ...Object.keys(journal.sourceStaged),
+    ...Object.keys(journal.sourceBackups),
+  ])) {
+    pruneEmptySourceDirectories(sourceFilePath(resolved, filename), root);
+  }
+}
+
+function actualSourceHash(locations: TrackRegistryLocations): string | null {
+  try {
+    return sha256OverSourceFiles(readTrackRegistrySourceFiles(locations));
+  } catch {
+    return null;
+  }
+}
+
+
+function rebuildRegistryArtifacts(source: TrackRegistrySource, locations: TrackRegistryLocations): void {
+  const canonical = validateTrackConfigurationSource(source);
+  const sourceHash = sha256OverSourceFiles(renderTrackRegistrySource(canonical));
+  if (resolve(locations.databasePath) === resolve(resolveTrackRegistryLocations().databasePath)) {
+    writeGeneratedTrackRegistry((database) => {
+      clearTrackRegistryProjection(database);
+      insertTrackRegistryProjection(database, canonical, sourceHash);
+    });
+    const projection = readTrackRegistryProjection(locations.databasePath);
+    writeAtomicFile(locations.reportPath, renderTrackRegistryReport(projection));
+    return;
+  }
+
+  const nonce = randomBytes(8).toString("hex");
+  const databaseStaged = `${locations.databasePath}.recovery.${nonce}.tmp`;
+  const reportStaged = `${locations.reportPath}.recovery.${nonce}.tmp`;
+  try {
+    const projection = compileTrackRegistryProjection(canonical, databaseStaged);
+    writeFile(reportStaged, renderTrackRegistryReport(projection));
+    Bun.gc(true);
+    renameSync(databaseStaged, locations.databasePath);
+    renameSync(reportStaged, locations.reportPath);
+  } finally {
+    removeIfExists(databaseStaged);
+    removeIfExists(reportStaged);
+  }
+}
+
+function restoreOldRegistryUpdate(
+  journal: TrackRegistryUpdateJournal,
+  resolved: TrackRegistryLocations,
+): void {
+  for (const filename of Object.keys(journal.sourceStaged)) {
+    if (!journal.sourceBackups[filename]) removeIfExists(sourceFilePath(resolved, filename));
+  }
+  for (const [filename, backup] of Object.entries(journal.sourceBackups)) {
+    if (!existsSync(backup)) {
+      throw new Error(`Missing track registry source backup ${backup}`);
+    }
+    copyFileSync(backup, sourceFilePath(resolved, filename));
+  }
+  const restored = loadTrackRegistrySource(resolved);
+  const restoredHash = sha256OverSourceFiles(renderTrackRegistrySource(restored));
+  if (restoredHash !== journal.oldSourceHash) {
+    throw new Error("Track registry recovery old-source hash mismatch");
+  }
+  rebuildRegistryArtifacts(restored, resolved);
+  cleanTrackRegistryUpdateFiles(journal, resolved);
+}
+
+export function recoverTrackRegistrySourceUpdate(locations: TrackRegistryLocationsInput = {}): void {
+  const resolved = resolveTrackRegistryLocations(locations);
+  if (!existsSync(resolved.transactionPath)) return;
+  let journal: TrackRegistryUpdateJournal;
+  try {
+    journal = JSON.parse(readFile(resolved.transactionPath)) as TrackRegistryUpdateJournal;
+  } catch {
+    throw new Error(`Malformed track registry transaction file ${resolved.transactionPath}`);
+  }
+  if (journal.version !== 1) {
+    throw new Error(`Unsupported track registry update transaction schema version ${journal.version}`);
+  }
+
+  if (actualSourceHash(resolved) === journal.newSourceHash) {
+    const source = loadTrackRegistrySource(resolved);
+    const canonicalHash = sha256OverSourceFiles(renderTrackRegistrySource(source));
+    if (canonicalHash !== journal.newSourceHash) {
+      throw new Error("Track registry recovery new-source hash mismatch");
+    }
+    rebuildRegistryArtifacts(source, resolved);
+    cleanTrackRegistryUpdateFiles(journal, resolved);
+    return;
+  }
+  restoreOldRegistryUpdate(journal, resolved);
+}
+
+export function updateTrackRegistrySource(
+  mutator: (draft: TrackRegistrySource) => TrackRegistrySource | void,
+  locations: TrackRegistryLocationsInput = {},
+): void {
+  const resolved = resolveTrackRegistryLocations(locations);
+  recoverTrackRegistrySourceUpdate(resolved);
+  const current = loadTrackRegistrySource(resolved);
+  const currentRendered = renderTrackRegistrySource(current);
+  const currentHash = sha256OverSourceFiles(currentRendered);
+  const draft = structuredClone(current) as TrackRegistrySource;
+  const mutated = mutator(draft) ?? draft;
+  const next = validateTrackConfigurationSource(mutated);
+  const nextRendered = renderTrackRegistrySource(next);
+  const nextHash = sha256OverSourceFiles(nextRendered);
+  const currentFiles = readTrackRegistrySourceFiles(resolved);
+  const needsCanonicalRewrite = currentFiles.size !== currentRendered.size ||
+    [...currentRendered].some(([filename, contents]) => currentFiles.get(filename) !== contents);
+  if (currentHash === nextHash && !needsCanonicalRewrite) return;
+  assertRemovedMetadataHasNoAssets(currentRendered, nextRendered, resolved);
+
+  const journal = stageTrackRegistrySourceUpdate(current, next, resolved, currentHash, nextHash);
+  writeAtomicFile(resolved.transactionPath, `${JSON.stringify(journal, null, 2)}\n`);
+  try {
+    for (const [filename, staged] of Object.entries(journal.sourceStaged)) {
+      renameSync(staged, sourceFilePath(resolved, filename));
+    }
+    for (const filename of Object.keys(journal.sourceBackups)) {
+      if (!journal.sourceStaged[filename]) removeIfExists(sourceFilePath(resolved, filename));
+    }
+    if (resolve(resolved.databasePath) === resolve(resolveTrackRegistryLocations().databasePath)) {
+      writeGeneratedTrackRegistry((database) => {
+        clearTrackRegistryProjection(database);
+        insertTrackRegistryProjection(database, next, nextHash);
+      });
+      removeIfExists(journal.databaseStaged);
+    } else {
+      renameSync(journal.databaseStaged, resolved.databasePath);
+    }
+    renameSync(journal.reportStaged, resolved.reportPath);
+    const projection = readTrackRegistryProjection(resolved.databasePath);
+    if (projection.sourceHash !== nextHash) {
+      throw new Error("Stale track registry projection after update");
+    }
+    if (readFile(resolved.reportPath) !== renderTrackRegistryReport(projection)) {
+      throw new Error("Stale track registry report after update");
+    }
+  } catch (error) {
+    restoreOldRegistryUpdate(journal, resolved);
+    throw error;
+  }
+  cleanTrackRegistryUpdateFiles(journal, resolved);
+}
+
+export function assertTrackRegistryArtifactsCurrent(locations: TrackRegistryLocationsInput = {}): void {
+  const resolved = resolveTrackRegistryLocations(locations);
+  if (existsSync(resolved.transactionPath)) {
+    throw new Error(`Pending track registry source update ${resolved.transactionPath}; run bun run tracks:registry`);
+  }
+  const source = loadTrackRegistrySource(resolved);
+  const rendered = renderTrackRegistrySource(source);
+  const actual = readTrackRegistrySourceFiles(resolved);
+  if (actual.size !== rendered.size) {
+    throw new Error("Non-canonical track registry source file set; run bun run tracks:registry");
+  }
+  for (const [filename, contents] of rendered) {
+    if (actual.get(filename) !== contents) {
+      throw new Error(`Non-canonical track registry source ${sourceFilePath(resolved, filename)}; run bun run tracks:registry`);
+    }
+  }
+
+  const disposableDatabase = `${resolved.databasePath}.check.${randomBytes(8).toString("hex")}.tmp`;
+  try {
+    const expectedProjection = compileTrackRegistryProjection(source, disposableDatabase);
+    const actualProjection = readTrackRegistryProjection(resolved.databasePath);
+    Bun.gc(true);
+    if (JSON.stringify(actualProjection) !== JSON.stringify(expectedProjection)) {
+      throw new Error("Stale generated track registry; run bun run tracks:registry");
+    }
+    if (readFile(resolved.reportPath) !== renderTrackRegistryReport(expectedProjection)) {
+      throw new Error("Stale track registry report; run bun run tracks:registry");
+    }
+  } finally {
+    removeIfExists(disposableDatabase);
+  }
+}

--- a/shared/racing/tracks/registry.ts
+++ b/shared/racing/tracks/registry.ts
@@ -1,0 +1,88 @@
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { IS_COMPILED } from "@shared/platform/runtime/data-paths";
+import { readTrackRegistrySourceFiles, resolveTrackRegistryLocations } from "./registry-source";
+
+export const TRACK_REGISTRY_VERSION = 2 as const;
+export const TRACK_REGISTRY_PATH = resolveTrackRegistryLocations().databasePath;
+
+let registry: Database | null = null;
+let registryRevision = 0;
+
+function actualSourceHash(sourceDirectory: string): string {
+  const hash = createHash("sha256");
+  for (const [filename, body] of readTrackRegistrySourceFiles({ sourceDirectory })) {
+    hash.update(filename);
+    hash.update("\0");
+    hash.update(body);
+  }
+  return hash.digest("hex");
+}
+
+function openTrackRegistry(validateArtifacts: boolean): Database {
+  if (registry) return registry;
+
+  const locations = resolveTrackRegistryLocations();
+  if (!IS_COMPILED && validateArtifacts && existsSync(locations.transactionPath)) {
+    throw new Error(`Pending track registry source update ${locations.transactionPath}; run bun run tracks:registry`);
+  }
+  if (!existsSync(TRACK_REGISTRY_PATH)) throw new Error(`Missing bundled track registry ${TRACK_REGISTRY_PATH}`);
+
+  const database = new Database(TRACK_REGISTRY_PATH, {
+    readonly: IS_COMPILED,
+    create: false,
+    strict: true,
+  });
+  database.exec("PRAGMA foreign_keys = ON");
+
+  const version = database.query("PRAGMA user_version").get() as { user_version: number };
+  if (version.user_version !== TRACK_REGISTRY_VERSION) {
+    database.close();
+    throw new Error(`Unsupported track registry version ${version.user_version}; expected ${TRACK_REGISTRY_VERSION}`);
+  }
+
+  let metadata: Array<{ key: string; value: string }>;
+  try {
+    metadata = database.query("SELECT key, value FROM registry_metadata ORDER BY key").all() as Array<{ key: string; value: string }>;
+  } catch {
+    database.close();
+    throw new Error("Track registry metadata missing; run bun run tracks:registry");
+  }
+  const metadataByKey = Object.fromEntries(metadata.map(({ key, value }) => [key, value]));
+  if (metadata.length !== 2 || metadataByKey.sourceVersion !== "1" || !/^[0-9a-f]{64}$/.test(metadataByKey.sourceHash ?? "")) {
+    database.close();
+    throw new Error("Track registry metadata invalid; run bun run tracks:registry");
+  }
+
+  if (!IS_COMPILED && validateArtifacts) {
+    const sourceHash = actualSourceHash(locations.sourceDirectory);
+    if (sourceHash !== metadataByKey.sourceHash) {
+      database.close();
+      throw new Error("Stale generated track registry; run bun run tracks:registry");
+    }
+  }
+
+  registry = database;
+  return database;
+}
+
+export function getTrackRegistry(): Database {
+  return openTrackRegistry(true);
+}
+
+export function writeGeneratedTrackRegistry(operation: (database: Database) => void): void {
+  if (IS_COMPILED) throw new Error("Bundled track registry is read-only");
+  const database = openTrackRegistry(false);
+  database.transaction(operation)(database);
+  registryRevision += 1;
+}
+
+export function getTrackRegistryRevision(): number {
+  return registryRevision;
+}
+
+export function closeTrackRegistry(): void {
+  registry?.close();
+  registry = null;
+}

--- a/shared/racing/tracks/storage/assets.ts
+++ b/shared/racing/tracks/storage/assets.ts
@@ -1,0 +1,170 @@
+import { getAccSharedTrackName } from "../catalogs/acc";
+import { resolve } from "node:path";
+import { GameIdSchema, type GameId } from "@shared/games/ids";
+import { SHARED_DIR } from "@shared/platform/runtime/data-paths";
+import { getTrackRegistry, getTrackRegistryRevision } from "../registry";
+import { canonicalTrackAssetPathComponents, parseVenueRevisionPath } from "../configuration";
+
+export type GeometryAssetKind = "centerline" | "raceline" | "boundaries";
+export type SharedGeometrySource = "acc" | "tumftm";
+
+export interface TrackAssetIdentity {
+  gameId: GameId;
+  ordinal: number;
+  venuePath: string;
+  layoutSlug: string;
+  factsSlug: string | null;
+}
+
+interface IdentityRow {
+  venuePath: string;
+  layoutSlug: string;
+  factsSlug: string | null;
+}
+
+const identityCache = new Map<string, TrackAssetIdentity | null>();
+let identityCacheRevision = -1;
+
+function clearStaleIdentityCache(): void {
+  const revision = getTrackRegistryRevision();
+  if (identityCacheRevision === revision) return;
+  identityCache.clear();
+  identityCacheRevision = revision;
+}
+
+/** Registry-backed canonical venue/layout identity for a game track ordinal. */
+export function getTrackAssetIdentity(gameId: string, ordinal: number): TrackAssetIdentity | null {
+  const parsedGameId = GameIdSchema.safeParse(gameId);
+  if (!parsedGameId.success || !Number.isInteger(ordinal) || ordinal < 0) return null;
+
+  clearStaleIdentityCache();
+  const key = `${parsedGameId.data}:${ordinal}`;
+  const cached = identityCache.get(key);
+  if (cached !== undefined) return cached;
+
+  const row = getTrackRegistry().query(`
+    SELECT l.venue_path AS venuePath, l.slug AS layoutSlug, l.facts_slug AS factsSlug
+      FROM game_tracks gt
+      JOIN layouts l ON l.canonical_id = gt.layout_id
+     WHERE gt.game_id = ? AND gt.track_ordinal = ?
+  `).get(parsedGameId.data, ordinal) as IdentityRow | null;
+  const identity = row && {
+    gameId: parsedGameId.data,
+    ordinal,
+    venuePath: row.venuePath,
+    layoutSlug: row.layoutSlug,
+    factsSlug: row.factsSlug,
+  };
+  identityCache.set(key, identity);
+  return identity;
+}
+
+/** Canonical venue/layout identity for one facts slug, or null when ambiguous. */
+export function getTrackAssetIdentityForFactsSlug(factsSlug: string): TrackAssetIdentity | null {
+  const rows = getTrackRegistry().query(`
+    SELECT gt.game_id AS gameId, MIN(gt.track_ordinal) AS ordinal,
+           l.venue_path AS venuePath, l.slug AS layoutSlug, l.facts_slug AS factsSlug
+      FROM layouts l
+      JOIN game_tracks gt ON gt.layout_id = l.canonical_id
+     WHERE l.facts_slug = ?
+     GROUP BY l.canonical_id
+     ORDER BY l.canonical_id
+  `).all(factsSlug) as TrackAssetIdentity[];
+  return rows.length === 1 ? rows[0] : null;
+}
+/** Every game assignment for one facts slug, optionally scoped to one game. */
+export function findTrackAssetIdentities(factsSlug: string, gameFilter?: string): TrackAssetIdentity[] {
+  const parsedGameId = gameFilter === undefined ? null : GameIdSchema.safeParse(gameFilter);
+  if (parsedGameId && !parsedGameId.success) return [];
+  return getTrackRegistry().query(`
+    SELECT gt.game_id AS gameId, gt.track_ordinal AS ordinal,
+           l.venue_path AS venuePath, l.slug AS layoutSlug, l.facts_slug AS factsSlug
+      FROM game_tracks gt
+      JOIN layouts l ON l.canonical_id = gt.layout_id
+     WHERE l.facts_slug = ?
+       AND (? IS NULL OR gt.game_id = ?)
+     ORDER BY gt.game_id, gt.track_ordinal
+  `).all(factsSlug, parsedGameId?.data ?? null, parsedGameId?.data ?? null) as TrackAssetIdentity[];
+}
+/** Every canonical game-track identity, optionally scoped to one game. */
+export function listTrackAssetIdentities(gameFilter?: string): TrackAssetIdentity[] {
+  const parsedGameId = gameFilter === undefined ? null : GameIdSchema.safeParse(gameFilter);
+  if (parsedGameId && !parsedGameId.success) return [];
+  return getTrackRegistry().query(`
+    SELECT gt.game_id AS gameId, gt.track_ordinal AS ordinal,
+           l.venue_path AS venuePath, l.slug AS layoutSlug, l.facts_slug AS factsSlug
+      FROM game_tracks gt
+      JOIN layouts l ON l.canonical_id = gt.layout_id
+     WHERE (? IS NULL OR gt.game_id = ?)
+     ORDER BY gt.game_id, gt.track_ordinal
+  `).all(parsedGameId?.data ?? null, parsedGameId?.data ?? null) as TrackAssetIdentity[];
+}
+
+
+
+const AC_EVO_ACC_FALLBACK_SLUGS: ReadonlySet<string> = new Set([
+  "budapest",
+  "catalunya",
+  "misano",
+  "silverstone",
+  "zandvoort",
+]);
+
+/** AC Evo layouts whose installed game data has no ideal line and explicitly reuses ACC. */
+export function usesAccGeometryFallback(identity: TrackAssetIdentity, factsSlug: string | null): boolean {
+  return identity.gameId === "ac-evo" && factsSlug !== null && AC_EVO_ACC_FALLBACK_SLUGS.has(factsSlug);
+}
+
+/**
+ * ACC ordinals 0–10 are original 2019 source layouts; 11–21 are their
+ * 2023 aliases in identical order. All 22 resolve to 11 root shared assets.
+ */
+const ACC_SHARED_SOURCE_ORDINAL: Readonly<Record<number, number>> = {
+  0: 0, 1: 1, 2: 2, 3: 3, 4: 4, 5: 5, 6: 6, 7: 7, 8: 8, 9: 9, 10: 10,
+  11: 0, 12: 1, 13: 2, 14: 3, 15: 4, 16: 5, 17: 6, 18: 7, 19: 8, 20: 9, 21: 10,
+};
+
+/** Whether ACC assignment uses one of the 11 shared 2019 source assets. */
+export function isSharedAccGeometryAsset(identity: TrackAssetIdentity): boolean {
+  return identity.gameId === "acc" && ACC_SHARED_SOURCE_ORDINAL[identity.ordinal] !== undefined;
+}
+
+/** Canonical shared ACC source slug for one of the 22 paired assignments. */
+export function sharedAccGeometrySlug(identity: TrackAssetIdentity): string | null {
+  if (identity.gameId !== "acc") return null;
+  const sourceOrdinal = ACC_SHARED_SOURCE_ORDINAL[identity.ordinal];
+  return sourceOrdinal === undefined ? null : getAccSharedTrackName(sourceOrdinal) ?? null;
+}
+
+/** Canonical bundled geometry path for one game-specific track layout. */
+export function bundledGeometryPath(identity: TrackAssetIdentity, kind: GeometryAssetKind): string {
+  return resolve(
+    SHARED_DIR,
+    "tracks",
+    ...canonicalTrackAssetPathComponents(identity.venuePath, identity.layoutSlug),
+    "geometry",
+    identity.gameId,
+    `${kind}.${kind === "boundaries" ? "json" : "csv"}`,
+  );
+}
+
+/** Canonical root-venue path for shared ACC or TUMFTM geometry. */
+export function bundledSharedGeometryPath(
+  identity: TrackAssetIdentity,
+  source: SharedGeometrySource,
+  slug: string,
+  kind: GeometryAssetKind,
+): string | null {
+  if (source === "tumftm" && kind === "raceline") return null;
+  const { rootVenuePath } = parseVenueRevisionPath(identity.venuePath);
+  if (!rootVenuePath || !slug) return null;
+  return resolve(
+    SHARED_DIR,
+    "tracks",
+    "venues",
+    rootVenuePath,
+    "geometry",
+    source,
+    `${slug}-${kind}.${kind === "boundaries" ? "json" : "csv"}`,
+  );
+}

--- a/test/track-imagery-artifact.test.ts
+++ b/test/track-imagery-artifact.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { createReadStream, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { resolveTrackImageryPackPath } from "../server/tracks/imagery-artifact";
+import { TrackImageryVenueManifestSchema, type TrackImageryArtifact } from "../shared/racing/tracks/imagery";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true });
+});
+
+function fixture(payload: Uint8Array): { directory: string; artifact: TrackImageryArtifact } {
+  const directory = mkdtempSync(join(tmpdir(), "raceiq-imagery-artifact-"));
+  temporaryDirectories.push(directory);
+  return {
+    directory,
+    artifact: {
+      url: "https://assets.example.test/imagery.rqi",
+      version: "track-imagery-v1",
+      sha256: createHash("sha256").update(payload).digest("hex"),
+      sizeBytes: payload.byteLength,
+      attribution: "Test imagery",
+    },
+  };
+}
+
+test("uses a matching local pack without network access", async () => {
+  const payload = Uint8Array.from([1, 2, 3, 4]);
+  const { directory, artifact } = fixture(payload);
+  const localPath = join(directory, "imagery.rqi");
+  writeFileSync(localPath, payload);
+
+  const resolved = await resolveTrackImageryPackPath(localPath, artifact, {
+    cacheDirectory: join(directory, "cache"),
+    fetcher: async () => {
+      throw new Error("unexpected fetch");
+    },
+  });
+
+  expect(resolved).toBe(localPath);
+});
+
+test("replaces a missing or invalid local pack with one verified cached download", async () => {
+  const payload = Uint8Array.from([5, 6, 7, 8, 9]);
+  const { directory, artifact } = fixture(payload);
+  const localPath = join(directory, "imagery.rqi");
+  const cacheDirectory = join(directory, "cache");
+  writeFileSync(localPath, Uint8Array.from([0, 0, 0, 0, 0]));
+  let fetches = 0;
+  const fetcher = async () => {
+    fetches += 1;
+    return new Response(payload);
+  };
+
+  const first = await resolveTrackImageryPackPath(localPath, artifact, { cacheDirectory, fetcher });
+  const second = await resolveTrackImageryPackPath(join(directory, "missing.rqi"), artifact, { cacheDirectory, fetcher });
+
+  expect(first).toBe(second);
+  expect(readFileSync(first)).toEqual(Buffer.from(payload));
+  expect(fetches).toBe(1);
+});
+
+test("rejects a corrupt download without retaining a cache file", async () => {
+  const payload = Uint8Array.from([10, 11, 12, 13]);
+  const { directory, artifact } = fixture(payload);
+  const cacheDirectory = join(directory, "cache");
+  const fetcher = async () => new Response(Uint8Array.from([13, 12, 11, 10]));
+
+  await expect(resolveTrackImageryPackPath(join(directory, "missing.rqi"), artifact, { cacheDirectory, fetcher })).rejects.toThrow("SHA-256 mismatch");
+  expect(readdirSync(cacheDirectory)).toEqual([]);
+});
+
+const CURATED_ARTIFACT_MANIFESTS = [
+  "circuit-de-spa-francorchamps/revisions/2010/imagery/manifest.json",
+  "circuit-de-spa-francorchamps/revisions/current/imagery/manifest.json",
+  "daytona-international-speedway/revisions/current/imagery/manifest.json",
+  "new-hampshire-motor-speedway/revisions/current/imagery/manifest.json",
+] as const;
+
+test("pins each curated LFS pack to matching artifact metadata", async () => {
+  const venueRoot = resolve(process.cwd(), "shared", "data", "tracks", "venues");
+  for (const relativeManifestPath of CURATED_ARTIFACT_MANIFESTS) {
+    const manifestPath = resolve(venueRoot, relativeManifestPath);
+    const manifest = TrackImageryVenueManifestSchema.parse(JSON.parse(readFileSync(manifestPath, "utf8")));
+    const artifact = manifest.base.artifact;
+    if (!artifact) throw new Error(`Missing imagery artifact metadata in ${manifestPath}`);
+    expect(artifact.attribution).toBe(manifest.base.source.attribution);
+    const expectedUrlSuffix = relativeManifestPath.replace(/manifest\.json$/, manifest.base.pack).replaceAll("\\", "/");
+    expect(artifact.url.endsWith(expectedUrlSuffix)).toBe(true);
+
+    const packPath = resolve(manifestPath, "..", manifest.base.pack);
+    const stat = statSync(packPath);
+    if (stat.size < 1024) {
+      const pointer = readFileSync(packPath, "utf8");
+      expect(pointer).toContain(`oid sha256:${artifact.sha256}`);
+      expect(pointer).toContain(`size ${artifact.sizeBytes}`);
+      continue;
+    }
+
+    expect(stat.size).toBe(artifact.sizeBytes);
+    const hash = createHash("sha256");
+    for await (const chunk of createReadStream(packPath)) hash.update(chunk);
+    expect(hash.digest("hex")).toBe(artifact.sha256);
+  }
+});

--- a/test/track-imagery.test.ts
+++ b/test/track-imagery.test.ts
@@ -131,6 +131,13 @@ test("keeps package base opaque while layers retain independent alpha", () => {
     calibration: { originLatitudeDeg: 29, originLongitudeDeg: -81, imageToEnu: [1, 0, 0, -1, 0, 0] },
     base: {
       pack: TRACK_IMAGERY_PACKAGE_NAME,
+      artifact: {
+        url: "https://assets.example.test/imagery.rqi",
+        version: "track-imagery-v1",
+        sha256: "a".repeat(64),
+        sizeBytes: 4,
+        attribution: "Owned base",
+      },
       tileSize: 512,
       bounds: { west: -81.01, south: 28.99, east: -80.99, north: 29.01 },
       source: {
@@ -147,6 +154,13 @@ test("keeps package base opaque while layers retain independent alpha", () => {
   expect(manifest.version).toBe(2);
   expect(manifest.base).toMatchObject({
     pack: "imagery.rqi",
+    artifact: {
+      url: "https://assets.example.test/imagery.rqi",
+      version: "track-imagery-v1",
+      sha256: "a".repeat(64),
+      sizeBytes: 4,
+      attribution: "Owned base",
+    },
     tileSize: 512,
     bounds: { west: -81.01, south: 28.99, east: -80.99, north: 29.01 },
     source: { provider: "manual", sourceResolutionM: 0.1, storedResolutionM: 0.1 },

--- a/test/track-imagery.test.ts
+++ b/test/track-imagery.test.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "bun:test";
+import { TrackConfigurationSchema, trackConfigurationCanonicalId, trackConfigurationVenueId } from "../shared/racing/tracks/configuration";
+import {
+  TRACK_IMAGERY_MANIFEST_VERSION,
+  TRACK_IMAGERY_PACKAGE_NAME,
+  TrackImageryVenueManifestSchema,
+  composeTrackImageryMatrices,
+  defaultVenueImageryCalibration,
+  geographicTrackImageryPoint,
+  resolveTrackImageryMatrix,
+  trackImageryCalibrationFromBounds,
+  trackImageryGeographicBounds,
+  transformTrackImageryPoint,
+  type TrackImageryGeographicPoint,
+  type TrackImageryMatrix,
+} from "../shared/racing/tracks/imagery";
+
+const EARTH_RADIUS_M = 6_378_137;
+
+function geographicFromEnu(east: number, north: number, originLatitudeDeg: number, originLongitudeDeg: number): TrackImageryGeographicPoint {
+  return {
+    latitudeDeg: originLatitudeDeg + ((north / EARTH_RADIUS_M) * 180) / Math.PI,
+    longitudeDeg: originLongitudeDeg + ((east / (EARTH_RADIUS_M * Math.cos((originLatitudeDeg * Math.PI) / 180))) * 180) / Math.PI,
+  };
+}
+
+test("validates hierarchical venue assignments and confirmation provenance", () => {
+  const configuration = TrackConfigurationSchema.parse({
+    version: 1,
+    gameId: "iracing",
+    trackOrdinal: 24,
+    venue: { id: "daytona", name: "Daytona" },
+    subVenues: [
+      { id: "historical", name: "Historical" },
+      { id: "2011", name: "2011" },
+    ],
+    track: { id: "road-course", name: "Road Course" },
+    confirmation: { confirmedAt: "2026-08-17", confirmedBy: "RaceIQ maintainer", commitId: "abcdef1" },
+  });
+  expect(trackConfigurationVenueId(configuration)).toBe("daytona/historical/2011");
+  expect(trackConfigurationCanonicalId(configuration)).toBe("daytona/historical/2011/road-course");
+  expect(TrackConfigurationSchema.safeParse({ ...configuration, subVenues: [{ id: "../", name: "Invalid" }] }).success).toBe(false);
+  expect(
+    TrackConfigurationSchema.safeParse({
+      ...configuration,
+      confirmation: { ...configuration.confirmation, confirmedAt: "2026-02-31" },
+    }).success,
+  ).toBe(false);
+});
+
+test("creates a north-up venue footprint that fully covers GPS path", () => {
+  const originLatitudeDeg = 29;
+  const originLongitudeDeg = -81;
+  const geographic = [
+    geographicFromEnu(-100, -40, originLatitudeDeg, originLongitudeDeg),
+    geographicFromEnu(100, -40, originLatitudeDeg, originLongitudeDeg),
+    geographicFromEnu(100, 40, originLatitudeDeg, originLongitudeDeg),
+    geographicFromEnu(-100, 40, originLatitudeDeg, originLongitudeDeg),
+  ];
+  const calibration = defaultVenueImageryCalibration(geographic, 2);
+  expect(calibration).not.toBeNull();
+  const [a, b, c, d] = calibration!.imageToEnu;
+  expect(a).toBeGreaterThanOrEqual(200);
+  expect(b).toBe(0);
+  expect(c).toBe(0);
+  expect(d).toBeLessThanOrEqual(-100);
+  expect(a / Math.abs(d)).toBeCloseTo(2, 8);
+});
+test("keeps surrounding satellite context available for manual rotation and translation", () => {
+  const originLatitudeDeg = 29;
+  const originLongitudeDeg = -81;
+  const geographic = [geographicFromEnu(-200, -100, originLatitudeDeg, originLongitudeDeg), geographicFromEnu(200, 100, originLatitudeDeg, originLongitudeDeg)];
+  const bounds = trackImageryGeographicBounds(geographic);
+  expect(bounds).not.toBeNull();
+  const calibration = trackImageryCalibrationFromBounds(geographic, bounds!);
+  expect(calibration).not.toBeNull();
+  expect(calibration!.imageToEnu[0]).toBeCloseTo(800, 5);
+  expect(calibration!.imageToEnu[3]).toBeCloseTo(-400, 5);
+});
+
+test("calibrates an API raster to its exact geographic bounds", () => {
+  const originLatitudeDeg = 29;
+  const originLongitudeDeg = -81;
+  const geographic = [geographicFromEnu(-200, -100, originLatitudeDeg, originLongitudeDeg), geographicFromEnu(200, 100, originLatitudeDeg, originLongitudeDeg)];
+  const bounds = trackImageryGeographicBounds(geographic, 0.1);
+  expect(bounds).not.toBeNull();
+  const calibration = trackImageryCalibrationFromBounds(geographic, bounds!);
+  expect(calibration).not.toBeNull();
+  const northWest = geographicTrackImageryPoint({ latitudeDeg: bounds!.north, longitudeDeg: bounds!.west }, calibration!);
+  const southEast = geographicTrackImageryPoint({ latitudeDeg: bounds!.south, longitudeDeg: bounds!.east }, calibration!);
+  expect(transformTrackImageryPoint(calibration!.imageToEnu, 0, 0)).toEqual(northWest);
+  const transformedSouthEast = transformTrackImageryPoint(calibration!.imageToEnu, 1, 1);
+  expect(transformedSouthEast.x).toBeCloseTo(southEast.x, 8);
+  expect(transformedSouthEast.z).toBeCloseTo(southEast.z, 8);
+});
+
+test("resolves one GPS-calibrated venue texture into mirrored game-local coordinates", () => {
+  const originLatitudeDeg = 29;
+  const originLongitudeDeg = -81;
+  const enu = [
+    { x: -80, z: -30 },
+    { x: 80, z: -30 },
+    { x: 120, z: 20 },
+    { x: 40, z: 90 },
+    { x: -90, z: 60 },
+  ];
+  const geographic = enu.map((point) => geographicFromEnu(point.x, point.z, originLatitudeDeg, originLongitudeDeg));
+  const enuToTrack: TrackImageryMatrix = [0, 1.5, 1.5, 0, 400, -120];
+  const local = enu.map((point) => transformTrackImageryPoint(enuToTrack, point.x, point.z));
+  const imageToEnu: TrackImageryMatrix = [240, 0, 0, -140, -120, 70];
+  const resolved = resolveTrackImageryMatrix(local, geographic, { originLatitudeDeg, originLongitudeDeg, imageToEnu });
+  expect(resolved).not.toBeNull();
+  const expected = composeTrackImageryMatrices(enuToTrack, imageToEnu);
+  for (const [u, v] of [
+    [0, 0],
+    [1, 0],
+    [1, 1],
+    [0.25, 0.75],
+  ] as const) {
+    const actualPoint = transformTrackImageryPoint(resolved!, u, v);
+    const expectedPoint = transformTrackImageryPoint(expected, u, v);
+    expect(actualPoint.x).toBeCloseTo(expectedPoint.x, 4);
+    expect(actualPoint.z).toBeCloseTo(expectedPoint.z, 4);
+  }
+});
+
+test("keeps package base opaque while layers retain independent alpha", () => {
+  const manifest = TrackImageryVenueManifestSchema.parse({
+    version: TRACK_IMAGERY_MANIFEST_VERSION,
+    venueId: "daytona",
+    calibration: { originLatitudeDeg: 29, originLongitudeDeg: -81, imageToEnu: [1, 0, 0, -1, 0, 0] },
+    base: {
+      pack: TRACK_IMAGERY_PACKAGE_NAME,
+      tileSize: 512,
+      bounds: { west: -81.01, south: 28.99, east: -80.99, north: 29.01 },
+      source: {
+        name: "Owned base",
+        provider: "manual",
+        license: "owned",
+        attribution: "",
+        sourceResolutionM: 0.1,
+        storedResolutionM: 0.1,
+      },
+    },
+    layers: [{ id: "road-course", kind: "layout", image: "road-course.webp", opacity: 0.65, source: { name: "Owned correction", license: "owned", attribution: "" } }],
+  });
+  expect(manifest.version).toBe(2);
+  expect(manifest.base).toMatchObject({
+    pack: "imagery.rqi",
+    tileSize: 512,
+    bounds: { west: -81.01, south: 28.99, east: -80.99, north: 29.01 },
+    source: { provider: "manual", sourceResolutionM: 0.1, storedResolutionM: 0.1 },
+  });
+  expect("opacity" in manifest.base).toBe(false);
+  expect("image" in manifest.base).toBe(false);
+  expect(manifest.layers[0]?.opacity).toBe(0.65);
+});


### PR DESCRIPTION
## Summary
- Serve curated track imagery metadata, tiles, and textures.
- Download absent LFS-backed packs into a checksum-verified local cache.
- Fall back from missing or corrupt bundled packs without loading entire artifacts into memory.

## Verification
- `bun test`: 10 focused imagery and changelog tests pass.
- Root TypeScript check passes.
- Running RaceIQ returned Daytona imagery metadata and a 66,162-byte WebP tile with HTTP 200.