### PR TITLE
ci: increase e2e test shards

### DIFF
--- a/.github/workflows/playwright-dev.yml
+++ b/.github/workflows/playwright-dev.yml
@@ -30,27 +30,37 @@ jobs:
           - name: seeded-shard-1
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
-            shard: 1/5
+            shard: 1/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-2
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
-            shard: 2/5
+            shard: 2/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-3
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
-            shard: 3/5
+            shard: 3/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-4
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
-            shard: 4/5
+            shard: 4/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-5
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
-            shard: 5/5
+            shard: 5/7
+            runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
+          - name: seeded-shard-6
+            server_set: seeded
+            projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
+            shard: 6/7
+            runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
+          - name: seeded-shard-7
+            server_set: seeded
+            projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports --project=mobile-device --project=tablet-device
+            shard: 7/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
     uses: ./.github/workflows/playwright.yml
     with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,27 +200,37 @@ jobs:
           - name: seeded-shard-1
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
-            shard: 1/5
+            shard: 1/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-2
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
-            shard: 2/5
+            shard: 2/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-3
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
-            shard: 3/5
+            shard: 3/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-4
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
-            shard: 4/5
+            shard: 4/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
           - name: seeded-shard-5
             server_set: seeded
             projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
-            shard: 5/5
+            shard: 5/7
+            runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
+          - name: seeded-shard-6
+            server_set: seeded
+            projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
+            shard: 6/7
+            runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
+          - name: seeded-shard-7
+            server_set: seeded
+            projects: --project=seeded-e2e --project=seeded-routes --project=seeded-imports
+            shard: 7/7
             runs_on: '["mars-windows-x64", "4VCPU", "15G"]'
     uses: ./.github/workflows/playwright.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Start RaceIQ successfully after installing a Windows release
 
 ### Internal
+- Increase seeded Playwright E2E CI coverage from five to seven shards
 
 ## v0.15.0 - 2026-09-01
 


### PR DESCRIPTION
## Summary
- increase seeded Playwright E2E CI matrices from 5 to 7 shards
- add internal changelog note

## Verification
- `bun test ./test/tooling/changelog.test.ts --timeout 60000`
- workflow YAML parsed successfully