### PR TITLE
feat(devtools): add TanStack store panel

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -2476,10 +2476,6 @@
 
     "@sindresorhus/transliterate/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
-    "@storybook/builder-vite/@storybook/csf-plugin": ["@storybook/csf-plugin@10.5.8", "", { "dependencies": { "unplugin": "^2.3.5" }, "peerDependencies": { "esbuild": "*", "rollup": "*", "storybook": "^10.5.8", "vite": "*", "webpack": "*" }, "optionalPeers": ["esbuild", "rollup", "vite", "webpack"] }, "sha512-/FHiMyOWWEXfwK/lM0WxmkP9GLzbSJJuzGtfeuNWSOVDnvAMbjavitxfHb5wSbWKIQo0XYC1EJ2Y7x91XNYP4w=="],
-
-    "@storybook/react/@storybook/react-dom-shim": ["@storybook/react-dom-shim@10.5.8", "", { "peerDependencies": { "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "storybook": "^10.5.8" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-N8D13/Xny+V3kfe1KBgsAHS0nKWXLLdgOOXS9poKdYzVwVCN+CGEGBxWX0zMMtdCptqa6/57em9coPlZMoO+bg=="],
-
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],

--- a/client/src/devtools/RaceIqDevtools.tsx
+++ b/client/src/devtools/RaceIqDevtools.tsx
@@ -5,6 +5,7 @@ import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
 import { useEffect, useState, type ComponentProps } from "react";
 import type { QueryClient } from "@tanstack/react-query";
 import { DevStateContent } from "../components/DevStateViewer";
+import { TanStackStoreDevtoolsPanel, type StoreDescriptor } from "./TanStackStoreDevtoolsPanel";
 import { devTelemetryStore, type DevTelemetryState } from "../stores/dev-telemetry";
 import { gameStore, type GameState } from "../stores/game";
 import { telemetryStore, type TelemetryState } from "../stores/telemetry";
@@ -73,6 +74,13 @@ function RaceIqRuntimePanel() {
   return <DevStateContent server={runtime.server} stores={runtime.stores} paused={runtime.stores.telemetry.devStatePaused} onTogglePause={() => raceIqRuntimeEventClient.emit("toggle-server-state-pause", undefined)} />;
 }
 
+const tanStackStoreDescriptors = {
+  telemetry: { name: "Telemetry", store: telemetryStore },
+  game: { name: "Game", store: gameStore },
+  ui: { name: "UI", store: uiStore },
+  devTelemetry: { name: "Dev Telemetry", store: devTelemetryStore },
+} satisfies Record<"telemetry" | "game" | "ui" | "devTelemetry", StoreDescriptor<unknown>>;
+
 export default function RaceIqDevtools({ router, queryClient }: { router: Router; queryClient: QueryClient }) {
   return (
     <>
@@ -80,6 +88,11 @@ export default function RaceIqDevtools({ router, queryClient }: { router: Router
       <TanStackDevtools plugins={[
         { id: "tanstack-query", name: "TanStack Query", render: <ReactQueryDevtoolsPanel client={queryClient} /> },
         { id: "tanstack-router", name: "TanStack Router", render: <TanStackRouterDevtoolsPanel router={router} /> },
+        {
+          id: "tanstack-store",
+          name: "TanStack Store",
+          render: <TanStackStoreDevtoolsPanel {...tanStackStoreDescriptors} />,
+        },
         { id: "raceiq-runtime", name: "RaceIQ Runtime", render: <RaceIqRuntimePanel /> },
       ]} />
     </>

--- a/client/src/devtools/TanStackStoreDevtoolsPanel.tsx
+++ b/client/src/devtools/TanStackStoreDevtoolsPanel.tsx
@@ -1,0 +1,48 @@
+import { useSelector } from "@tanstack/react-store";
+
+export type StoreSource<T> = {
+  get: () => T;
+  subscribe: (listener: (value: T) => void) => { unsubscribe: () => void };
+};
+export type StoreDescriptor<T> = {
+  name: string;
+  store: StoreSource<T>;
+};
+
+export type StoreSnapshot = {
+  name: string;
+  state: unknown;
+};
+
+export function getTanStackStoreSnapshots(descriptors: readonly StoreDescriptor<unknown>[]): StoreSnapshot[] {
+  return descriptors.map(({ name, store }) => ({ name, state: store.get() }));
+}
+
+type TanStackStoreDevtoolsPanelProps = {
+  telemetry: StoreDescriptor<unknown>;
+  game: StoreDescriptor<unknown>;
+  ui: StoreDescriptor<unknown>;
+  devTelemetry: StoreDescriptor<unknown>;
+};
+
+function StoreState({ descriptor }: { descriptor: StoreDescriptor<unknown> }) {
+  const state = useSelector(descriptor.store, (value) => value);
+  return (
+    <details open className="border border-app-border rounded bg-app-surface">
+      <summary className="cursor-pointer px-2 py-1 text-xs text-app-text">{descriptor.name}</summary>
+      <pre className="overflow-auto border-t border-app-border p-2 text-xs font-mono text-app-text">{JSON.stringify(state, null, 2)}</pre>
+    </details>
+  );
+}
+
+export function TanStackStoreDevtoolsPanel({ telemetry, game, ui, devTelemetry }: TanStackStoreDevtoolsPanelProps) {
+  return (
+    <div className="flex h-full flex-col gap-2 overflow-auto p-2">
+      <span className="text-xs uppercase tracking-wider text-app-text-muted">TanStack Store</span>
+      <StoreState descriptor={telemetry} />
+      <StoreState descriptor={game} />
+      <StoreState descriptor={ui} />
+      <StoreState descriptor={devTelemetry} />
+    </div>
+  );
+}

--- a/client/test/store-devtools.test.ts
+++ b/client/test/store-devtools.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { createStore } from "@tanstack/react-store";
+import { getTanStackStoreSnapshots } from "../src/devtools/TanStackStoreDevtoolsPanel";
+
+describe("TanStack Store devtools panel", () => {
+  test("exposes named live snapshots for each registered store", () => {
+    const alpha = createStore({ count: 1 });
+    const beta = createStore({ ready: true });
+
+    expect(getTanStackStoreSnapshots([
+      { name: "Alpha", store: alpha },
+      { name: "Beta", store: beta },
+    ])).toEqual([
+      { name: "Alpha", state: { count: 1 } },
+      { name: "Beta", state: { ready: true } },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add TanStack store devtools panel
- register panel in RaceIQ devtools
- add focused store-devtools coverage

## Verification
- `E2E_SERVER_MODE=dev PW_SERVER_SET=fresh PW_WORKERS=1 bunx playwright test tests/responsive/workspaces.spec.ts --project=fresh-install --grep 'workspace-wide-short.*compare'`
  - 1 passed
- Full responsive workspace suite reached 23 passing tests before local command timeout; no failures observed before timeout.