### PR TITLE
fix(update): read notes from release bodies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,9 +147,7 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: raceiq-v${{ needs.compute-version.outputs.version }}-release-note
-          path: |
-            releasenote.md
-            releasenotes.md
+          path: releasenote.md
 
   playwright-test:
     if: github.event_name == 'workflow_dispatch'
@@ -248,16 +246,6 @@ jobs:
           ref: main
       - uses: oven-sh/setup-bun@v2
 
-      - name: Regenerate release note assets
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG="${{ github.event.release.tag_name }}"
-          VERSION="${TAG#v}"
-          PUBLISHED_AT="${{ github.event.release.published_at }}"
-          bun scripts/release/generate-release-note.ts "$VERSION" "$PUBLISHED_AT"
-          gh release upload "$TAG" releasenote.md releasenotes.md --clobber
 
       - name: Roll over changelog
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Keep live track maps from repeatedly refreshing track boundaries after boundary data loads
 
 ### Internal
+- Read release notes from GitHub release bodies instead of downloading release-note assets
 - Use explicit comprehensive Storybook stories for visual baselines so shared layouts cover every supported field without simulator fixture churn
 - Benchmark telemetry parser and replay performance with reproducible Mitata CPU guardrails and separate report-only storage I/O measurements
 - Stabilize benchmark regression checks with paired CPU samples, retained-heap probes, and counterbalanced base/current runs

--- a/client/src/components/UpdateModal.tsx
+++ b/client/src/components/UpdateModal.tsx
@@ -35,12 +35,13 @@ function StepIndicator({ step, current }: { step: (typeof STEPS)[number]; curren
   );
 }
 
-export function UpdateModal({ version, newReleases, fullReleaseNotes, onClose }: { version: string; newReleases: { version: string; notes: string; date: string }[]; fullReleaseNotes: string | null; onClose: () => void }) {
+export function UpdateModal({ version, currentVersion, newReleases, fullReleaseNotes, currentReleaseNotes, currentReleaseDate, onClose }: { version: string; currentVersion: string; newReleases: { version: string; notes: string; date: string }[]; fullReleaseNotes: string | null; currentReleaseNotes: string | null; currentReleaseDate: string | null; onClose: () => void }) {
   const updateProgress = useTelemetryStore((s) => s.updateProgress);
   const [error, setError] = useState<string | null>(null);
   const [showAllReleases, setShowAllReleases] = useState(false);
 
   const stage = updateProgress?.stage ?? null;
+  const releasesToDisplay = currentReleaseNotes ? [...newReleases, { version: currentVersion, notes: currentReleaseNotes, date: currentReleaseDate ?? "" }] : newReleases;
   const percent = updateProgress?.percent ?? 0;
 
   const handleInstall = async () => {
@@ -113,9 +114,9 @@ export function UpdateModal({ version, newReleases, fullReleaseNotes, onClose }:
                   <ReleaseNotes notes={fullReleaseNotes} />
                 </div>
               ) : (
-                newReleases.length > 0 &&
+                releasesToDisplay.length > 0 &&
                 (() => {
-                  const [latest, ...older] = newReleases;
+                  const [latest, ...older] = releasesToDisplay;
                   return (
                     <div className="max-h-52 overflow-y-auto space-y-3">
                       <div>

--- a/client/src/routes/__root.tsx
+++ b/client/src/routes/__root.tsx
@@ -177,7 +177,7 @@ function AppShell() {
           </div>
         )}
 
-        {(showUpdateModal || updateProgress) && <UpdateModal version={updateState?.latest ?? updateAvailable ?? "?"} newReleases={updateState?.newReleases ?? []} fullReleaseNotes={updateState?.fullReleaseNotes ?? null} onClose={() => setShowUpdateModal(false)} />}
+        {(showUpdateModal || updateProgress) && <UpdateModal version={updateState?.latest ?? updateAvailable ?? "?"} currentVersion={updateState?.current ?? "?"} newReleases={updateState?.newReleases ?? []} fullReleaseNotes={updateState?.fullReleaseNotes ?? null} currentReleaseNotes={updateState?.currentReleaseNotes ?? null} currentReleaseDate={updateState?.currentReleaseDate ?? null} onClose={() => setShowUpdateModal(false)} />}
         {onboardingOpen && <OnboardingModal onClose={closeOnboarding} />}
       </div>
       <StaleLapReprocessing />

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -5,9 +5,9 @@ Validate and render release metadata.
 | Command | Purpose |
 |---|---|
 | `bun scripts/release/check-changelog.ts` | In pull-request CI, require a new note under `## Unreleased`; no-op outside pull requests. |
-| `bun scripts/release/generate-release-note.ts <version>` | Render `CHANGELOG.md`'s unreleased body and all release notes into `releasenote.md` and `releasenotes.md`. |
+| `bun scripts/release/generate-release-note.ts <version>` | Render `CHANGELOG.md`'s unreleased body for the GitHub release body. |
 
-Inputs: `CHANGELOG.md`, git base ref and event variables for CI validation, and release version argument for rendering. Outputs: validation status or two root release-note files.
+Inputs: `CHANGELOG.md`, git base ref and event variables for CI validation, and release version argument for rendering. Outputs: validation status or the draft release body.
 
 Boundary: release-note validation/rendering only. Scripts do not publish releases, edit changelog content, or build artifacts.
 

--- a/scripts/release/generate-release-note.ts
+++ b/scripts/release/generate-release-note.ts
@@ -1,15 +1,11 @@
 import { readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { formatReleaseDate, renderAllReleaseNotes, renderUnreleasedBody } from "@shared/tooling/render";
+import { renderUnreleasedBody } from "@shared/tooling/render";
 const version = process.argv[2];
-const publishedAt = process.argv[3];
 if (!version) throw new Error("Usage: bun scripts/release/generate-release-note.ts <version> [publishedAt]");
 
 const changelog = readFileSync(join(process.cwd(), "CHANGELOG.md"), "utf8");
 const notes = renderUnreleasedBody(changelog);
 if (!notes) throw new Error(`CHANGELOG.md has no release notes under ## Unreleased for v${version}`);
-const release = publishedAt === undefined ? { version } : { version, date: formatReleaseDate(publishedAt) };
-
 writeFileSync("releasenote.md", `${notes}\n`);
-writeFileSync("releasenotes.md", `${renderAllReleaseNotes(changelog, release)}\n`);
-console.log(`Generated releasenote.md and releasenotes.md for v${version}`);
+console.log(`Generated releasenote.md for v${version}`);

--- a/scripts/test/integration-files.txt
+++ b/scripts/test/integration-files.txt
@@ -226,3 +226,4 @@ test/games/shared/parser.test.ts
 test/lap-analysis/clean-lap-aggregate.test.ts
 test/lap-analysis/corner-resolution.test.ts
 test/laps/archive-detection.test.ts
+test/runtime/update-github.integration.test.ts

--- a/server/runtime/update/check.ts
+++ b/server/runtime/update/check.ts
@@ -47,7 +47,7 @@ interface UpdateState {
   downloadUrl: string | null;
   /** All releases newer than current version */
   newReleases: ReleaseInfo[];
-  /** Full public release history from releasenotes.md for the latest release. */
+  /** Deprecated compatibility field; release history now comes from API bodies. */
   fullReleaseNotes: string | null;
   currentReleaseNotes: string | null;
   currentReleaseDate: string | null;
@@ -68,10 +68,10 @@ let state: UpdateState = {
   checked: false,
 };
 
-// Tag associated with the release-note artifacts held in `state`.
+// Tag associated with the release-note data held in `state`.
 let releaseArtifactsTag: string | null = null;
 
-// Release metadata is cheap to poll; attached markdown assets are not.
+// Release metadata and bodies are fetched only when latest tag changes.
 export function shouldFetchReleaseArtifacts(cachedTag: string | null, latestTag: string): boolean {
   return cachedTag !== latestTag;
 }
@@ -101,26 +101,38 @@ function notifyUpdateAvailable(version: string): void {
 
 interface GitHubRelease {
   tag_name: string;
+  body?: string | null;
   published_at?: string;
   assets: { name: string; browser_download_url: string }[];
 }
 
-export function findReleaseAsset(release: GitHubRelease, filename: string): string | null {
-  return release.assets.find((candidate) => candidate.name.toLowerCase() === filename.toLowerCase())?.browser_download_url ?? null;
+export function getReleaseNotes(release: GitHubRelease): string | null {
+  const body = release.body?.trim();
+  return body || null;
 }
 
-async function fetchReleaseAsset(release: GitHubRelease, filename: string): Promise<string | null> {
-  const url = findReleaseAsset(release, filename);
-  if (!url) return null;
-  const response = await fetch(url, { headers: GH_HEADERS });
-  if (!response.ok) return null;
-  const notes = (await response.text()).trim();
-  return notes || null;
-}
+export function collectReleaseNotes(releases: GitHubRelease[], currentVersion: string): {
+  newReleases: ReleaseInfo[];
+  currentReleaseNotes: string | null;
+  currentReleaseDate: string | null;
+} {
+  const newReleases: ReleaseInfo[] = [];
+  let currentReleaseNotes: string | null = null;
+  let currentReleaseDate: string | null = null;
 
-/** Fetch the complete curated release note asset attached to a GitHub release. */
-async function fetchReleaseNotes(release: GitHubRelease): Promise<string | null> {
-  return fetchReleaseAsset(release, "releasenote.md");
+  for (const release of releases) {
+    const version = release.tag_name.replace(/^v/, "");
+    if (version !== currentVersion && !isNewer(version, currentVersion)) continue;
+    const notes = getReleaseNotes(release);
+    if (version === currentVersion) {
+      currentReleaseNotes = notes;
+      currentReleaseDate = release.published_at ?? null;
+    } else if (notes) {
+      newReleases.push({ version, notes, date: release.published_at ?? "" });
+    }
+  }
+
+  return { newReleases, currentReleaseNotes, currentReleaseDate };
 }
 
 /** Fetch all releases from GitHub and split into new/current. */
@@ -129,35 +141,23 @@ export function mergeLatestRelease(releases: GitHubRelease[], latest?: GitHubRel
   return [latest, ...releases];
 }
 
-async function fetchReleases(currentVersion: string, latest?: GitHubRelease): Promise<{
+export async function fetchReleases(currentVersion: string, latest?: GitHubRelease): Promise<{
   newReleases: ReleaseInfo[];
   fullReleaseNotes: string | null;
   currentReleaseNotes: string | null;
   currentReleaseDate: string | null;
 }> {
-  const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=50`, { headers: GH_HEADERS });
-  if (!res.ok) throw new Error(`Release list fetch failed: ${res.status}`);
-
-  const releases = mergeLatestRelease(await res.json() as GitHubRelease[], latest);
-  const fullReleaseNotes = latest ? await fetchReleaseAsset(latest, "releasenotes.md") : null;
-  const newReleases: ReleaseInfo[] = [];
-  let currentReleaseNotes: string | null = null;
-  let currentReleaseDate: string | null = null;
-
-
-  for (const r of releases) {
-    const ver = r.tag_name.replace(/^v/, "");
-    if (ver !== currentVersion && !isNewer(ver, currentVersion)) continue;
-    const notes = await fetchReleaseNotes(r);
-    if (ver === currentVersion) {
-      currentReleaseNotes = notes;
-      currentReleaseDate = r.published_at ?? null;
-    } else if (notes) {
-      newReleases.push({ version: ver, notes, date: r.published_at ?? "" });
-    }
+  const releases: GitHubRelease[] = [];
+  for (let page = 1; ; page += 1) {
+    const res = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=50&page=${page}`, { headers: GH_HEADERS });
+    if (!res.ok) throw new Error(`Release list fetch failed: ${res.status}`);
+    const pageReleases = await res.json() as GitHubRelease[];
+    releases.push(...pageReleases);
+    if (pageReleases.length < 50) break;
   }
 
-  return { newReleases, fullReleaseNotes, currentReleaseNotes, currentReleaseDate };
+  const mergedReleases = mergeLatestRelease(releases, latest);
+  return { ...collectReleaseNotes(mergedReleases, currentVersion), fullReleaseNotes: null };
 }
 
 

--- a/test/runtime/update-check.test.ts
+++ b/test/runtime/update-check.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { resolveDataDir } from "../../server/runtime/config/data-dir";
-import { findReleaseAsset, isNewer, mergeLatestRelease, shouldFetchReleaseArtifacts } from "../../server/runtime/update/check";
+import { collectReleaseNotes, fetchReleases, getReleaseNotes, isNewer, mergeLatestRelease, shouldFetchReleaseArtifacts } from "../../server/runtime/update/check";
 describe("resolveDataDir", () => {
   let originalDataDir: string | undefined;
 
@@ -67,18 +67,60 @@ describe("release list merging", () => {
   });
 });
 
-describe("release asset selection", () => {
-  test("selects the full plural release history asset", () => {
+
+describe("release body selection", () => {
+  test("uses the GitHub release body instead of release-note assets", () => {
     const release = {
       tag_name: "v0.14.0",
-      assets: [
-        { name: "releasenote.md", browser_download_url: "single" },
-        { name: "releasenotes.md", browser_download_url: "full" },
-      ],
+      body: "### Features\n- Faster updates",
+      assets: [{ name: "releasenote.md", browser_download_url: "asset" }],
     };
 
-    expect(findReleaseAsset(release, "releasenotes.md")).toBe("full");
+    expect(getReleaseNotes(release)).toBe("### Features\n- Faster updates");
   });
+  test("collects bodies from the installed version through latest", () => {
+    const releases = [
+      { tag_name: "v0.16.0", body: "latest body", published_at: "2026-08-01", assets: [] },
+      { tag_name: "v0.15.0", body: "middle body", published_at: "2026-07-01", assets: [] },
+      { tag_name: "v0.14.0", body: "installed body", published_at: "2026-06-01", assets: [] },
+      { tag_name: "v0.13.0", body: "older body", published_at: "2026-05-01", assets: [] },
+    ];
+
+    expect(collectReleaseNotes(releases, "0.14.0")).toEqual({
+      newReleases: [
+        { version: "0.16.0", notes: "latest body", date: "2026-08-01" },
+        { version: "0.15.0", notes: "middle body", date: "2026-07-01" },
+      ],
+      currentReleaseNotes: "installed body",
+      currentReleaseDate: "2026-06-01",
+    });
+  });
+  test("fetches release bodies for every release from the installed version", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestedUrl = "";
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = String(input);
+      return new Response(JSON.stringify([
+        { tag_name: "v0.16.0", body: "latest body", published_at: "2026-08-01", assets: [] },
+        { tag_name: "v0.15.0", body: "middle body", published_at: "2026-07-01", assets: [] },
+        { tag_name: "v0.14.0", body: "installed body", published_at: "2026-06-01", assets: [] },
+        { tag_name: "v0.13.0", body: "older body", published_at: "2026-05-01", assets: [] },
+      ]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    try {
+      const result = await fetchReleases("0.14.0");
+      expect(requestedUrl).toBe("https://api.github.com/repos/SpeedHQ/RaceIQ/releases?per_page=50&page=1");
+      expect(result.newReleases).toEqual([
+        { version: "0.16.0", notes: "latest body", date: "2026-08-01" },
+        { version: "0.15.0", notes: "middle body", date: "2026-07-01" },
+      ]);
+      expect(result.currentReleaseNotes).toBe("installed body");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
 });
 
 describe("release artifact cache gate", () => {

--- a/test/runtime/update-github.integration.test.ts
+++ b/test/runtime/update-github.integration.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { fetchReleases } from "../../server/runtime/update/check";
+
+describe("GitHub release body integration", () => {
+  test.skipIf(process.env.RUN_GITHUB_RELEASE_INTEGRATION !== "1")(
+    "loads bodies from v0.12.1 through released v0.14.0",
+    async () => {
+      const result = await fetchReleases("0.12.1");
+      const v013 = result.newReleases.find((release) => release.version === "0.13.0");
+      const v014 = result.newReleases.find((release) => release.version === "0.14.0");
+
+      expect(result.currentReleaseNotes).toContain("capture AI chat errors");
+      expect(v013?.notes).toContain("label Power and Torque rows separately");
+      expect(v014?.notes).toContain("Analyze recent driving trends");
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- read current and newer release notes from GitHub release bodies
- paginate release metadata so every release since installed version is considered
- stop publishing release-note assets to keep download counts installer-only

## Verification
- `bun test ./test/runtime/update-check.test.ts ./test/tooling/changelog.test.ts --timeout 60000`
- `bun run typecheck`