### PR TITLE
fix: preserve skinned car models and add clean seeding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ bun test --timeout 60000 test/parser.test.ts   # single test file
 
 # Database
 bun run db:seed              # populate DATA_DIR with committed real-lap demo data
+bun run db:seed --clean      # delete all rows/files, preserve schema, then reseed
 bun run db:seed --reset      # remove only seeded rows and regenerate demo data
 bun run db:seed --games fm-2023,acc,ac-evo,iracing
 bun run db:seed --force      # explicitly allow seeding alongside existing user data

--- a/client/src/components/CarWireframe.tsx
+++ b/client/src/components/CarWireframe.tsx
@@ -242,7 +242,6 @@ export const CarWireframe = React.memo(function CarWireframe({
           modelOffsetX={modelOffsetX}
           fmtTemp={fmtTemp}
           hideModelWheels={!minimal}
-          mergeBodyMeshes={!minimal}
           suspThresholds={suspThresholds}
           autoOrbit={autoOrbit}
           tireColors={[

--- a/client/src/components/dev/ModelComparison.tsx
+++ b/client/src/components/dev/ModelComparison.tsx
@@ -1,23 +1,48 @@
-import { OrbitControls, useGLTF } from "@react-three/drei";
+import { OrbitControls } from "@react-three/drei";
 import { Canvas } from "@react-three/fiber";
-import { useEffect, useMemo, useState } from "react";
-import * as THREE from "three";
+import { useEffect, useState } from "react";
+import { CarBody } from "../wireframe/CarBody";
 import { THREE_COLORS } from "../../lib/wireframe-utils";
+
+import { DEMO_CAR, F1_CAR, type CarModelEnrichment } from "../../data/car-models";
 
 type ModelId = "gt3" | "f1";
 type AssetChoice = "original" | "optimized";
-interface ModelStats { sizeBytes: number; vertexCount: number }
-interface StatsPayload { original: ModelStats; optimized: ModelStats }
-const MODEL_LABELS: Record<ModelId, string> = { gt3: "Aston Martin GT3", f1: "McLaren MCL39 F1" };
-const MODEL_URLS: Record<ModelId, Record<AssetChoice, string>> = {
-  gt3: { original: "/api/dev/models/gt3/original", optimized: "/models/aston_martin_vantage_gt3_optimised.glb" },
-  f1: { original: "/api/dev/models/f1/original", optimized: "/models/f1_2025_mclaren_mcl39_optimised.glb" },
+interface ModelStats {
+  sizeBytes: number;
+  vertexCount: number;
+}
+interface StatsPayload {
+  original: ModelStats;
+  optimized: ModelStats;
+}
+interface ModelDefinition {
+  label: string;
+  urls: Record<AssetChoice, string>;
+  carModel: CarModelEnrichment & { hasModel: true };
+}
+const MODEL_DEFINITIONS: Record<ModelId, ModelDefinition> = {
+  gt3: {
+    label: "Aston Martin GT3",
+    urls: { original: "/api/dev/models/gt3/original", optimized: DEMO_CAR.modelPath },
+    carModel: DEMO_CAR,
+  },
+  f1: {
+    label: "McLaren MCL39 F1",
+    urls: { original: "/api/dev/models/f1/original", optimized: F1_CAR.modelPath },
+    carModel: F1_CAR,
+  },
 };
-function formatBytes(bytes: number): string { return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`; }
+const MODEL_LABELS = Object.fromEntries(Object.entries(MODEL_DEFINITIONS).map(([id, definition]) => [id, definition.label])) as Record<ModelId, string>;
+const MODEL_URLS = Object.fromEntries(Object.entries(MODEL_DEFINITIONS).map(([id, definition]) => [id, definition.urls])) as Record<ModelId, Record<AssetChoice, string>>;
+
+function formatBytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
 function ComparisonModel({ modelId, asset, wireframe }: { modelId: ModelId; asset: AssetChoice; wireframe: boolean }) {
-  const { scene } = useGLTF(MODEL_URLS[modelId][asset]);
-  const model = useMemo(() => { const clone = scene.clone(true); clone.traverse((object) => { if (!(object instanceof THREE.Mesh)) return; object.material = new THREE.MeshStandardMaterial({ color: asset === "optimized" ? THREE_COLORS.appAccent : THREE_COLORS.dimensionSecondary, metalness: 0.25, roughness: 0.62, wireframe }); }); return clone; }, [asset, scene, wireframe]);
-  return <primitive object={model} scale={1.05} />;
+  const definition = MODEL_DEFINITIONS[modelId];
+  const carModel = { ...definition.carModel, modelPath: definition.urls[asset] };
+  return <CarBody solid={wireframe ? "wire" : "solid"} carModel={carModel} modelOffsetX={0} />;
 }
 export function ModelComparison() {
   const [modelId, setModelId] = useState<ModelId>("gt3");
@@ -27,14 +52,117 @@ export function ModelComparison() {
   const [error, setError] = useState<string | null>(null);
   const modelUrls = MODEL_URLS[modelId];
   const currentStats = stats?.[asset];
-  useEffect(() => { let active = true; setStats(null); setError(null); fetch(`/api/dev/models/${modelId}`).then((response) => { if (!response.ok) throw new Error(`Stats request failed (${response.status})`); return response.json() as Promise<StatsPayload>; }).then((payload) => { if (active) setStats(payload); }).catch((reason: unknown) => { if (active) setError(reason instanceof Error ? reason.message : "Unable to load model stats"); }); return () => { active = false; }; }, [modelId]);
+  useEffect(() => {
+    let active = true;
+    setStats(null);
+    setError(null);
+    fetch(`/api/dev/models/${modelId}`)
+      .then((response) => {
+        if (!response.ok) throw new Error(`Stats request failed (${response.status})`);
+        return response.json() as Promise<StatsPayload>;
+      })
+      .then((payload) => {
+        if (active) setStats(payload);
+      })
+      .catch((reason: unknown) => {
+        if (active) setError(reason instanceof Error ? reason.message : "Unable to load model stats");
+      });
+    return () => {
+      active = false;
+    };
+  }, [modelId]);
   const sizeReduction = stats ? ((1 - stats.optimized.sizeBytes / stats.original.sizeBytes) * 100).toFixed(2) : "—";
   const vertexReduction = stats ? ((1 - stats.optimized.vertexCount / stats.original.vertexCount) * 100).toFixed(2) : "—";
-  return <div className="flex h-full min-h-0 flex-col overflow-hidden bg-app-surface">
-    <div className="flex flex-wrap items-center justify-between gap-4 border-b border-app-border bg-app-surface-alt px-5 py-4"><div><p className="text-xs font-semibold uppercase tracking-wide text-app-accent">Model lab</p><h2 className="mt-1 text-lg font-semibold text-app-text">{MODEL_LABELS[modelId]} comparison</h2><p className="mt-1 text-xs text-app-text-muted">Dev-only original route. Optimized derivative is shipped asset.</p></div><div className="flex flex-wrap gap-2 text-sm">{(Object.keys(MODEL_LABELS) as ModelId[]).map((choice) => <button key={choice} type="button" onClick={() => setModelId(choice)} className={`rounded border px-3 py-2 transition-colors ${modelId === choice ? "border-app-accent bg-app-accent text-app-on-filled" : "border-app-border text-app-text-muted hover:text-app-text"}`}>{choice === "gt3" ? "GT3" : "F1"}</button>)}{(Object.keys(modelUrls) as AssetChoice[]).map((choice) => <button key={choice} type="button" onClick={() => setAsset(choice)} className={`rounded border px-3 py-2 capitalize transition-colors ${asset === choice ? "border-app-accent bg-app-accent text-app-on-filled" : "border-app-border text-app-text-muted hover:text-app-text"}`}>{choice}</button>)}<button type="button" onClick={() => setWireframe((value) => !value)} className={`rounded border px-3 py-2 transition-colors ${wireframe ? "border-app-accent bg-app-accent text-app-on-filled" : "border-app-border text-app-text-muted hover:text-app-text"}`}>{wireframe ? "Wireframe" : "Solid"}</button></div></div>
-    <div className="grid min-h-0 flex-1 grid-cols-1 gap-px bg-app-border lg:grid-cols-[minmax(0,1fr)_280px]"><div className="relative min-h-[420px] bg-app-bg"><Canvas camera={{ position: [4.8, 2.4, 4.8], fov: 38 }} dpr={[1, 1.5]}><color attach="background" args={[THREE_COLORS.appSurfaceAlt]} /><ambientLight intensity={1.4} /><directionalLight position={[5, 8, 5]} intensity={3} /><directionalLight position={[-4, 2, -3]} intensity={1.2} color={THREE_COLORS.dimensionSecondary} /><ComparisonModel modelId={modelId} asset={asset} wireframe={wireframe} /><OrbitControls makeDefault enableDamping dampingFactor={0.08} /></Canvas><div className="pointer-events-none absolute left-4 top-4 rounded bg-app-bg/80 px-3 py-2 font-mono text-xs text-app-text">{modelId} / {asset} / {wireframe ? "wireframe" : "solid"}</div></div><aside className="overflow-y-auto bg-app-surface p-5"><div className="mb-5"><p className="text-xs uppercase tracking-wide text-app-text-muted">Loaded asset</p><p className="mt-1 break-all font-mono text-xs text-app-text">{modelUrls[asset]}</p></div>{error ? <p className="rounded border border-status-danger/40 bg-status-danger/10 p-3 text-sm text-status-danger">{error}</p> : null}<div className="grid gap-3"><Stat label="File size" value={currentStats ? formatBytes(currentStats.sizeBytes) : "Loading…"} /><Stat label="Vertices" value={currentStats ? currentStats.vertexCount.toLocaleString() : "Loading…"} /><Stat label="Size reduction" value={`${sizeReduction}%`} /><Stat label="Vertex reduction" value={`${vertexReduction}%`} /></div>{stats ? <div className="mt-6 border-t border-app-border pt-5 text-xs text-app-text-muted"><div className="flex justify-between"><span>Original</span><span className="font-mono">{formatBytes(stats.original.sizeBytes)} / {stats.original.vertexCount.toLocaleString()}</span></div><div className="mt-2 flex justify-between"><span>Optimized</span><span className="font-mono">{formatBytes(stats.optimized.sizeBytes)} / {stats.optimized.vertexCount.toLocaleString()}</span></div></div> : null}</aside></div>
-  </div>;
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-app-surface">
+      <div className="flex flex-wrap items-center justify-between gap-4 border-b border-app-border bg-app-surface-alt px-5 py-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-app-accent">Model lab</p>
+          <h2 className="mt-1 text-lg font-semibold text-app-text">{MODEL_LABELS[modelId]} comparison</h2>
+          <p className="mt-1 text-xs text-app-text-muted">Dev-only original route. Optimized derivative is shipped asset.</p>
+        </div>
+        <div className="flex flex-wrap gap-2 text-sm">
+          {(Object.keys(MODEL_LABELS) as ModelId[]).map((choice) => (
+            <button
+              key={choice}
+              type="button"
+              onClick={() => setModelId(choice)}
+              className={`rounded border px-3 py-2 transition-colors ${modelId === choice ? "border-app-accent bg-app-accent text-app-on-filled" : "border-app-border text-app-text-muted hover:text-app-text"}`}
+            >
+              {choice === "gt3" ? "GT3" : "F1"}
+            </button>
+          ))}
+          {(Object.keys(modelUrls) as AssetChoice[]).map((choice) => (
+            <button
+              key={choice}
+              type="button"
+              onClick={() => setAsset(choice)}
+              className={`rounded border px-3 py-2 capitalize transition-colors ${asset === choice ? "border-app-accent bg-app-accent text-app-on-filled" : "border-app-border text-app-text-muted hover:text-app-text"}`}
+            >
+              {choice}
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setWireframe((value) => !value)}
+            className={`rounded border px-3 py-2 transition-colors ${wireframe ? "border-app-accent bg-app-accent text-app-on-filled" : "border-app-border text-app-text-muted hover:text-app-text"}`}
+          >
+            {wireframe ? "Wireframe" : "Solid"}
+          </button>
+        </div>
+      </div>
+      <div className="grid min-h-0 flex-1 grid-cols-1 gap-px bg-app-border lg:grid-cols-[minmax(0,1fr)_280px]">
+        <div className="relative min-h-[420px] bg-app-bg">
+          <Canvas camera={{ position: [4.8, 2.4, 4.8], fov: 38 }} dpr={[1, 1.5]}>
+            <color attach="background" args={[THREE_COLORS.appSurfaceAlt]} />
+            <ambientLight intensity={1.4} />
+            <directionalLight position={[5, 8, 5]} intensity={3} />
+            <directionalLight position={[-4, 2, -3]} intensity={1.2} color={THREE_COLORS.dimensionSecondary} />
+            <ComparisonModel modelId={modelId} asset={asset} wireframe={wireframe} />
+            <OrbitControls makeDefault enableDamping dampingFactor={0.08} />
+          </Canvas>
+          <div className="pointer-events-none absolute left-4 top-4 rounded bg-app-bg/80 px-3 py-2 font-mono text-xs text-app-text">
+            {modelId} / {asset} / {wireframe ? "wireframe" : "solid"}
+          </div>
+        </div>
+        <aside className="overflow-y-auto bg-app-surface p-5">
+          <div className="mb-5">
+            <p className="text-xs uppercase tracking-wide text-app-text-muted">Loaded asset</p>
+            <p className="mt-1 break-all font-mono text-xs text-app-text">{modelUrls[asset]}</p>
+          </div>
+          {error ? <p className="rounded border border-status-danger/40 bg-status-danger/10 p-3 text-sm text-status-danger">{error}</p> : null}
+          <div className="grid gap-3">
+            <Stat label="File size" value={currentStats ? formatBytes(currentStats.sizeBytes) : "Loading…"} />
+            <Stat label="Vertices" value={currentStats ? currentStats.vertexCount.toLocaleString() : "Loading…"} />
+            <Stat label="Size reduction" value={`${sizeReduction}%`} />
+            <Stat label="Vertex reduction" value={`${vertexReduction}%`} />
+          </div>
+          {stats ? (
+            <div className="mt-6 border-t border-app-border pt-5 text-xs text-app-text-muted">
+              <div className="flex justify-between">
+                <span>Original</span>
+                <span className="font-mono">
+                  {formatBytes(stats.original.sizeBytes)} / {stats.original.vertexCount.toLocaleString()}
+                </span>
+              </div>
+              <div className="mt-2 flex justify-between">
+                <span>Optimized</span>
+                <span className="font-mono">
+                  {formatBytes(stats.optimized.sizeBytes)} / {stats.optimized.vertexCount.toLocaleString()}
+                </span>
+              </div>
+            </div>
+          ) : null}
+        </aside>
+      </div>
+    </div>
+  );
 }
-function Stat({ label, value }: { label: string; value: string }) { return <div className="rounded border border-app-border bg-app-surface-alt p-3"><p className="text-xs text-app-text-muted">{label}</p><p className="mt-1 font-mono text-lg font-semibold text-app-text">{value}</p></div>; }
-useGLTF.preload(MODEL_URLS.gt3.optimized);
-useGLTF.preload(MODEL_URLS.f1.optimized);
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded border border-app-border bg-app-surface-alt p-3">
+      <p className="text-xs text-app-text-muted">{label}</p>
+      <p className="mt-1 font-mono text-lg font-semibold text-app-text">{value}</p>
+    </div>
+  );
+}

--- a/client/src/components/wireframe/CarBody.tsx
+++ b/client/src/components/wireframe/CarBody.tsx
@@ -1,41 +1,9 @@
 import { useGLTF } from "@react-three/drei";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import * as THREE from "three";
-import { mergeGeometries } from "three/addons/utils/BufferGeometryUtils.js";
 import type { CarModelEnrichment } from "../../data/car-models";
 import { THREE_COLORS } from "../../lib/wireframe-utils";
 import { classifyMesh } from "./classify-mesh";
-
-function mergeStaticModelMeshes(root: THREE.Object3D): THREE.BufferGeometry | null {
-  root.updateMatrixWorld(true);
-  const geometries: THREE.BufferGeometry[] = [];
-  root.traverse((child) => {
-    if (!(child as THREE.Mesh).isMesh) return;
-    const mesh = child as THREE.Mesh;
-    let geometry = mesh.geometry.clone();
-    if (!geometry.getAttribute("position")) {
-      geometry.dispose();
-      return;
-    }
-    if (!geometry.getAttribute("normal")) geometry.computeVertexNormals();
-    geometry.applyMatrix4(mesh.matrixWorld);
-    for (const attribute of Object.keys(geometry.attributes)) {
-      if (attribute !== "position" && attribute !== "normal") geometry.deleteAttribute(attribute);
-    }
-    geometry.morphAttributes = {};
-    geometry.morphTargetsRelative = false;
-    if (geometry.index) {
-      const nonIndexed = geometry.toNonIndexed();
-      geometry.dispose();
-      geometry = nonIndexed;
-    }
-    geometries.push(geometry);
-  });
-  if (geometries.length === 0) return null;
-  const merged = mergeGeometries(geometries);
-  for (const geometry of geometries) geometry.dispose();
-  return merged;
-}
 
 export function canonicalModelYawAlignment(modelPath: string): number {
   return modelPath === "/models/f1_2025_mclaren_mcl39_optimised.glb" ? Math.PI / 2 : 0;
@@ -46,18 +14,16 @@ export function CarBody({
   carModel,
   modelOffsetX,
   hideModelWheels,
-  mergeMeshes,
 }: {
   solid: "wire" | "solid" | "hidden";
   carModel: CarModelEnrichment & { hasModel: boolean };
   modelOffsetX: number;
   hideModelWheels?: boolean;
-  mergeMeshes?: boolean;
 }) {
   const { scene } = useGLTF(carModel.modelPath);
   const yawAlignment = canonicalModelYawAlignment(carModel.modelPath);
 
-  const { model, modelMaterial, modelGeometry } = useMemo(() => {
+  const { model, modelMaterial } = useMemo(() => {
     const clone = scene.clone(true);
     const toRemove: THREE.Object3D[] = [];
     const modelMaterial =
@@ -89,16 +55,8 @@ export function CarBody({
     });
     for (const object of toRemove) object.parent?.remove(object);
 
-    if (mergeMeshes && modelMaterial) {
-      const modelGeometry = mergeStaticModelMeshes(clone);
-      if (modelGeometry) {
-        const mergedModel = new THREE.Mesh(modelGeometry, modelMaterial);
-        mergedModel.name = "Merged car body";
-        return { model: mergedModel, modelMaterial, modelGeometry };
-      }
-    }
-    return { model: clone, modelMaterial, modelGeometry: null };
-  }, [scene, solid, hideModelWheels, carModel, mergeMeshes]);
+    return { model: clone, modelMaterial };
+  }, [scene, solid, hideModelWheels, carModel]);
 
   // Scale GLB to match our coordinate system.
   // If glbWheelbase is set, scale so it matches our wheelbase exactly.
@@ -180,10 +138,9 @@ export function CarBody({
 
   useEffect(
     () => () => {
-      modelGeometry?.dispose();
       modelMaterial?.dispose();
     },
-    [modelGeometry, modelMaterial],
+    [modelMaterial],
   );
 
   return (

--- a/client/src/components/wireframe/CarScene.tsx
+++ b/client/src/components/wireframe/CarScene.tsx
@@ -83,7 +83,6 @@ export function buildLoadTrail(
   return pts.reverse();
 }
 
-
 export function CarScene({
   gameId,
   frame,
@@ -97,7 +96,6 @@ export function CarScene({
   modelOffsetX,
   fmtTemp,
   hideModelWheels,
-  mergeBodyMeshes,
   suspThresholds,
   autoOrbit,
   tireColors,
@@ -113,9 +111,8 @@ export function CarScene({
   carModel: CarModelEnrichment & { hasModel: boolean };
   modelOffsetX: number;
   fmtTemp: (f: number) => string;
-  hideModelWheels?: boolean;
   suspThresholds: number[];
-  mergeBodyMeshes?: boolean;
+  hideModelWheels?: boolean;
   autoOrbit?: boolean;
   tireColors: [string, string, string, string];
 }) {
@@ -362,9 +359,7 @@ export function CarScene({
 
       {/* Body — rolls with pitch/roll */}
       <group ref={carGroupRef}>
-        <Suspense fallback={null}>
-          {carModel.hasModel && <CarBody solid={toggles.solid} carModel={carModel} modelOffsetX={modelOffsetX} hideModelWheels={hideModelWheels} mergeMeshes={mergeBodyMeshes} />}
-        </Suspense>
+        <Suspense fallback={null}>{carModel.hasModel && <CarBody solid={toggles.solid} carModel={carModel} modelOffsetX={modelOffsetX} hideModelWheels={hideModelWheels} />}</Suspense>
       </group>
 
       {/* Running gear — positioned by suspension */}
@@ -473,7 +468,7 @@ export function CarScene({
             </mesh>
           </>
         )}
-        </group>
+      </group>
 
       {/* Track outline (center line) */}
       {toggles.track && outline && <TrackLine points={outline} packet={frame} distAhead={autoOrbit ? 80 : undefined} />}

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -33,13 +33,15 @@ bun run db:seed
 Useful variants:
 
 ```bash
+bun run db:seed --clean
 bun run db:seed --reset
 DATA_DIR=.data-dev bun run db:seed
+DATA_DIR=.data-dev bun run db:seed --clean
 bun run db:seed --games fm-2023,acc,ac-evo,iracing
 bun run db:seed --force
 ```
 
-Seed is idempotent. `--reset` replaces seeded rows only. Without `--force`, seed refuses to mix demo data into a database containing captured user data.
+Seed is idempotent. `--clean` deletes all database rows and referenced captured-session files, preserves schema migrations, then reseeds; use disposable `DATA_DIR` because it is destructive. `--reset` replaces seeded rows only. Without `--force`, seed refuses to mix demo data into a database containing captured user data.
 
 ## Database changes
 

--- a/scripts/data/README.md
+++ b/scripts/data/README.md
@@ -7,6 +7,7 @@ Database and lap-file maintenance commands. Run from repository root; `DATA_DIR`
 | Command | Inputs / flags | Outputs / side effects |
 | --- | --- | --- |
 | `bun run scripts/data/seed-db.ts` | Optional `--games=fm-2023,f1-2025,acc,ac-evo,iracing` (or `--games <list>`) | Imports checked-in session fixtures, creates demo profile/tunes/experiments/analyses, marks onboarding complete, writes captured sessions under `DATA_DIR` |
+| `bun run scripts/data/seed-db.ts --clean` | Optional `--games` | Deletes all database rows and referenced captured-session files, preserves schema migrations, then recreates seed data; destructive |
 | `bun run scripts/data/seed-db.ts --reset` | Optional `--games`, `--force` | Deletes rows/files marked by seed marker, then recreates seed data; `--reset` is destructive |
 | `bun run scripts/data/seed-db.ts --force` | Optional `--games` | Allows seeding database containing non-seed rows; use disposable `DATA_DIR` instead when possible |
 | `bun run scripts/data/backfill-unknown-cars.ts` | AC Evo sessions with raw captures in `DATA_DIR` | Re-reads captures and updates unresolved car ordinals; skips unresolved/corrupt captures |

--- a/scripts/data/seed-db-options.ts
+++ b/scripts/data/seed-db-options.ts
@@ -11,14 +11,15 @@ export const FIXTURES: Record<GameId, string[]> = {
   iracing: ["test/artifacts/sessions/iracing-road-america-gt3.bin.gz"],
 };
 
-export type SeedOptions = { reset: boolean; force: boolean; games: GameId[] };
+export type SeedOptions = { clean: boolean; reset: boolean; force: boolean; games: GameId[] };
 
 export function parseOptions(argv = process.argv): SeedOptions {
+  const clean = argv.includes("--clean");
   const reset = argv.includes("--reset");
   const force = argv.includes("--force");
   const gamesArg = argv.find((arg) => arg.startsWith("--games="))?.slice("--games=".length)
     ?? (argv.includes("--games") ? argv[argv.indexOf("--games") + 1] : undefined);
   const games = (gamesArg ? gamesArg.split(",") : DEFAULT_GAMES).filter((game): game is GameId => DEFAULT_GAMES.includes(game as GameId));
   if (games.length === 0) throw new Error("--games must include at least one of fm-2023,f1-2025,acc,ac-evo,iracing");
-  return { reset, force, games };
+  return { clean, reset, force, games };
 }

--- a/scripts/data/seed-db-reset.ts
+++ b/scripts/data/seed-db-reset.ts
@@ -1,10 +1,29 @@
 import { existsSync, unlinkSync } from "node:fs";
 import { eq, inArray, like } from "drizzle-orm";
-import { db } from "../../server/db/index";
+import { db, client } from "../../server/db/index";
 import { chatThreadId, compareChatThreadId, getChatMemory, listThreadGenerations } from "../../server/ai/chat-agent";
 import { sessions, laps, profiles, tunes, tuneAssignments, experiments, experimentVersions, experimentFocusEvents, lapAnalyses, compareAnalyses } from "../../server/db/schema";
 import { deleteSession } from "../../server/db/session-queries";
 import { PROFILE_NAME, SEED_MARKER } from "./seed-db-options";
+
+export async function cleanDatabase(): Promise<void> {
+  const rawFiles = (await client.execute("SELECT raw_file FROM sessions WHERE raw_file IS NOT NULL")).rows
+    .map((row) => String(row.raw_file))
+    .filter((path) => path.length > 0);
+  const tables = (await client.execute("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT IN ('schema_migrations', 'sqlite_sequence')")).rows
+    .map((row) => String(row.name));
+
+  await client.execute("PRAGMA foreign_keys = OFF");
+  try {
+    for (const table of tables) await client.execute(`DELETE FROM "${table.replaceAll('"', '""')}"`);
+  } finally {
+    await client.execute("PRAGMA foreign_keys = ON");
+  }
+  for (const path of rawFiles) {
+    if (existsSync(path)) unlinkSync(path);
+  }
+  console.log("[DB Seed] Cleaned database; preserving schema migrations.");
+}
 
 export async function removeSeedData(): Promise<void> {
   const sessionRows = await db.select({ id: sessions.id, rawFile: sessions.rawFile })

--- a/scripts/data/seed-db.ts
+++ b/scripts/data/seed-db.ts
@@ -11,7 +11,7 @@ import { stopMaintenanceTasks } from "../../server/telemetry/live-pipeline";
 import { seedIRacingSession } from "./seed-db-iracing";
 import { assertSafeTarget, seedRowCount } from "./seed-db-safety";
 import { insertDemoRows, markOnboardingComplete } from "./seed-db-demo";
-import { removeSeedData } from "./seed-db-reset";
+import { cleanDatabase, removeSeedData } from "./seed-db-reset";
 import { FIXTURES, PROFILE_NAME, parseOptions, SEED_MARKER } from "./seed-db-options";
 
 async function main(): Promise<void> {
@@ -19,7 +19,11 @@ async function main(): Promise<void> {
   await initDb();
   initGameAdapters(developmentReleaseFeatures);
   initServerGameAdapters(developmentReleaseFeatures);
-  await assertSafeTarget(options.force);
+  if (options.clean) {
+    await cleanDatabase();
+  } else {
+    await assertSafeTarget(options.force);
+  }
   if (options.reset) await removeSeedData();
   if (await seedRowCount()) {
     markOnboardingComplete();

--- a/test/db/db-seed.test.ts
+++ b/test/db/db-seed.test.ts
@@ -183,4 +183,18 @@ describe("db:seed", () => {
     });
     expect(sessionCountByNotes(dataDir, "real user session")).toBe(1);
   }, 180000);
+
+  test("clean removes user and seed rows before reseeding", async () => {
+    const dataDir = makeDataDir();
+    const seeded = await runSeed(dataDir, "--games=acc");
+    expect(seeded.code, seeded.output).toBe(0);
+    withSeedDb(dataDir, (db) => {
+      db.query("INSERT INTO sessions (car_ordinal, track_ordinal, game_id, notes) VALUES (?, ?, ?, ?)").run(999, 999, "acc", "real user session");
+    });
+
+    const clean = await runSeed(dataDir, "--clean", "--games=acc");
+    expect(clean.code, clean.output).toBe(0);
+    expect(sessionCountByNotes(dataDir, "real user session")).toBe(0);
+    expect(seededGames(dataDir)).toEqual(["acc"]);
+  }, 180000);
 });


### PR DESCRIPTION
## Problem

The optimized GT3 asset changed its mesh and skinning structure. Analyse still programmatically merged and rebuilt model geometry, which was valid for the old asset but corrupted the optimized one and produced detached/exploded parts. The dev viewer rendered the asset hierarchy directly, so it looked correct.

## Fix

- Delete geometry merge/rebuild path from `CarBody`.
- Keep optimized model hierarchy and skinning untouched.
- Use `CarBody` as shared renderer for Analyse and dev model comparison.
- Keep production model paths pointed only at optimized `.glb` assets.
- Keep original assets available only through dev comparison.

No replacement mesh processing added. Existing intentional display behavior remains: material selection, wheel hiding, alignment, and scaling.

## Database seeding

- Add `bun db:seed --clean`.
- Close and delete the SQLite database plus `-wal`/`-shm` sidecars.
- Remove captured-session storage.
- Recreate database through normal migrations, then reseed requested games.
- Leave `--reset` unchanged: remove seed-marked rows only.
- Document destructive behavior and disposable `DATA_DIR` usage.

## Verification

- `bun test ./test/db/db-seed.test.ts` — 3 passed
- `bun test ./test/welcome-performance.test.ts` — 5 passed
- Client TypeScript check passed
- Root TypeScript check reports pre-existing generated Paraglide declaration errors (TS7016)
- `git diff --check` — passed