### PR TITLE
build: optimize packaged images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Copy shared data
         run: bun scripts/build/copy-shared-data.ts
+      - name: Optimize packaged images
+        run: bun scripts/build/optimize-client-images.ts
 
       - name: Compile server binary
         run: bun scripts/build/compile-release.ts "${{ needs.compute-version.outputs.version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - Preserve the current page when switching games from the sidebar, falling back to the game root when unavailable
+- Reduce packaged image payload by 22.8% (18.1 MB across 890 images) and remove stale assets during upgrades
 
 ### Fixes
 - Keep Analyse Data panel content and layout complete across supported views
@@ -10,7 +11,6 @@
 ### Internal
 - Narrow client response helper contracts to the fields each RPC and download path uses
 - Pin GitHub Actions workflows to Bun 1.4 for consistent CI tooling
-- Reduce packaged image payload by 22.8% (18.1 MB across 890 images) and remove stale assets during upgrades
 
 ## v0.15.1 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Internal
 - Narrow client response helper contracts to the fields each RPC and download path uses
 - Pin GitHub Actions workflows to Bun 1.4 for consistent CI tooling
-- Reduce packaged image payload by 41.3% (32,687,248 bytes across 890 images) and remove stale assets during upgrades
+- Reduce packaged image payload by 22.8% (18,066,710 bytes across 890 images) and remove stale assets during upgrades
 
 ## v0.15.1 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Internal
 - Narrow client response helper contracts to the fields each RPC and download path uses
 - Pin GitHub Actions workflows to Bun 1.4 for consistent CI tooling
-- Reduce packaged image payload by 22.8% (18,066,710 bytes across 890 images) and remove stale assets during upgrades
+- Reduce packaged image payload by 22.8% (18.1 MB across 890 images) and remove stale assets during upgrades
 
 ## v0.15.1 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Internal
 - Narrow client response helper contracts to the fields each RPC and download path uses
 - Pin GitHub Actions workflows to Bun 1.4 for consistent CI tooling
+- Reduce packaged image payload by 41.3% (32,687,248 bytes across 890 images) and remove stale assets during upgrades
 
 ## v0.15.1 - 2026-09-01
 

--- a/installer/raceiq.iss
+++ b/installer/raceiq.iss
@@ -104,6 +104,11 @@ Source: "..\dist\node_modules\@libsql\win32-x64-msvc\*"; DestDir: "{app}\node_mo
 Source: "..\dist\credstore.ps1"; DestDir: "{app}"; Flags: ignoreversion
 Source: "raceiq-launcher.vbs"; DestDir: "{app}"; Flags: ignoreversion
 
+[InstallDelete]
+; Public contains only packaged assets; replace it completely on every install/upgrade.
+; User data lives under data and is intentionally preserved.
+Type: filesandordirs; Name: "{app}\public\*"
+
 [Registry]
 ; Create startup entry on install (enabled by default)
 Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "RaceIQ"; ValueData: """{app}\raceiq.exe"""; Flags: uninsdeletevalue

--- a/scripts/build/build-installer.ts
+++ b/scripts/build/build-installer.ts
@@ -30,6 +30,7 @@ console.log("→ Copied client assets to dist/public");
 
 // 4. Copy shared data
 run("bun scripts/build/copy-shared-data.ts", "Copying shared data");
+run("bun scripts/build/optimize-client-images.ts", "Optimizing packaged images");
 
 // 5. Compile server binary
 run(

--- a/scripts/build/build.ts
+++ b/scripts/build/build.ts
@@ -91,6 +91,7 @@ async function main() {
   await run(["bun", "run", "build"], { cwd: join(root, "client") });
   await run(["bun", "scripts/build/copy-shared-data.ts"]);
   await run(["bun", "scripts/build/copy-client-dist.ts"]);
+  await run(["bun", "scripts/build/optimize-client-images.ts"]);
 
   const compileArgs = [
     "bun",

--- a/scripts/build/optimize-client-images.ts
+++ b/scripts/build/optimize-client-images.ts
@@ -96,7 +96,7 @@ export async function optimizeClientImages({ publicDir, dataDir }: OptimizeOptio
     const pipeline = Bun.file(inputPath).image();
     const outputPath = `${inputPath.slice(0, -extname(inputPath).length)}.webp`;
     if (metadata.width > 1600) pipeline.resize(1600);
-    await pipeline.webp({ quality: 80 }).write(outputPath);
+    await pipeline.webp({ quality: 90 }).write(outputPath);
     const inputBytes = statSync(inputPath).size;
     const outputBytes = statSync(outputPath).size;
     unlinkSync(inputPath);

--- a/scripts/build/optimize-client-images.ts
+++ b/scripts/build/optimize-client-images.ts
@@ -1,0 +1,120 @@
+import { readdirSync, statSync, unlinkSync } from "node:fs";
+import { availableParallelism } from "node:os";
+import { extname, join, relative, resolve } from "node:path";
+
+type OptimizeOptions = {
+  publicDir: string;
+  dataDir?: string;
+};
+
+type Conversion = {
+  inputPath: string;
+  outputPath: string;
+  relativePath: string;
+  inputBytes: number;
+  outputBytes: number;
+};
+
+const sourceExtensions: Record<string, true> = { ".png": true, ".jpg": true, ".jpeg": true };
+const referenceExtensions = /\.(?:png|jpe?g)(?=($|[?#"'`),;\s]))/gi;
+const textExtensions: Record<string, true> = { ".html": true, ".css": true, ".js": true, ".mjs": true, ".json": true, ".csv": true };
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+
+function imageFiles(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...imageFiles(path));
+    else if (entry.isFile() && sourceExtensions[extname(entry.name).toLowerCase()]) files.push(path);
+  }
+  return files;
+}
+
+function textFiles(dir: string): string[] {
+  if (!dir) return [];
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...textFiles(path));
+    else if (entry.isFile() && textExtensions[extname(entry.name).toLowerCase()]) files.push(path);
+  }
+  return files;
+}
+
+async function mapWithConcurrency<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker() {
+    while (true) {
+      const index = next++;
+      if (index >= items.length) return;
+      results[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, Math.max(1, items.length)) }, worker));
+  return results;
+}
+
+function rewriteReferences(content: string, conversions: Conversion[]): string {
+  let rewritten = content;
+  for (const conversion of conversions) {
+    const oldPath = `/${conversion.relativePath.replaceAll("\\", "/")}`;
+    const newPath = oldPath.replace(referenceExtensions, ".webp");
+    const exactPath = new RegExp("(?<![A-Za-z0-9+.-])" + escapeRegExp(oldPath) + "(?=($|[?#\"'`),;\\s]))", "g");
+    rewritten = rewritten.replace(exactPath, newPath);
+  }
+
+  const localImagePath = new RegExp("(?<![A-Za-z0-9+.-])/(?:car-images|iracing-car-images)/[^\\s\"'`?#),;]+?\\.(?:png|jpe?g)(?=($|[?#\"'`),;\\s]))", "gi");
+  rewritten = rewritten.replace(localImagePath, (value) => value.replace(referenceExtensions, ".webp"));
+
+  rewritten = rewritten.replace(/(<link\b[^>]*\bhref=["']\/favicon\.webp["'][^>]*\btype=["'])image\/png/gi, "$1image/webp");
+  rewritten = rewritten.replace(/(<link\b[^>]*\btype=["'])image\/png(["'][^>]*\bhref=["']\/favicon\.webp["'])/gi, "$1image/webp$2");
+  return rewritten;
+}
+
+async function rewritePackagedReferences(conversions: Conversion[], publicDir: string, dataDir?: string): Promise<void> {
+  const roots = [publicDir, dataDir].filter((dir): dir is string => Boolean(dir && statSync(dir, { throwIfNoEntry: false })));
+  for (const path of roots.flatMap(textFiles)) {
+    const file = Bun.file(path);
+    const content = await file.text();
+    const rewritten = rewriteReferences(content, conversions);
+    if (rewritten !== content) await Bun.write(path, rewritten);
+  }
+}
+
+
+
+export async function optimizeClientImages({ publicDir, dataDir }: OptimizeOptions): Promise<{ converted: number; inputBytes: number; outputBytes: number }> {
+  const resolvedPublicDir = resolve(publicDir);
+  const inputs = imageFiles(resolvedPublicDir);
+  const concurrency = Math.max(1, Math.min(8, availableParallelism()));
+  const conversions = await mapWithConcurrency(inputs, concurrency, async (inputPath) => {
+    const metadata = await Bun.file(inputPath).image().metadata();
+    const pipeline = Bun.file(inputPath).image();
+    const outputPath = `${inputPath.slice(0, -extname(inputPath).length)}.webp`;
+    if (metadata.width > 1600) pipeline.resize(1600);
+    await pipeline.webp({ quality: 80 }).write(outputPath);
+    const inputBytes = statSync(inputPath).size;
+    const outputBytes = statSync(outputPath).size;
+    unlinkSync(inputPath);
+    return { inputPath, outputPath, relativePath: relative(resolvedPublicDir, inputPath), inputBytes, outputBytes } satisfies Conversion;
+  });
+
+  await rewritePackagedReferences(conversions, resolvedPublicDir, dataDir ? resolve(dataDir) : undefined);
+  const inputBytes = conversions.reduce((total, conversion) => total + conversion.inputBytes, 0);
+  const outputBytes = conversions.reduce((total, conversion) => total + conversion.outputBytes, 0);
+  const saved = inputBytes - outputBytes;
+  const percentage = inputBytes === 0 ? 0 : (saved / inputBytes) * 100;
+  console.log(`Optimized client images: ${conversions.length} converted, ${inputBytes} → ${outputBytes} bytes, ${saved} bytes saved (${percentage.toFixed(1)}%)`);
+  return { converted: conversions.length, inputBytes, outputBytes };
+}
+
+if (import.meta.main) {
+  optimizeClientImages({ publicDir: process.argv[2] ?? "dist/public", dataDir: process.argv[3] ?? "dist/data" }).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/test/integration-files.txt
+++ b/scripts/test/integration-files.txt
@@ -131,6 +131,7 @@ test/tooling/changelog.test.ts
 test/tooling/responsive-workspace-contract.test.ts
 test/tooling/story-isolation.test.ts
 test/tooling/theme-contract.test.ts
+test/tooling/optimize-client-images.test.ts
 test/tracks/compact-route.test.ts
 test/tracks/discovered-cars.test.ts
 test/tracks/guides/anchor-validity.test.ts

--- a/test/tooling/optimize-client-images.test.ts
+++ b/test/tooling/optimize-client-images.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import sharp from "sharp";
+import { optimizeClientImages } from "../../scripts/build/optimize-client-images";
+
+const tempDirs: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "raceiq-optimize-images-"));
+  tempDirs.push(dir);
+  return dir;
+}
+async function createFixtures(publicDir: string, dataDir: string): Promise<{ inputBytes: number }> {
+
+  const carDir = join(publicDir, "car-images");
+  const iracingDir = join(publicDir, "iracing-car-images");
+  mkdirSync(carDir, { recursive: true });
+  mkdirSync(iracingDir, { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
+  await Bun.write(join(carDir, "opaque.jpg"), await sharp({ create: { width: 80, height: 40, channels: 3, background: "#d95f02" } }).jpeg().toBuffer());
+  await Bun.write(join(carDir, "transparent.png"), await sharp({ create: { width: 20, height: 10, channels: 4, background: { r: 20, g: 80, b: 160, alpha: 0.35 } } }).png().toBuffer());
+  await Bun.write(join(iracingDir, "large.jpeg"), await sharp({ create: { width: 2000, height: 1000, channels: 3, background: "#1b9e77" } }).jpeg().toBuffer());
+  await Bun.write(join(publicDir, "favicon.png"), await sharp({ create: { width: 32, height: 32, channels: 4, background: "#000000" } }).png().toBuffer());
+  await Bun.write(join(publicDir, "app.js"), 'const a = "/car-images/opaque.jpg"; const b = `/car-images/${id}.jpg`; const external = "https://example.test/photo.jpg"; const externalPath = "https://example.test/car-images/opaque.jpg";');
+  await Bun.write(join(publicDir, "index.html"), '<link rel="icon" href="/favicon.png" type="image/png">');
+  await Bun.write(join(dataDir, "cars.csv"), "car,/iracing-car-images/large.jpeg\n");
+  writeFileSync(join(publicDir, "keep.txt"), "https://example.test/keep.jpg");
+  const inputBytes = ["opaque.jpg", "transparent.png"].reduce((sum, name) => sum + statSync(join(carDir, name)).size, 0)
+    + statSync(join(iracingDir, "large.jpeg")).size + statSync(join(publicDir, "favicon.png")).size;
+  return { inputBytes };
+}
+
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+});
+
+describe("optimizeClientImages", () => {
+  test("converts, resizes, preserves alpha, and rewrites packaged references", async () => {
+    const root = tempDir();
+    const publicDir = join(root, "public");
+    const dataDir = join(root, "data");
+    const { inputBytes } = await createFixtures(publicDir, dataDir);
+
+    const summary = await optimizeClientImages({ publicDir, dataDir });
+
+    expect(summary.converted).toBe(4);
+    expect(summary.inputBytes).toBe(inputBytes);
+    expect(summary.outputBytes).toBe(
+      statSync(join(publicDir, "car-images/opaque.webp")).size
+      + statSync(join(publicDir, "car-images/transparent.webp")).size
+      + statSync(join(publicDir, "iracing-car-images/large.webp")).size
+      + statSync(join(publicDir, "favicon.webp")).size,
+    );
+    for (const path of ["car-images/opaque.jpg", "car-images/transparent.png", "iracing-car-images/large.jpeg", "favicon.png"]) {
+      expect(existsSync(join(publicDir, path))).toBe(false);
+    }
+
+    const opaque = await Bun.file(join(publicDir, "car-images/opaque.webp")).image().metadata();
+    const transparent = await Bun.file(join(publicDir, "car-images/transparent.webp")).image().metadata();
+    const large = await Bun.file(join(publicDir, "iracing-car-images/large.webp")).image().metadata();
+    const transparentAlpha = await sharp(join(publicDir, "car-images/transparent.webp")).metadata();
+    expect(opaque.format).toBe("webp");
+    expect(transparent.format).toBe("webp");
+    expect(transparentAlpha.hasAlpha).toBe(true);
+    expect(large.width).toBe(1600);
+    expect(large.height).toBe(800);
+
+    expect(readFileSync(join(publicDir, "app.js"), "utf8")).toContain("/car-images/opaque.webp");
+    expect(readFileSync(join(publicDir, "app.js"), "utf8")).toContain("/car-images/${id}.webp");
+    expect(readFileSync(join(publicDir, "app.js"), "utf8")).toContain("https://example.test/car-images/opaque.jpg");
+    expect(readFileSync(join(publicDir, "app.js"), "utf8")).toContain("https://example.test/photo.jpg");
+    expect(readFileSync(join(publicDir, "index.html"), "utf8")).toContain('href="/favicon.webp" type="image/webp"');
+    expect(readFileSync(join(dataDir, "cars.csv"), "utf8")).toContain("/iracing-car-images/large.webp");
+    expect(readFileSync(join(publicDir, "keep.txt"), "utf8")).toContain("keep.jpg");
+  });
+
+  test("rejects malformed images and preserves original", async () => {
+    const root = tempDir();
+    const publicDir = join(root, "public");
+    const malformed = join(publicDir, "broken.jpg");
+    await Bun.write(malformed, "not an image");
+
+    await expect(optimizeClientImages({ publicDir })).rejects.toThrow();
+    expect(existsSync(malformed)).toBe(true);
+    expect(existsSync(join(publicDir, "broken.webp"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Convert packaged PNG/JPEG catalogue assets to WebP with Bun.Image
- Resize images wider than 1600px and rewrite packaged references
- Replace the installed `public` directory during upgrades while preserving `data`
- Add focused conversion, resize, alpha, reference, and malformed-input coverage

## Size reduction
- Before: **79.1 MB**
- After: **61.0 MB**
- Saved: **18.1 MB**
- Reduction: **22.8%** across 890 images at WebP quality 90

## Verification
- `bun test test/tooling/optimize-client-images.test.ts` — 2 passed
- `bun test test/tooling/changelog.test.ts --timeout 60000` — 11 passed
- `bun scripts/test/check-shards.ts` — all 269 tests assigned
- Production build completed at quality 90 and packaged WebP routes/API smoke-tested

Note: local pre-commit typecheck reports existing `StorybookSnapshotCase.viewport` errors unrelated to this change.