### PR TITLE
refactor: use canonical telemetry for live track consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - Show vehicle roll in the correct direction on the Analyse attitude indicator
 - Restore Analyse Data panel rows, section grouping, source-native tyre temperatures, copied values, F1 ERS/DRS details, and green throttle traces on both 2D and 3D views
 - Reduce unnecessary network traffic during update checks when release tags are unchanged
+- Keep live track maps from repeatedly refreshing track boundaries after boundary data loads
 
 ### Internal
 - Speed Vite development startup with compact locale modules, no development declarations, cached unchanged compiles, and pinned Inlang compiler modules

--- a/client/src/components/RaceInfo.tsx
+++ b/client/src/components/RaceInfo.tsx
@@ -1,9 +1,7 @@
 import { LiveTrackMap } from "@/components/live-track/LiveTrackMap";
 import { m } from "@/paraglide/messages";
 import type { LiveSectorData } from "../../../shared/racing/live/types";
-import type { TelemetryPacket } from "../../../shared/telemetry/types";
 import type { LiveTelemetryView } from "../lib/live-telemetry-view";
-import { useMemo } from "react";
 import { SectorTimes } from "./SectorTimes";
 import { LapTimes } from "./telemetry/LapTimes";
 export function RaceInfo({
@@ -25,14 +23,6 @@ export function RaceInfo({
   showTrackMap?: boolean;
   showSectors?: boolean;
 }) {
-  const mapPacket = useMemo(() => ({
-    gameId: view.simulator,
-    TrackOrdinal: view.identity.trackOrdinal ?? 0,
-    LapNumber: view.timing.lapNumber ?? 0,
-    DistanceTraveled: view.motion.distanceM ?? 0,
-    PositionX: view.motion.position?.x ?? 0,
-    PositionZ: view.motion.position?.z ?? 0,
-  } as unknown as TelemetryPacket), [view]);
   return (
     <div className="border-b border-app-border">
       <div className={showTrackMap ? "grid grid-cols-1 @7xl/workspace:grid-cols-[1fr_220px]" : ""}>
@@ -75,7 +65,7 @@ export function RaceInfo({
             <div className="p-2 border-b border-app-border">
               <div className="text-xs font-semibold text-app-text-muted uppercase tracking-wider truncate">{trackName || m.raceinfo_track_map_heading()}</div>
             </div>
-            <LiveTrackMap packet={mapPacket} />
+            <LiveTrackMap view={view} />
           </div>
         )}
       </div>

--- a/client/src/components/live-track/LiveTrackMap.tsx
+++ b/client/src/components/live-track/LiveTrackMap.tsx
@@ -132,6 +132,8 @@ export function LiveTrackMap({ view, issues }: Props) {
     }
 
     // Re-fetch boundaries — calibration may now provide game-space coords
+    // Boundary state is intentionally not an effect dependency: a response
+    // must not trigger another fetch before the next lap checks calibration.
     if (!boundaries || (boundaries.coordSystem !== "forza" && boundaries.coordSystem !== "f1-2025")) {
       client.api["track-boundaries"][":ordinal"]
         .$get({ param: { ordinal: String(trackOrd) }, query: { gameId: gameId ?? undefined } })
@@ -141,7 +143,7 @@ export function LiveTrackMap({ view, issues }: Props) {
         }) // eslint-disable-line @typescript-eslint/no-explicit-any
         .catch(() => {});
     }
-  }, [boundaries, gameId, isRecorded, sample?.lapNumber]);
+  }, [gameId, isRecorded, sample?.lapNumber]);
 
   // Track distance at lap boundaries for position estimation
   useEffect(() => {

--- a/client/src/components/live-track/LiveTrackMap.tsx
+++ b/client/src/components/live-track/LiveTrackMap.tsx
@@ -1,22 +1,21 @@
-import { deadReckonIRacingPosition } from "@shared/racing/tracks/path";
 import type { TuneIssue } from "@shared/racing/tuning/issues";
-import type { TelemetryPacket } from "@shared/telemetry/types";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { LiveTelemetryView } from "@/lib/live-telemetry-view";
 import { Button } from "@/components/ui/button";
 import { client } from "@/lib/rpc";
 import { m } from "@/paraglide/messages";
-import { useGameId } from "@/stores/game";
+import { advanceLiveTrackPosition, type LiveTrackSample, liveTrackSampleFromView } from "./live-track-sample";
 import { drawLiveTrack, type Point, type TrackBoundaryData } from "./draw-live-track";
 
 interface Props {
-  packet: TelemetryPacket | null;
-  /** Live Tuning Dashboard: transient issues to plot as markers along the track,
-   *  positioned by their distanceFrac. Omitted/undefined elsewhere. */
+  view: LiveTelemetryView | null;
+  /** Live Tuning Dashboard issues positioned by canonical lap fraction. */
   issues?: TuneIssue[];
 }
 
-export function LiveTrackMap({ packet, issues }: Props) {
-  const gameId = useGameId();
+export function LiveTrackMap({ view, issues }: Props) {
+  const sample = useMemo(() => (view ? liveTrackSampleFromView(view) : null), [view]);
+  const gameId = sample?.simulator ?? null;
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [outline, setOutline] = useState<Point[] | null>(null);
   const [noOutline, setNoOutline] = useState(false);
@@ -37,14 +36,14 @@ export function LiveTrackMap({ packet, issues }: Props) {
   const liveTraceRef = useRef<Point[]>([]);
   const lastTracePos = useRef<Point | null>(null);
   const deadReckonedPosRef = useRef<Point | null>(null);
-  const deadReckonedPacketRef = useRef<TelemetryPacket | null>(null);
+  const previousSampleRef = useRef<LiveTrackSample | null>(null);
   const deadReckonedLapRef = useRef<number | null>(null);
   const traceMinDist = 3;
 
-  // Auto-detect track changes from packet.TrackOrdinal and fetch outline
+  // Auto-detect track changes from canonical identity and fetch outline.
   useEffect(() => {
-    if (!packet?.TrackOrdinal) return;
-    const trackOrd = packet.TrackOrdinal;
+    if (sample?.trackOrdinal === undefined) return;
+    const trackOrd = sample.trackOrdinal;
     if (trackOrd === lastTrackOrdRef.current) return;
     lastTrackOrdRef.current = trackOrd;
 
@@ -52,7 +51,7 @@ export function LiveTrackMap({ packet, issues }: Props) {
     liveTraceRef.current = [];
     lastTracePos.current = null;
     deadReckonedPosRef.current = null;
-    deadReckonedPacketRef.current = null;
+    previousSampleRef.current = null;
     deadReckonedLapRef.current = null;
     lapDistRef.current = { startDist: 0, totalDist: 0, lastLap: -1 };
     setOutline(null);
@@ -105,15 +104,15 @@ export function LiveTrackMap({ packet, issues }: Props) {
         setStartYaw(null);
         setNoOutline(true);
       });
-  }, [packet?.TrackOrdinal, gameId]);
+  }, [gameId, sample?.trackOrdinal]);
 
   // Re-fetch outline on lap completion if we don't have a recorded one yet.
   // The server may have just recorded the first lap trace.
   // Also re-fetch boundaries (calibration may have completed after a lap).
   useEffect(() => {
-    if (!packet) return;
+    if (!sample) return;
     const trackOrd = lastTrackOrdRef.current;
-    if (!trackOrd) return;
+    if (trackOrd === null) return;
 
     if (!gameId) return;
     if (!isRecorded) {
@@ -142,69 +141,52 @@ export function LiveTrackMap({ packet, issues }: Props) {
         }) // eslint-disable-line @typescript-eslint/no-explicit-any
         .catch(() => {});
     }
-  }, [packet?.LapNumber, gameId]);
+  }, [boundaries, gameId, isRecorded, sample?.lapNumber]);
 
   // Track distance at lap boundaries for position estimation
   useEffect(() => {
-    if (!packet) return;
-    const d = lapDistRef.current;
-    if (packet.LapNumber !== d.lastLap) {
-      // Lap boundary: record total distance of completed lap, reset start
-      if (d.lastLap >= 0 && d.startDist > 0) {
-        const completedDist = packet.DistanceTraveled - d.startDist;
-        if (completedDist > 50) {
-          d.totalDist = completedDist;
-        }
+    if (sample?.lapNumber === undefined || sample.distanceM === undefined) return;
+    const distance = lapDistRef.current;
+    if (sample.lapNumber !== distance.lastLap) {
+      if (distance.lastLap >= 0 && distance.startDist > 0) {
+        const completedDistanceM = sample.distanceM - distance.startDist;
+        if (completedDistanceM > 50) distance.totalDist = completedDistanceM;
       }
-      d.startDist = packet.DistanceTraveled;
-      d.lastLap = packet.LapNumber;
+      distance.startDist = sample.distanceM;
+      distance.lastLap = sample.lapNumber;
     }
-  }, [packet?.LapNumber, packet?.DistanceTraveled]);
+  }, [sample?.distanceM, sample?.lapNumber]);
 
-  // Collect real positions when available. iRacing deliberately publishes no
-  // world position, so dead-reckon speed along heading while the first lap is
-  // being built. Once an outline exists, native LapDistPct takes over.
+  // Build a live trace from canonical world position when available. When it is
+  // unavailable, dead-reckon from canonical speed and yaw without simulator switches.
   useEffect(() => {
-    if (!packet) return;
-    let pos: Point | null = null;
-    if (packet.PositionX !== 0 || packet.PositionZ !== 0) {
-      pos = { x: packet.PositionX, z: packet.PositionZ };
-    } else if (packet.gameId === "iracing") {
-      const previousPacket = deadReckonedPacketRef.current;
-      const lapChanged = deadReckonedLapRef.current != null && deadReckonedLapRef.current !== packet.LapNumber;
+    if (!sample) return;
+    let position = sample.positionM ?? null;
+    if (!position && sample.yawRad !== undefined && sample.speedMps !== undefined) {
+      const previousSample = previousSampleRef.current;
+      const lapChanged = deadReckonedLapRef.current !== null && deadReckonedLapRef.current !== sample.lapNumber;
       if (!deadReckonedPosRef.current || lapChanged) {
         deadReckonedPosRef.current = { x: 0, z: 0 };
         liveTraceRef.current = [];
         lastTracePos.current = null;
-      } else if (previousPacket) {
-        deadReckonedPosRef.current = deadReckonIRacingPosition(previousPacket, packet, deadReckonedPosRef.current);
+      } else if (previousSample) {
+        deadReckonedPosRef.current = advanceLiveTrackPosition(previousSample, sample, deadReckonedPosRef.current);
       }
-      deadReckonedPacketRef.current = packet;
-      deadReckonedLapRef.current = packet.LapNumber;
-      pos = deadReckonedPosRef.current;
+      position = deadReckonedPosRef.current;
     }
-    if (!pos) return;
+    previousSampleRef.current = sample;
+    deadReckonedLapRef.current = sample.lapNumber ?? null;
+    if (!position) return;
     const last = lastTracePos.current;
-
-    if (last) {
-      const dx = pos.x - last.x;
-      const dz = pos.z - last.z;
-      const dist = Math.sqrt(dx * dx + dz * dz);
-      if (dist < traceMinDist) return;
-    }
-
-    liveTraceRef.current.push(pos);
-    lastTracePos.current = pos;
-
-    // Cap at 2000 points (enough for most tracks)
-    if (liveTraceRef.current.length > 2000) {
-      liveTraceRef.current.shift();
-    }
-  }, [packet]);
+    if (last && Math.hypot(position.x - last.x, position.z - last.z) < traceMinDist) return;
+    liveTraceRef.current.push(position);
+    lastTracePos.current = position;
+    if (liveTraceRef.current.length > 2000) liveTraceRef.current.shift();
+  }, [sample]);
 
   // Redraw
   useEffect(() => {
-    drawLiveTrack({ canvasRef, packet, outline, noOutline, isRecorded, startYaw, sectors, boundaries, issues, liveTraceRef, deadReckonedPosRef, lapDistRef });
+    drawLiveTrack({ canvasRef, sample, outline, noOutline, isRecorded, startYaw, sectors, boundaries, issues, liveTraceRef, deadReckonedPosRef, lapDistRef });
   });
 
   async function handleDeleteMap() {
@@ -219,7 +201,7 @@ export function LiveTrackMap({ packet, issues }: Props) {
       liveTraceRef.current = [];
       lastTracePos.current = null;
       deadReckonedPosRef.current = null;
-      deadReckonedPacketRef.current = null;
+      previousSampleRef.current = null;
       deadReckonedLapRef.current = null;
     } catch {}
   }

--- a/client/src/components/live-track/draw-live-track.ts
+++ b/client/src/components/live-track/draw-live-track.ts
@@ -1,7 +1,6 @@
-import { pointAtLapFraction } from "@shared/racing/tracks/path";
 import type { TuneIssue } from "@shared/racing/tuning/issues";
-import type { TelemetryPacket } from "@shared/telemetry/types";
 import type { MutableRefObject, RefObject } from "react";
+import { pointForLiveTrackSample, type LiveTrackSample } from "./live-track-sample";
 import { SECTOR_COLOR_VARS } from "@/lib/colors";
 import { getSemanticCanvasContext } from "@/lib/rendering/css-canvas";
 
@@ -20,7 +19,7 @@ const ISSUE_COLORS: Record<TuneIssue["severity"], string> = { info: "var(--statu
 
 export function drawLiveTrack({
   canvasRef,
-  packet,
+  sample,
   outline,
   noOutline,
   isRecorded,
@@ -33,7 +32,7 @@ export function drawLiveTrack({
   lapDistRef,
 }: {
   canvasRef: RefObject<HTMLCanvasElement | null>;
-  packet: TelemetryPacket | null;
+  sample: LiveTrackSample | null;
   outline: Point[] | null;
   noOutline: boolean;
   isRecorded: boolean;
@@ -409,75 +408,30 @@ export function drawLiveTrack({
     ctx.fillText(`Mapping... ${displayOutline.length} pts`, 8, h - 8);
   }
 
-  // Live car position
-  if (packet) {
-    let cx: number;
-    let cy: number;
-    let hasPos = false;
+  // Live car position. Selection follows semantic availability, not simulator.
+  if (sample) {
+    const distance = lapDistRef.current;
+    const distanceFraction = distance.totalDist > 50 && sample.distanceM !== undefined ? Math.max(0, Math.min((sample.distanceM - distance.startDist) / distance.totalDist, 1)) : undefined;
+    const point = pointForLiveTrackSample(sample, displayOutline, {
+      useWorldPosition: isLiveTrace || isRecorded || boundaryCenter !== null,
+      deadReckonedPosition: isLiveTrace ? deadReckonedPosRef.current : null,
+      distanceFraction,
+    });
 
-    const nativeLapFraction = packet.iracing?.lapDistancePct;
-    if (packet.gameId === "iracing" && outline && Number.isFinite(nativeLapFraction)) {
-      const point = pointAtLapFraction(displayOutline, nativeLapFraction!);
-      if (point) {
-        [cx, cy] = toCanvas(point.x, point.z);
-        hasPos = true;
-      } else {
-        [cx, cy] = [0, 0];
-      }
-    } else if (isLiveTrace && packet.gameId === "iracing") {
-      const point = deadReckonedPosRef.current;
-      if (point) {
-        [cx, cy] = toCanvas(point.x, point.z);
-        hasPos = true;
-      } else {
-        [cx, cy] = [0, 0];
-      }
-    } else if (isLiveTrace || isRecorded || boundaryCenter) {
-      // Forza coords: live trace, recorded outline, or boundary center — plot directly
-      if (packet.PositionX !== 0 || packet.PositionZ !== 0) {
-        [cx, cy] = toCanvas(packet.PositionX, packet.PositionZ);
-        hasPos = true;
-      } else {
-        [cx, cy] = [0, 0];
-      }
-    } else {
-      // Pre-made outline: use distance fraction to determine position.
-      // (distance traveled this lap) / (total lap distance) = 0-1 progress
-      const d = lapDistRef.current;
-      if (d.totalDist > 50) {
-        const lapDist = packet.DistanceTraveled - d.startDist;
-        const frac = Math.max(0, Math.min(lapDist / d.totalDist, 1));
-        const idx = Math.round(frac * (displayOutline.length - 1));
-        const pt = displayOutline[Math.min(idx, displayOutline.length - 1)];
-        if (pt) {
-          [cx, cy] = toCanvas(pt.x, pt.z);
-          hasPos = true;
-        } else {
-          [cx, cy] = [0, 0];
-        }
-      } else {
-        [cx, cy] = [0, 0];
-        ctx.fillStyle = "var(--app-text-dim)";
-        ctx.font = "var(--text-app-micro) var(--font-sans)";
-        ctx.textAlign = "left";
-        ctx.fillText("Complete a lap to track position", 8, h - 8);
-      }
-    }
-
-    if (hasPos) {
-      // Glow
+    if (point) {
+      const [cx, cy] = toCanvas(point.x, point.z);
       ctx.beginPath();
-      ctx.arc(cx, cy, 10, 0, Math.PI * 2);
-      ctx.fillStyle = "color-mix(in srgb, var(--app-accent) 20%, transparent)";
+      ctx.arc(cx, cy, 7, 0, Math.PI * 2);
+      ctx.fillStyle = "var(--track-position)";
       ctx.fill();
-      // Dot
-      ctx.beginPath();
-      ctx.arc(cx, cy, 5, 0, Math.PI * 2);
-      ctx.fillStyle = "var(--app-accent)";
-      ctx.fill();
-      ctx.strokeStyle = "var(--track-label-background)";
-      ctx.lineWidth = 1.5;
+      ctx.strokeStyle = "var(--track-position-outline)";
+      ctx.lineWidth = 2;
       ctx.stroke();
+    } else if (!isLiveTrace) {
+      ctx.fillStyle = "var(--app-text-dim)";
+      ctx.font = "var(--text-app-caption) var(--font-sans)";
+      ctx.textAlign = "center";
+      ctx.fillText("Waiting for track position...", w / 2, h - 8);
     }
   }
 }

--- a/client/src/components/live-track/live-track-sample.ts
+++ b/client/src/components/live-track/live-track-sample.ts
@@ -1,0 +1,65 @@
+import type { GameId } from "@shared/games/ids";
+import { pointAtLapFraction } from "@shared/racing/tracks/path";
+import type { LiveTelemetryView } from "@/lib/live-telemetry-view";
+
+export interface LiveTrackPoint {
+  x: number;
+  z: number;
+}
+
+export interface LiveTrackSample {
+  simulator: GameId;
+  observedAtMs: number;
+  trackOrdinal?: number;
+  lapNumber?: number;
+  distanceM?: number;
+  lapFraction?: number;
+  positionM?: LiveTrackPoint;
+  yawRad?: number;
+  speedMps?: number;
+}
+
+export function liveTrackSampleFromView(view: LiveTelemetryView): LiveTrackSample {
+  return {
+    simulator: view.simulator,
+    observedAtMs: view.observedAtMs,
+    trackOrdinal: view.identity.trackOrdinal,
+    lapNumber: view.timing.lapNumber,
+    distanceM: view.motion.distanceM,
+    lapFraction: view.timing.lapFraction,
+    positionM: view.motion.position,
+    yawRad: view.motion.attitude?.yaw,
+    speedMps: view.motion.speedMps,
+  };
+}
+
+export function advanceLiveTrackPosition(previous: LiveTrackSample, current: LiveTrackSample, previousPosition: LiveTrackPoint): LiveTrackPoint {
+  if (previous.yawRad === undefined || current.yawRad === undefined || current.speedMps === undefined) return previousPosition;
+  const elapsedS = (current.observedAtMs - previous.observedAtMs) / 1000;
+  if (elapsedS <= 0 || elapsedS > 1) return previousPosition;
+  const yawRad = Math.atan2(Math.sin(previous.yawRad) + Math.sin(current.yawRad), Math.cos(previous.yawRad) + Math.cos(current.yawRad));
+  return {
+    x: previousPosition.x + Math.sin(yawRad) * current.speedMps * elapsedS,
+    z: previousPosition.z + Math.cos(yawRad) * current.speedMps * elapsedS,
+  };
+}
+
+export function pointForLiveTrackSample(
+  sample: LiveTrackSample,
+  outline: readonly LiveTrackPoint[],
+  options: {
+    useWorldPosition: boolean;
+    deadReckonedPosition?: LiveTrackPoint | null;
+    distanceFraction?: number;
+  },
+): LiveTrackPoint | null {
+  if (options.useWorldPosition && sample.positionM) return sample.positionM;
+  if (options.useWorldPosition && options.deadReckonedPosition) return options.deadReckonedPosition;
+  if (sample.lapFraction !== undefined && Number.isFinite(sample.lapFraction)) {
+    return pointAtLapFraction(outline, sample.lapFraction) ?? null;
+  }
+  if (options.distanceFraction !== undefined && Number.isFinite(options.distanceFraction)) {
+    return pointAtLapFraction(outline, options.distanceFraction) ?? null;
+  }
+  return null;
+}

--- a/client/src/styles/theme.css
+++ b/client/src/styles/theme.css
@@ -194,6 +194,8 @@
 
   /* Track-map identities. */
   --track-start: var(--color-emerald-500);
+  --track-position: var(--color-cyan-400);
+  --track-position-outline: var(--color-slate-900);
   --track-surface: var(--color-slate-700);
   --track-edge: var(--color-slate-500);
   --track-outline: var(--color-slate-700);

--- a/client/test/live-track-sample.test.ts
+++ b/client/test/live-track-sample.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { KNOWN_GAME_IDS, type GameId } from "../../shared/games/ids";
+import { advanceLiveTrackPosition, type LiveTrackSample, liveTrackSampleFromView, pointForLiveTrackSample } from "../src/components/live-track/live-track-sample";
+import type { LiveTelemetryView } from "../src/lib/live-telemetry-view";
+
+function view(simulator: GameId): LiveTelemetryView {
+  return {
+    simulator,
+    streamId: `stream-${simulator}`,
+    sessionId: 1,
+    sequence: 2,
+    observedAtMs: 1_000,
+    identity: { trackOrdinal: 42 },
+    motion: {
+      speedMps: 20,
+      distanceM: 500,
+      position: { x: 10, z: 20 },
+      attitude: { roll: 0, pitch: 0, yaw: 0.5 },
+    },
+    inputs: {},
+    engine: {},
+    fuel: {},
+    timing: { lapNumber: 3, lapFraction: 0.25 },
+    tires: {},
+    weather: {},
+    aero: {},
+    ers: {},
+    damage: {},
+    competitors: [],
+    stateBySemanticId: {},
+  };
+}
+
+function sample(simulator: GameId, overrides: Partial<LiveTrackSample> = {}): LiveTrackSample {
+  return { simulator, observedAtMs: 1_000, ...overrides };
+}
+
+describe("canonical live track samples", () => {
+  test("preserves simulator identity and explicit canonical units", () => {
+    for (const simulator of KNOWN_GAME_IDS) {
+      expect(liveTrackSampleFromView(view(simulator))).toEqual({
+        simulator,
+        observedAtMs: 1_000,
+        trackOrdinal: 42,
+        lapNumber: 3,
+        distanceM: 500,
+        lapFraction: 0.25,
+        positionM: { x: 10, z: 20 },
+        yawRad: 0.5,
+        speedMps: 20,
+      });
+    }
+  });
+
+  test("places every simulator from canonical lap fraction", () => {
+    const outline = [
+      { x: 0, z: 0 },
+      { x: 100, z: 0 },
+    ];
+    for (const simulator of KNOWN_GAME_IDS) {
+      expect(pointForLiveTrackSample(sample(simulator, { lapFraction: 0.25 }), outline, { useWorldPosition: false })).toEqual({ x: 25, z: 0 });
+    }
+  });
+
+  test("keeps unavailable position distinct from legitimate origin", () => {
+    const outline = [
+      { x: 0, z: 0 },
+      { x: 100, z: 0 },
+    ];
+    expect(pointForLiveTrackSample(sample("acc"), outline, { useWorldPosition: true })).toBeNull();
+    expect(pointForLiveTrackSample(sample("acc", { positionM: { x: 0, z: 0 } }), outline, { useWorldPosition: true })).toEqual({ x: 0, z: 0 });
+  });
+
+  test("dead-reckons from canonical speed and yaw without simulator branches", () => {
+    for (const simulator of KNOWN_GAME_IDS) {
+      const previous = sample(simulator, { observedAtMs: 1_000, yawRad: 0, speedMps: 10 });
+      const current = sample(simulator, { observedAtMs: 1_100, yawRad: 0, speedMps: 10 });
+      expect(advanceLiveTrackPosition(previous, current, { x: 0, z: 0 })).toEqual({ x: 0, z: 1 });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- migrate RaceInfo and live track rendering from raw packet fields to canonical LiveTelemetryView samples
- centralize sample positioning and dead reckoning with explicit canonical units and simulator identity
- keep unavailable coordinates distinct from origin and stop boundary data from retriggering boundary fetches

## Testing

- `bun test ./client/test/live-track-sample.test.ts`
- `bun run --cwd client i18n:compile`
- `bunx tsc --build client/tsconfig.json --pretty false`
- `bunx tsc --project tsconfig.json --noEmit --pretty false`

Part of #301